### PR TITLE
Fix cross-host landing integration observation

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/checkout.rs
+++ b/crates/flotilla-controllers/src/reconcilers/checkout.rs
@@ -2,10 +2,14 @@ use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use flotilla_core::checkout_integration::{
+    checkout_observation_lacks_convoy_association, convoy_change_request_id_for_checkout, LANDING_EVIDENCE_TTL,
+};
 use flotilla_resources::{
-    controller::{ReconcileOutcome, Reconciler},
+    controller::{ReconcileOutcome, Reconciler, ReplicaConvoyCheckoutWatch, SecondaryWatch},
     Checkout, CheckoutBranchProvenance, CheckoutIntegrationStatus, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutStatusPatch, Clock,
-    Clone, ClonePhase, IntegrationCondition, ResourceBackend, ResourceError, ResourceObject, SystemClock, TypedResolver,
+    Clone, ClonePhase, Convoy, ConvoyPhase, IntegrationCondition, ReplicaReadResolver, ResourceBackend, ResourceError, ResourceObject,
+    ResourceProvenance, SystemClock, TypedResolver, ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL,
 };
 use tracing::warn;
 
@@ -54,13 +58,19 @@ pub trait CheckoutRuntime: Send + Sync {
         base_ref: Option<&str>,
         target_path: &str,
     ) -> Result<PreparedCheckout, String>;
-    async fn inspect_integration(&self, checkout: &ResourceObject<Checkout>) -> Result<CheckoutIntegrationStatus, String>;
+    async fn inspect_integration(
+        &self,
+        checkout: &ResourceObject<Checkout>,
+        convoy: Option<&ResourceObject<Convoy>>,
+    ) -> Result<CheckoutIntegrationStatus, String>;
     async fn remove_checkout(&self, removal: &CheckoutRemoval) -> Result<CheckoutRemovalOutcome, String>;
 }
 
 pub struct CheckoutReconciler<R> {
     runtime: Arc<R>,
     clones: TypedResolver<Clone>,
+    convoys: TypedResolver<Convoy>,
+    federated_convoys: Option<ReplicaReadResolver<Convoy>>,
     clock: Arc<dyn Clock>,
 }
 
@@ -70,8 +80,74 @@ impl<R> CheckoutReconciler<R> {
     }
 
     pub fn with_clock(runtime: Arc<R>, backend: ResourceBackend, namespace: &str, clock: Arc<dyn Clock>) -> Self {
-        Self { runtime, clones: backend.using::<Clone>(namespace), clock }
+        Self {
+            runtime,
+            clones: backend.clone().using::<Clone>(namespace),
+            convoys: backend.using::<Convoy>(namespace),
+            federated_convoys: None,
+            clock,
+        }
     }
+
+    pub fn with_federated_convoys(mut self, backend: &ResourceBackend, namespace: &str) -> Self {
+        self.federated_convoys = Some(backend.including_replicas::<Convoy>(namespace));
+        self
+    }
+
+    pub fn federated_secondary_watches(backend: &ResourceBackend, namespace: &str) -> Vec<Box<dyn SecondaryWatch<Primary = Checkout>>> {
+        vec![Box::new(ReplicaConvoyCheckoutWatch { resolver: backend.including_replicas::<Convoy>(namespace) })]
+    }
+
+    async fn owning_convoy(&self, checkout: &ResourceObject<Checkout>) -> Result<Option<ResourceObject<Convoy>>, ResourceError> {
+        let convoy_ref = checkout.metadata.labels.get(CONVOY_LABEL);
+        let Some(origin) = checkout.metadata.annotations.get(ACTUATOR_SOURCE_ROOT_ANNOTATION) else {
+            if let Some(convoy_ref) = convoy_ref {
+                match self.convoys.get(convoy_ref).await {
+                    Ok(convoy) => return Ok(Some(convoy)),
+                    Err(ResourceError::NotFound { .. }) => {}
+                    Err(error) => return Err(error),
+                }
+            }
+            if let Some(convoy) =
+                self.convoys.list().await?.items.into_iter().find(|convoy| convoy_claims_checkout(convoy, &checkout.metadata.name))
+            {
+                return Ok(Some(convoy));
+            }
+            return self.any_federated_convoy(convoy_ref.map(String::as_str), &checkout.metadata.name).await;
+        };
+        let Some(federated) = self.federated_convoys.as_ref() else {
+            return Ok(None);
+        };
+        Ok(federated.list().await?.items.into_iter().find_map(|source| {
+            (convoy_ref.map_or_else(
+                || convoy_claims_checkout(&source.object, &checkout.metadata.name),
+                |convoy_ref| source.object.metadata.name == *convoy_ref,
+            ) && matches!(&source.provenance, ResourceProvenance::Replica { origin_root, .. } if origin_root.as_str() == origin))
+            .then_some(source.object)
+        }))
+    }
+
+    async fn any_federated_convoy(
+        &self,
+        convoy_ref: Option<&str>,
+        checkout_name: &str,
+    ) -> Result<Option<ResourceObject<Convoy>>, ResourceError> {
+        let Some(federated) = self.federated_convoys.as_ref() else {
+            return Ok(None);
+        };
+        Ok(federated.list().await?.items.into_iter().find_map(|source| {
+            convoy_ref
+                .map_or_else(
+                    || convoy_claims_checkout(&source.object, checkout_name),
+                    |convoy_ref| source.object.metadata.name == convoy_ref,
+                )
+                .then_some(source.object)
+        }))
+    }
+}
+
+fn convoy_claims_checkout(convoy: &ResourceObject<Convoy>, checkout_name: &str) -> bool {
+    flotilla_resources::expected_checkout_refs(convoy).is_ok_and(|expected| expected.contains(checkout_name))
 }
 
 pub enum CheckoutDeps {
@@ -86,7 +162,7 @@ fn integration_observed_at(condition: &IntegrationCondition) -> Option<DateTime<
     DateTime::parse_from_rfc3339(condition.observed_at.as_deref()?).ok().map(|observed_at| observed_at.with_timezone(&Utc))
 }
 
-fn integration_is_fresh(status: &CheckoutStatus, now: DateTime<Utc>) -> bool {
+fn integration_is_fresh(status: &CheckoutStatus, now: DateTime<Utc>, max_age: Duration) -> bool {
     let observed_at = [
         integration_observed_at(&status.integration.clean),
         integration_observed_at(&status.integration.pushed),
@@ -95,7 +171,13 @@ fn integration_is_fresh(status: &CheckoutStatus, now: DateTime<Utc>) -> bool {
     let Some(oldest_observation) = observed_at.into_iter().collect::<Option<Vec<_>>>().and_then(|values| values.into_iter().min()) else {
         return false;
     };
-    now.signed_duration_since(oldest_observation).to_std().is_ok_and(|age| age < CHECKOUT_INTEGRATION_REFRESH_AFTER)
+    now.signed_duration_since(oldest_observation).to_std().is_ok_and(|age| age < max_age)
+}
+
+fn convoy_needs_terminal_evidence(convoy: Option<&ResourceObject<Convoy>>) -> bool {
+    convoy.and_then(|convoy| convoy.status.as_ref()).is_some_and(|status| {
+        status.phase == ConvoyPhase::Landing || (status.phase.is_terminal() && status.phase != ConvoyPhase::Abandoned)
+    })
 }
 
 impl<R> Reconciler for CheckoutReconciler<R>
@@ -107,12 +189,19 @@ where
 
     async fn fetch_dependencies(&self, obj: &ResourceObject<Self::Resource>) -> Result<Self::Dependencies, ResourceError> {
         if obj.status.as_ref().map(|status| status.phase).unwrap_or(CheckoutPhase::Pending) != CheckoutPhase::Pending {
-            if obj
-                .status
-                .as_ref()
-                .is_some_and(|status| status.phase == CheckoutPhase::Ready && !integration_is_fresh(status, self.clock.now()))
-            {
-                return Ok(match self.runtime.inspect_integration(obj).await {
+            let convoy = self.owning_convoy(obj).await?;
+            let terminal_evidence = convoy_needs_terminal_evidence(convoy.as_ref());
+            let refresh_after = if terminal_evidence { LANDING_EVIDENCE_TTL } else { CHECKOUT_INTEGRATION_REFRESH_AFTER };
+            let expected_change_request_id = convoy.as_ref().and_then(|convoy| convoy_change_request_id_for_checkout(convoy, obj));
+            if obj.status.as_ref().is_some_and(|status| {
+                status.phase == CheckoutPhase::Ready
+                    && (!integration_is_fresh(status, self.clock.now(), refresh_after)
+                        || (terminal_evidence && checkout_observation_lacks_convoy_association(&status.integration))
+                        || expected_change_request_id.as_ref().is_some_and(|expected| {
+                            status.integration.change_request.as_ref().map(|observed| &observed.id) != Some(expected)
+                        }))
+            }) {
+                return Ok(match self.runtime.inspect_integration(obj, convoy.as_ref()).await {
                     Ok(status) => CheckoutDeps::Integration { status: Box::new(status) },
                     Err(err) => CheckoutDeps::Failed(err),
                 });

--- a/crates/flotilla-controllers/src/reconcilers/checkout.rs
+++ b/crates/flotilla-controllers/src/reconcilers/checkout.rs
@@ -174,6 +174,8 @@ fn integration_is_fresh(status: &CheckoutStatus, now: DateTime<Utc>, max_age: Du
     now.signed_duration_since(oldest_observation).to_std().is_ok_and(|age| age < max_age)
 }
 
+/// Terminal convoys keep the Landing TTL because teardown consumes the same
+/// fresh evidence and no longer probes a checkout on demand.
 fn convoy_needs_terminal_evidence(convoy: Option<&ResourceObject<Convoy>>) -> bool {
     convoy.and_then(|convoy| convoy.status.as_ref()).is_some_and(|status| {
         status.phase == ConvoyPhase::Landing || (status.phase.is_terminal() && status.phase != ConvoyPhase::Abandoned)
@@ -198,7 +200,7 @@ where
                     && (!integration_is_fresh(status, self.clock.now(), refresh_after)
                         || (terminal_evidence && checkout_observation_lacks_convoy_association(&status.integration))
                         || expected_change_request_id.as_ref().is_some_and(|expected| {
-                            status.integration.change_request.as_ref().map(|observed| &observed.id) != Some(expected)
+                            status.integration.change_request.as_ref().is_some_and(|observed| &observed.id != expected)
                         }))
             }) {
                 return Ok(match self.runtime.inspect_integration(obj, convoy.as_ref()).await {

--- a/crates/flotilla-controllers/tests/checkout_reconciler.rs
+++ b/crates/flotilla-controllers/tests/checkout_reconciler.rs
@@ -19,7 +19,8 @@ use flotilla_resources::{
     controller::{ControllerLoop, Reconciler},
     repo_key, Checkout, CheckoutBranchProvenance, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutWorktreeSpec, ConditionValue,
     Convoy, ConvoyPhase, ConvoySpec, ConvoyStatus, FreshCloneCheckoutSpec, InMemoryBackend, InputMeta, IntegrationCondition, RepositoryKey,
-    ResourceBackend, ResourceError, ResourceObject, StatusPatch, VirtualClock, ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL,
+    ResourceBackend, ResourceError, ResourceObject, StatusPatch, VirtualClock, ACTUATOR_SOURCE_ROOT_ANNOTATION, CHANGE_REQUEST_ID_LABEL,
+    CONVOY_LABEL,
 };
 use tokio::time::timeout;
 
@@ -439,4 +440,73 @@ async fn checkout_authority_observes_when_replicated_convoy_enters_landing() {
 
     assert!(matches!(deps, CheckoutDeps::Integration { .. }), "Landing must shorten the observation TTL to 30 seconds");
     assert_eq!(*runtime.inspections.lock().expect("inspections lock"), 1, "only the checkout authority should probe its checkout");
+}
+
+#[tokio::test]
+async fn fresh_failed_change_request_lookup_waits_for_the_landing_ttl_before_retrying() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let now = chrono::DateTime::parse_from_rfc3339("2026-08-03T21:45:00Z").expect("timestamp").with_timezone(&chrono::Utc);
+    let convoys = backend.clone().using::<Convoy>(NAMESPACE);
+    let convoy = convoys
+        .create(
+            &InputMeta::builder().name("convoy-a".to_string()).build(),
+            &ConvoySpec::builder().workflow_ref("review-and-fix".to_string()).build(),
+        )
+        .await
+        .expect("create convoy");
+    convoys
+        .update_status(&convoy.metadata.name, &convoy.metadata.resource_version, &ConvoyStatus {
+            phase: ConvoyPhase::Landing,
+            ..Default::default()
+        })
+        .await
+        .expect("mark convoy Landing");
+    let checkouts = backend.clone().using::<Checkout>(NAMESPACE);
+    let checkout = checkouts
+        .create(
+            &InputMeta::builder()
+                .name("checkout-a".to_string())
+                .labels(BTreeMap::from([
+                    (CONVOY_LABEL.to_string(), "convoy-a".to_string()),
+                    (CHANGE_REQUEST_ID_LABEL.to_string(), "42".to_string()),
+                ]))
+                .build(),
+            &CheckoutSpec::FreshClone(FreshCloneCheckoutSpec {
+                repo_ref: RepositoryKey(repo_key(REPO_URL)),
+                env_ref: "host-direct-a".to_string(),
+                r#ref: "feature/a".to_string(),
+                base_ref: Some("main".to_string()),
+                target_path: "/checkouts/a".to_string(),
+                url: REPO_URL.to_string(),
+            }),
+        )
+        .await
+        .expect("create checkout");
+    let failed_lookup = IntegrationCondition::builder()
+        .value(ConditionValue::Unknown)
+        .details(vec!["gh PR lookup failed".to_string()])
+        .observed_at(now.to_rfc3339())
+        .build();
+    checkouts
+        .update_status(&checkout.metadata.name, &checkout.metadata.resource_version, &CheckoutStatus {
+            phase: CheckoutPhase::Ready,
+            path: Some("/checkouts/a".to_string()),
+            integration: flotilla_resources::CheckoutIntegrationStatus {
+                clean: failed_lookup.clone(),
+                pushed: failed_lookup.clone(),
+                landed: failed_lookup,
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .await
+        .expect("record failed lookup");
+
+    let runtime = Arc::new(RecordingCheckoutRuntime::default());
+    let reconciler = CheckoutReconciler::with_clock(runtime.clone(), backend, NAMESPACE, Arc::new(VirtualClock::new(now)));
+    let checkout = checkouts.get("checkout-a").await.expect("get checkout");
+    let deps = reconciler.fetch_dependencies(&checkout).await.expect("fetch dependencies");
+
+    assert!(matches!(deps, CheckoutDeps::None));
+    assert_eq!(*runtime.inspections.lock().expect("inspections lock"), 0, "forge failures should be rate-limited by the TTL");
 }

--- a/crates/flotilla-controllers/tests/checkout_reconciler.rs
+++ b/crates/flotilla-controllers/tests/checkout_reconciler.rs
@@ -4,6 +4,7 @@
 mod common;
 
 use std::{
+    collections::BTreeMap,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -13,10 +14,12 @@ use common::{create_ready_checkout, create_ready_clone, meta};
 use flotilla_controllers::reconcilers::{
     checkout::CheckoutDeps, CheckoutReconciler, CheckoutRemoval, CheckoutRemovalOutcome, CheckoutRuntime, PreparedCheckout,
 };
+use flotilla_protocol::NodeId;
 use flotilla_resources::{
     controller::{ControllerLoop, Reconciler},
     repo_key, Checkout, CheckoutBranchProvenance, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutWorktreeSpec, ConditionValue,
-    FreshCloneCheckoutSpec, IntegrationCondition, RepositoryKey, ResourceBackend, ResourceError, ResourceObject, StatusPatch,
+    Convoy, ConvoyPhase, ConvoySpec, ConvoyStatus, FreshCloneCheckoutSpec, InMemoryBackend, InputMeta, IntegrationCondition, RepositoryKey,
+    ResourceBackend, ResourceError, ResourceObject, StatusPatch, VirtualClock, ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL,
 };
 use tokio::time::timeout;
 
@@ -55,6 +58,7 @@ impl CheckoutRuntime for RecordingCheckoutRuntime {
     async fn inspect_integration(
         &self,
         _checkout: &ResourceObject<Checkout>,
+        _convoy: Option<&ResourceObject<flotilla_resources::Convoy>>,
     ) -> Result<flotilla_resources::CheckoutIntegrationStatus, String> {
         *self.inspections.lock().expect("inspections lock") += 1;
         Ok(flotilla_resources::CheckoutIntegrationStatus {
@@ -359,4 +363,80 @@ async fn ready_checkout_reconciler_skips_fresh_integration_probe() {
     assert!(matches!(deps, CheckoutDeps::None));
     assert!(outcome.patch.is_none(), "fresh integration status should not be patched");
     assert_eq!(*runtime.inspections.lock().expect("inspections lock"), 0);
+}
+
+#[tokio::test]
+async fn checkout_authority_observes_when_replicated_convoy_enters_landing() {
+    let authority_root = NodeId::new("convoy-authority");
+    let checkout_root = NodeId::new("checkout-authority");
+    let authority = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(authority_root.clone());
+    let checkout_host = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(checkout_root);
+    let now = chrono::DateTime::parse_from_rfc3339("2026-08-03T21:45:00Z").expect("timestamp").with_timezone(&chrono::Utc);
+    let clock = Arc::new(VirtualClock::new(now));
+
+    let convoys = authority.clone().using::<Convoy>(NAMESPACE);
+    let convoy = convoys
+        .create(
+            &InputMeta::builder().name("cross-host".to_string()).build(),
+            &ConvoySpec::builder().workflow_ref("review-and-fix".to_string()).build(),
+        )
+        .await
+        .expect("create authority convoy");
+    convoys
+        .update_status(&convoy.metadata.name, &convoy.metadata.resource_version, &ConvoyStatus {
+            phase: ConvoyPhase::Landing,
+            ..Default::default()
+        })
+        .await
+        .expect("mark convoy Landing");
+    checkout_host
+        .replica_writer::<Convoy>(authority_root, NAMESPACE)
+        .replace(&convoys.list().await.expect("list authority convoys"), now)
+        .await
+        .expect("replicate convoy to checkout host");
+
+    let checkouts = checkout_host.clone().using::<Checkout>(NAMESPACE);
+    let checkout = checkouts
+        .create(
+            &InputMeta::builder()
+                .name("remote-checkout".to_string())
+                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "cross-host".to_string())]))
+                .annotations(BTreeMap::from([(ACTUATOR_SOURCE_ROOT_ANNOTATION.to_string(), "convoy-authority".to_string())]))
+                .build(),
+            &CheckoutSpec::FreshClone(FreshCloneCheckoutSpec {
+                repo_ref: RepositoryKey(repo_key(REPO_URL)),
+                env_ref: "host-direct-checkout-authority".to_string(),
+                r#ref: "feature/cross-host".to_string(),
+                base_ref: Some("main".to_string()),
+                target_path: "/checkouts/cross-host".to_string(),
+                url: REPO_URL.to_string(),
+            }),
+        )
+        .await
+        .expect("create checkout on its authority host");
+    let observed_at = (now - chrono::Duration::seconds(31)).to_rfc3339();
+    checkouts
+        .update_status(&checkout.metadata.name, &checkout.metadata.resource_version, &CheckoutStatus {
+            phase: CheckoutPhase::Ready,
+            path: Some("/checkouts/cross-host".to_string()),
+            integration: flotilla_resources::CheckoutIntegrationStatus {
+                clean: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observed_at.clone()).build(),
+                pushed: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observed_at.clone()).build(),
+                landed: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observed_at).build(),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .await
+        .expect("record pre-Landing evidence");
+
+    let checkout = checkouts.get("remote-checkout").await.expect("get checkout");
+    let runtime = Arc::new(RecordingCheckoutRuntime::default());
+    let reconciler = CheckoutReconciler::with_clock(runtime.clone(), checkout_host.clone(), NAMESPACE, clock)
+        .with_federated_convoys(&checkout_host, NAMESPACE);
+
+    let deps = reconciler.fetch_dependencies(&checkout).await.expect("resolve replicated Landing convoy");
+
+    assert!(matches!(deps, CheckoutDeps::Integration { .. }), "Landing must shorten the observation TTL to 30 seconds");
+    assert_eq!(*runtime.inspections.lock().expect("inspections lock"), 1, "only the checkout authority should probe its checkout");
 }

--- a/crates/flotilla-controllers/tests/liveness_contract.rs
+++ b/crates/flotilla-controllers/tests/liveness_contract.rs
@@ -54,7 +54,11 @@ impl CheckoutRuntime for HarnessRuntime {
         Ok(PreparedCheckout { commit: Some("abc123".to_string()), branch_provenance: CheckoutBranchProvenance::CreatedForConvoy })
     }
 
-    async fn inspect_integration(&self, _checkout: &ResourceObject<Checkout>) -> Result<CheckoutIntegrationStatus, String> {
+    async fn inspect_integration(
+        &self,
+        _checkout: &ResourceObject<Checkout>,
+        _convoy: Option<&ResourceObject<Convoy>>,
+    ) -> Result<CheckoutIntegrationStatus, String> {
         self.inspections.fetch_add(1, Ordering::SeqCst);
         if self.fail_inspection {
             return Err("resource says Ready but checkout path is missing".to_string());

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -112,6 +112,7 @@ impl CheckoutRuntime for FakeCheckoutRuntime {
     async fn inspect_integration(
         &self,
         _checkout: &flotilla_resources::ResourceObject<Checkout>,
+        _convoy: Option<&flotilla_resources::ResourceObject<Convoy>>,
     ) -> Result<flotilla_resources::CheckoutIntegrationStatus, String> {
         Ok(flotilla_resources::CheckoutIntegrationStatus::default())
     }
@@ -153,6 +154,7 @@ impl CheckoutRuntime for CountingCheckoutRuntime {
     async fn inspect_integration(
         &self,
         _checkout: &ResourceObject<Checkout>,
+        _convoy: Option<&ResourceObject<Convoy>>,
     ) -> Result<flotilla_resources::CheckoutIntegrationStatus, String> {
         Ok(flotilla_resources::CheckoutIntegrationStatus::default())
     }

--- a/crates/flotilla-core/src/checkout_integration.rs
+++ b/crates/flotilla-core/src/checkout_integration.rs
@@ -1,15 +1,25 @@
 use std::{
+    collections::BTreeMap,
     fmt,
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 use chrono::Utc;
 use flotilla_resources::{
-    ChangeRequestMergeability, ChangeRequestObservation, ChangeRequestState, CheckoutIntegrationStatus, CheckoutSpec, CheckoutStatus,
-    ConditionValue, IntegrationCondition, LandedEvidence,
+    ChangeRequestMergeability, ChangeRequestObservation, ChangeRequestState, Checkout, CheckoutIntegrationStatus, CheckoutSpec,
+    CheckoutStatus, ConditionValue, Convoy, CrewWorkPhase, IntegrationCondition, LandedEvidence, ResourceObject, CHANGE_REQUEST_ID_LABEL,
 };
 
 use crate::providers::{ChannelLabel, CommandRunner};
+
+/// Maximum age of checkout evidence used to settle or tear down a convoy.
+pub const LANDING_EVIDENCE_TTL: Duration = Duration::from_secs(30);
+const CONVOY_ASSOCIATION_UNAVAILABLE: &str = "no change request exists for the checkout ref, but convoy association was not available";
+
+pub fn checkout_observation_lacks_convoy_association(status: &CheckoutIntegrationStatus) -> bool {
+    status.landed.details.iter().any(|detail| detail == CONVOY_ASSOCIATION_UNAVAILABLE)
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
 struct EmbeddedRepository {
@@ -54,6 +64,48 @@ pub fn checkout_path_from_status_and_spec<'a>(status: Option<&'a CheckoutStatus>
     status.as_ref().and_then(|status| status.path.as_deref()).or_else(|| spec.target_path()).or(match spec {
         CheckoutSpec::Observed(spec) => Some(spec.path.as_str()),
         _ => None,
+    })
+}
+
+/// Resolve the change request associated with one of a convoy's checkouts.
+///
+/// The checkout authority uses this before probing so a replicated convoy's
+/// completion message can supply the forge identity even when the checkout
+/// itself predates that association.
+pub fn convoy_change_request_id_for_checkout(convoy: &ResourceObject<Convoy>, checkout: &ResourceObject<Checkout>) -> Option<String> {
+    if let Some(id) = checkout.metadata.labels.get(CHANGE_REQUEST_ID_LABEL) {
+        return Some(id.clone());
+    }
+    if let Some(change_request) =
+        convoy.spec.change_request.as_ref().filter(|change_request| change_request.repository_ref == *checkout.spec.repo_ref())
+    {
+        return Some(change_request.id.clone());
+    }
+
+    let repository = convoy.spec.repositories.iter().find(|repository| repository.repo_ref == *checkout.spec.repo_ref())?;
+    convoy
+        .status
+        .as_ref()?
+        .crew_work
+        .values()
+        .flat_map(BTreeMap::values)
+        .filter(|work| work.phase == CrewWorkPhase::Done)
+        .filter_map(|work| {
+            let id = change_request_id_from_completion_message(work.message.as_deref()?, &repository.url)?;
+            Some((work.finished_at, id))
+        })
+        .max_by_key(|(finished_at, _)| *finished_at)
+        .map(|(_, id)| id)
+}
+
+pub(crate) fn change_request_id_from_completion_message(message: &str, repository_url: &str) -> Option<String> {
+    let repository_url = repository_url.trim().trim_end_matches('/').trim_end_matches(".git");
+    ["pull", "pulls"].into_iter().find_map(|segment| {
+        let prefix = format!("{repository_url}/{segment}/");
+        message.match_indices(&prefix).find_map(|(start, _)| {
+            let id = message[start + prefix.len()..].chars().take_while(char::is_ascii_digit).collect::<String>();
+            (!id.is_empty()).then_some(id)
+        })
     })
 }
 
@@ -428,7 +480,7 @@ fn landed_without_change_request(
     if !convoy_association_complete {
         return IntegrationCondition::builder()
             .value(ConditionValue::Unknown)
-            .details(vec!["no change request exists for the checkout ref, but convoy association was not available".to_string()])
+            .details(vec![CONVOY_ASSOCIATION_UNAVAILABLE.to_string()])
             .observed_at(observed_at.to_string())
             .build();
     }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -41,15 +41,15 @@ use flotilla_resources::{
     watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, BoundChangeRequest, Checkout as ResourceCheckout,
     CheckoutIntegrationStatus, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
     CheckoutStatus as ResourceCheckoutStatus, Clock, ConditionValue, Convoy as ResourceConvoy, ConvoyIssue, ConvoyRepositorySpec,
-    ConvoySpec, ConvoyStatusPatch, CredentialGrant, CredentialSpec, CrewCompletionPending, CrewSource, CrewWorkPhase,
-    Environment as ResourceEnvironment, EnvironmentPhase, Host as ResourceHost, HostDirectPlacementPolicyCheckout,
-    HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus, InMemoryBackend, InputMeta, InputValue, IntegrationCondition,
-    IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable, LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec,
-    PlacementPolicy, PlacementPolicySpec, Project, ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource,
-    ResourceBackend, ResourceError, ResourceObject, ResourceProvenance, SystemClock, TerminalBrief, TerminalCrewContext,
-    TerminalCrewMessage, TerminalSession as ResourceTerminalSession, TerminalSessionIdentity,
-    TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch, Vessel, WatchEvent,
-    WatchStart, WorkCompletionAuthority, WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec, CONVOY_LABEL,
+    ConvoySpec, ConvoyStatusPatch, CredentialGrant, CredentialSpec, CrewCompletionPending, CrewSource, Environment as ResourceEnvironment,
+    Host as ResourceHost, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus,
+    InMemoryBackend, InputMeta, InputValue, IntegrationCondition, IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable,
+    LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project,
+    ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError,
+    ResourceObject, ResourceProvenance, SystemClock, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
+    TerminalSession as ResourceTerminalSession, TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase,
+    TerminalSessionSource, TerminalSessionStatusPatch, Vessel, WatchEvent, WatchStart, WorkCompletionAuthority,
+    WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec, ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL,
     HEARTBEAT_READY_TTL_SECS, MANAGED_BY_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
 use futures::{FutureExt, StreamExt};
@@ -61,7 +61,10 @@ use tracing::{debug, info, warn};
 use crate::{
     agent_adapter::CapabilityTable,
     aggregator_projection::AggregatorProjectionState,
-    checkout_integration::{checkout_path_from_status_and_spec, inspect_checkout_integration, inspect_convoy_checkout_integration},
+    checkout_integration::{
+        checkout_path_from_status_and_spec, convoy_change_request_id_for_checkout, inspect_checkout_integration,
+        inspect_convoy_checkout_integration, LANDING_EVIDENCE_TTL,
+    },
     config::{ConfigStore, RemoteHostConfig, StaticEnvironmentConfig},
     convert::snapshot_to_proto,
     daemon::{DaemonHandle, QuerySubscription},
@@ -1581,10 +1584,6 @@ struct ConvoyAdmission {
 /// recently observed snapshot. Keep this deliberately fixed until an
 /// operational need establishes that it should be configurable.
 const ISSUE_SNAPSHOT_FRESHNESS: ChronoDuration = ChronoDuration::minutes(5);
-/// Maximum age of a checkout's landed observation for the Landing→Landed
-/// decision; older evidence is re-probed at the decision edge (#1163).
-const LANDING_EVIDENCE_TTL: ChronoDuration = ChronoDuration::seconds(30);
-
 fn issue_snapshot_is_fresh(issue: &flotilla_protocol::Issue) -> bool {
     let Some(observed_at) = issue.observed_at else { return false };
     let age = Utc::now().signed_duration_since(observed_at);
@@ -1666,48 +1665,17 @@ fn checkout_path(checkout: &ResourceObject<ResourceCheckout>) -> Option<&str> {
     checkout_path_from_status_and_spec(checkout.status.as_ref(), &checkout.spec)
 }
 
-fn convoy_change_request_id_for_checkout(
-    convoy: &ResourceObject<ResourceConvoy>,
-    checkout: &ResourceObject<ResourceCheckout>,
-) -> Option<String> {
-    if let Some(id) = checkout.metadata.labels.get(flotilla_resources::CHANGE_REQUEST_ID_LABEL) {
-        return Some(id.clone());
-    }
-    if let Some(change_request) =
-        convoy.spec.change_request.as_ref().filter(|change_request| change_request.repository_ref == *checkout.spec.repo_ref())
-    {
-        return Some(change_request.id.clone());
-    }
-
-    let repository = convoy.spec.repositories.iter().find(|repository| repository.repo_ref == *checkout.spec.repo_ref())?;
-    convoy
-        .status
-        .as_ref()?
-        .crew_work
-        .values()
-        .flat_map(BTreeMap::values)
-        .filter(|work| work.phase == CrewWorkPhase::Done)
-        .filter_map(|work| {
-            let id = change_request_id_from_completion_message(work.message.as_deref()?, &repository.url)?;
-            Some((work.finished_at, id))
-        })
-        .max_by_key(|(finished_at, _)| *finished_at)
-        .map(|(_, id)| id)
-}
-
-fn change_request_id_from_completion_message(message: &str, repository_url: &str) -> Option<String> {
-    let repository_url = repository_url.trim().trim_end_matches('/').trim_end_matches(".git");
-    ["pull", "pulls"].into_iter().find_map(|segment| {
-        let prefix = format!("{repository_url}/{segment}/");
-        message.match_indices(&prefix).find_map(|(start, _)| {
-            let id = message[start + prefix.len()..].chars().take_while(char::is_ascii_digit).collect::<String>();
-            (!id.is_empty()).then_some(id)
-        })
-    })
-}
-
 fn condition_is_true(condition: &IntegrationCondition) -> bool {
     condition.value == ConditionValue::True
+}
+
+fn integration_condition_is_fresh(condition: &IntegrationCondition, now: chrono::DateTime<Utc>) -> bool {
+    condition
+        .observed_at
+        .as_deref()
+        .and_then(|observed_at| chrono::DateTime::parse_from_rfc3339(observed_at).ok())
+        .and_then(|observed_at| now.signed_duration_since(observed_at).to_std().ok())
+        .is_some_and(|age| age < LANDING_EVIDENCE_TTL)
 }
 
 fn condition_problem(label: &str, condition: &IntegrationCondition) -> Option<String> {
@@ -1740,23 +1708,6 @@ fn checkout_integration_summary(checkout: &ResourceObject<ResourceCheckout>, int
     } else {
         Some(format!("{} [{}]: {}", checkout.metadata.name, checkout_path(checkout).unwrap_or("<unknown path>"), problems.join("; ")))
     }
-}
-
-fn integration_observation_matches(left: &CheckoutIntegrationStatus, right: &CheckoutIntegrationStatus) -> bool {
-    [(&left.clean, &right.clean), (&left.pushed, &right.pushed), (&left.landed, &right.landed)]
-        .into_iter()
-        .all(|(left, right)| left.value == right.value && left.details == right.details)
-        && left.landed_evidence == right.landed_evidence
-        && match (&left.change_request, &right.change_request) {
-            (Some(left), Some(right)) => {
-                left.id == right.id
-                    && left.state == right.state
-                    && left.mergeability == right.mergeability
-                    && left.target_ref == right.target_ref
-            }
-            (None, None) => true,
-            _ => false,
-        }
 }
 
 fn latch_evidence_backed_integration(existing: &CheckoutIntegrationStatus, observed: &mut CheckoutIntegrationStatus) {
@@ -2429,13 +2380,44 @@ impl InProcessDaemon {
                 continue;
             };
             let runner = self.runner_for_resource_checkout(&checkout).await?;
-            let mut integration = inspect_checkout_integration(
-                &*runner,
-                Path::new(path),
-                &checkout.spec,
-                checkout.metadata.labels.get(flotilla_resources::CHANGE_REQUEST_ID_LABEL).map(String::as_str),
-            )
-            .await;
+            let convoy_ref = checkout.metadata.labels.get(CONVOY_LABEL).map(String::as_str);
+            let source_root = checkout.metadata.annotations.get(ACTUATOR_SOURCE_ROOT_ANNOTATION).map(String::as_str);
+            let convoy = self
+                .resource_backend
+                .clone()
+                .including_replicas::<ResourceConvoy>(namespace)
+                .list()
+                .await
+                .map_err(|error| error.to_string())?
+                .items
+                .into_iter()
+                .find_map(|source| {
+                    let origin_matches = match (source_root, &source.provenance) {
+                        (Some(expected), ResourceProvenance::Replica { origin_root, .. }) => origin_root.as_str() == expected,
+                        (Some(_), ResourceProvenance::Local) => false,
+                        (None, _) => true,
+                    };
+                    let association_matches = convoy_ref.map_or_else(
+                        || {
+                            flotilla_resources::expected_checkout_refs(&source.object)
+                                .is_ok_and(|expected| expected.contains(&checkout.metadata.name))
+                        },
+                        |expected| source.object.metadata.name == expected,
+                    );
+                    (origin_matches && association_matches).then_some(source.object)
+                });
+            let mut integration = if let Some(convoy) = convoy.as_ref() {
+                let change_request_id = convoy_change_request_id_for_checkout(convoy, &checkout);
+                inspect_convoy_checkout_integration(&*runner, Path::new(path), &checkout.spec, change_request_id.as_deref()).await
+            } else {
+                inspect_checkout_integration(
+                    &*runner,
+                    Path::new(path),
+                    &checkout.spec,
+                    checkout.metadata.labels.get(flotilla_resources::CHANGE_REQUEST_ID_LABEL).map(String::as_str),
+                )
+                .await
+            };
             if let Some(existing) = checkout.status.as_ref() {
                 latch_evidence_backed_integration(&existing.integration, &mut integration);
             }
@@ -6182,28 +6164,14 @@ impl InProcessDaemon {
         self.local_command_runner().ok_or_else(|| "local command runner unavailable".to_string())
     }
 
-    async fn checkout_environment_is_destroyed(&self, namespace: &str, env_ref: &str) -> Result<bool, String> {
-        let environments = self.resource_backend.clone().using::<ResourceEnvironment>(namespace);
-        match environments.get(env_ref).await {
-            Ok(environment) => {
-                Ok(!environment.status.as_ref().is_some_and(|status| status.ready && status.phase == EnvironmentPhase::Ready))
-            }
-            Err(ResourceError::NotFound { .. }) => Ok(true),
-            Err(error) => Err(error.to_string()),
-        }
-    }
-
     /// Evaluate the Landing→Landed condition on evidence no older than
     /// [`LANDING_EVIDENCE_TTL`]: every managed convoy checkout's landed
-    /// condition must be `True` on a recent observation. Cached conditions may
-    /// predate a just-opened change request (#1163), so anything older is
-    /// re-probed at the decision edge and the fresh observation persisted;
-    /// anything unknown or unprobeable holds Landing — absence of evidence
-    /// never releases the gate. Recent observations are trusted as-is, which
-    /// bounds forge lookups and keeps the persist from re-triggering the
-    /// reconcile in a loop. Adopted checkouts participate because an adopted
-    /// open change request is still outstanding, even though its checkout is
-    /// exempt from deletion.
+    /// condition must be `True` on a recent authority-side observation.
+    /// Missing, stale, or unknown replicated evidence holds Landing; this
+    /// evaluator never probes or writes a checkout because its authority may
+    /// be another host. Adopted checkouts participate because an adopted open
+    /// change request is still outstanding, even though its checkout is exempt
+    /// from deletion.
     pub async fn convoy_change_requests_settled(&self, namespace: &str, name: &str) -> Result<bool, String> {
         let checkout_list = self
             .resource_backend
@@ -6224,48 +6192,26 @@ impl InProcessDaemon {
         checkout_list: &[ResourceObject<ResourceCheckout>],
     ) -> Result<bool, String> {
         let expected = flotilla_resources::expected_checkout_refs(convoy)?;
-        let checkouts = self.resource_backend.clone().using::<ResourceCheckout>(&convoy.metadata.namespace);
         for checkout_name in expected {
             let Some(checkout) = checkout_list.iter().find(|checkout| checkout.metadata.name == checkout_name) else {
+                warn!(checkout = %checkout_name, convoy = %convoy.metadata.name, "checkout landing evidence is missing");
                 return Ok(false);
             };
-            if let Some(landed) = checkout.status.as_ref().map(|status| &status.integration.landed) {
-                let recent = landed
-                    .observed_at
-                    .as_deref()
-                    .and_then(|observed_at| chrono::DateTime::parse_from_rfc3339(observed_at).ok())
-                    .is_some_and(|observed_at| self.clock.now().signed_duration_since(observed_at) < LANDING_EVIDENCE_TTL);
-                if recent {
-                    match landed.value {
-                        ConditionValue::True => continue,
-                        ConditionValue::False => return Ok(false),
-                        ConditionValue::Unknown => {}
-                    }
+            let Some(landed) = checkout.status.as_ref().map(|status| &status.integration.landed) else {
+                warn!(checkout = %checkout.metadata.name, convoy = %convoy.metadata.name, "checkout landing evidence is missing");
+                return Ok(false);
+            };
+            if !integration_condition_is_fresh(landed, self.clock.now()) {
+                warn!(checkout = %checkout.metadata.name, convoy = %convoy.metadata.name, "checkout landing evidence is missing or stale");
+                return Ok(false);
+            }
+            match landed.value {
+                ConditionValue::True => continue,
+                ConditionValue::False => return Ok(false),
+                ConditionValue::Unknown => {
+                    warn!(checkout = %checkout.metadata.name, convoy = %convoy.metadata.name, details = ?landed.details, "checkout landing evidence is unknown");
+                    return Ok(false);
                 }
-            }
-            let Some(path) = checkout_path(checkout).map(|path| Path::new(path).to_path_buf()) else {
-                return Ok(false);
-            };
-            let runner = match self.runner_for_resource_checkout(checkout).await {
-                Ok(runner) => runner,
-                Err(_) => return Ok(false),
-            };
-            let change_request_id = convoy_change_request_id_for_checkout(convoy, checkout);
-            let mut integration = inspect_convoy_checkout_integration(&*runner, &path, &checkout.spec, change_request_id.as_deref()).await;
-            if let Some(existing) = checkout.status.as_ref() {
-                latch_evidence_backed_integration(&existing.integration, &mut integration);
-            }
-            if let Err(error) = apply_resource_status_patch(
-                &checkouts,
-                &checkout.metadata.name,
-                &flotilla_resources::CheckoutStatusPatch::UpdateIntegration { integration: Box::new(integration.clone()) },
-            )
-            .await
-            {
-                warn!(checkout = %checkout.metadata.name, %error, "failed to persist checkout integration conditions during landing evaluation");
-            }
-            if !condition_is_true(&integration.landed) {
-                return Ok(false);
             }
         }
         Ok(true)
@@ -6320,91 +6266,30 @@ impl InProcessDaemon {
             ));
         }
 
-        let checkouts = self.resource_backend.clone().using::<ResourceCheckout>(namespace);
         let mut refusals = Vec::new();
-        let mut verified = false;
         for checkout in checkout_list.iter().filter(|checkout| expected.contains(&checkout.metadata.name)) {
             let is_adopted = checkout.metadata.lifecycle_authority().map_err(|err| err.to_string())? == Some(LifecycleAuthority::Adopted);
-            if let Some(env_ref) = checkout.spec.env_ref() {
-                if self.checkout_environment_is_destroyed(namespace, env_ref).await? {
-                    warn!(
-                        checkout = %checkout.metadata.name,
-                        env_ref,
-                        "checkout environment is gone; allowing corpse cleanup without integration probes"
-                    );
-                    continue;
-                }
-            }
-            let path = match checkout_path(checkout) {
-                Some(path) => Path::new(path).to_path_buf(),
-                None => {
-                    if is_adopted {
-                        warn!(checkout = %checkout.metadata.name, "adopted checkout has no resolved path; releasing without deletion");
-                        continue;
-                    }
-                    refusals.push(format!("{} [<unknown path>]: Clean=Unknown (checkout has no resolved path)", checkout.metadata.name));
-                    continue;
-                }
+            let Some(integration) = checkout.status.as_ref().map(|status| &status.integration) else {
+                refusals.push(format!("{}: integration evidence is missing", checkout.metadata.name));
+                continue;
             };
-            let runner = match self.runner_for_resource_checkout(checkout).await {
-                Ok(runner) => runner,
-                Err(error) => {
-                    if is_adopted {
-                        warn!(checkout = %checkout.metadata.name, %error, "adopted checkout integration could not be probed; releasing without deletion");
-                        continue;
-                    }
-                    refusals.push(format!(
-                        "{} [{}]: Clean=Unknown ({error}); Pushed=Unknown ({error}); Landed=Unknown ({error})",
-                        checkout.metadata.name,
-                        path.display()
-                    ));
-                    continue;
-                }
+            let required = if is_adopted {
+                vec![("Landed", &integration.landed)]
+            } else {
+                vec![("Clean", &integration.clean), ("Pushed", &integration.pushed), ("Landed", &integration.landed)]
             };
-            match runner.path_exists(&path).await {
-                Ok(false) => {
-                    warn!(
-                        checkout = %checkout.metadata.name,
-                        path = %path.display(),
-                        "checkout path is already gone; allowing reclaim to finish"
-                    );
-                    continue;
-                }
-                Ok(true) => {}
-                Err(error) => {
-                    refusals.push(format!(
-                        "{} [{}]: Clean=Unknown (checkout path could not be probed: {error})",
-                        checkout.metadata.name,
-                        path.display()
-                    ));
-                    continue;
-                }
-            }
-            let change_request_id = convoy_change_request_id_for_checkout(convoy, checkout);
-            let mut integration = inspect_convoy_checkout_integration(&*runner, &path, &checkout.spec, change_request_id.as_deref()).await;
-            verified = true;
-            if let Some(existing) = checkout.status.as_ref() {
-                latch_evidence_backed_integration(&existing.integration, &mut integration);
-            }
-            if !checkout.status.as_ref().is_some_and(|status| integration_observation_matches(&status.integration, &integration)) {
-                if let Err(error) = apply_resource_status_patch(
-                    &checkouts,
-                    &checkout.metadata.name,
-                    &flotilla_resources::CheckoutStatusPatch::UpdateIntegration { integration: Box::new(integration.clone()) },
-                )
-                .await
-                {
-                    warn!(
-                        checkout = %checkout.metadata.name,
-                        %error,
-                        "failed to persist checkout integration conditions during teardown gate"
-                    );
-                }
+            let stale = required
+                .iter()
+                .filter_map(|(label, condition)| (!integration_condition_is_fresh(condition, self.clock.now())).then_some(*label))
+                .collect::<Vec<_>>();
+            if !stale.is_empty() {
+                refusals.push(format!("{}: {} evidence is missing or stale", checkout.metadata.name, stale.join(", ")));
+                continue;
             }
             if is_adopted {
                 if !condition_is_true(&integration.landed) {
                     refusals.push(
-                        checkout_integration_summary(checkout, &integration)
+                        checkout_integration_summary(checkout, integration)
                             .unwrap_or_else(|| format!("{}: Landed is not verified", checkout.metadata.name)),
                     );
                 }
@@ -6412,14 +6297,12 @@ impl InProcessDaemon {
             }
             if !(condition_is_true(&integration.clean) && condition_is_true(&integration.pushed) && condition_is_true(&integration.landed))
             {
-                if let Some(summary) = checkout_integration_summary(checkout, &integration) {
+                if let Some(summary) = checkout_integration_summary(checkout, integration) {
                     refusals.push(summary);
                 }
             }
         }
-        if !verified {
-            Err(format!("convoy {namespace}/{name} is not safe to delete: no checkout integration evidence"))
-        } else if refusals.is_empty() {
+        if refusals.is_empty() {
             Ok(())
         } else {
             refusals.sort();

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -60,7 +60,7 @@ const TEST_LOCAL_ATTACH_HOST: &str = "local";
 #[test]
 fn completion_message_extracts_github_and_forgejo_change_request_urls_from_prose() {
     assert_eq!(
-        change_request_id_from_completion_message(
+        crate::checkout_integration::change_request_id_from_completion_message(
             "Opened [PR #1338](https://github.com/flotilla-org/flotilla/pull/1338); checks are green.",
             "https://github.com/flotilla-org/flotilla.git",
         )
@@ -68,7 +68,7 @@ fn completion_message_extracts_github_and_forgejo_change_request_urls_from_prose
         Some("1338")
     );
     assert_eq!(
-        change_request_id_from_completion_message(
+        crate::checkout_integration::change_request_id_from_completion_message(
             "Ready: https://forgejo.lab/fork-issues/zellij/pulls/9 (reviewed)",
             "https://forgejo.lab/fork-issues/zellij",
         )
@@ -80,7 +80,7 @@ fn completion_message_extracts_github_and_forgejo_change_request_urls_from_prose
 #[test]
 fn completion_message_ignores_change_request_urls_for_other_repositories() {
     assert_eq!(
-        change_request_id_from_completion_message(
+        crate::checkout_integration::change_request_id_from_completion_message(
             "https://github.com/flotilla-org/other/pull/42",
             "https://github.com/flotilla-org/flotilla",
         ),
@@ -1109,6 +1109,28 @@ async fn create_ready_observed_checkout_for_convoy(
         .await
         .expect("checkout should be ready");
     record_expected_checkout_for_convoy(daemon, namespace, convoy, checkout_name).await;
+}
+
+async fn observe_checkout_for_convoy(daemon: &InProcessDaemon, namespace: &str, convoy_name: &str, checkout_name: &str) {
+    let convoys = daemon.resource_backend().using::<Convoy>(namespace);
+    let convoy = convoys.get(convoy_name).await.expect("owning convoy should exist");
+    let checkouts = daemon.resource_backend().using::<ResourceCheckout>(namespace);
+    let checkout = checkouts.get(checkout_name).await.expect("checkout should exist");
+    let path = checkout_path(&checkout).expect("checkout should have a resolved path");
+    let runner = daemon.runner_for_resource_checkout(&checkout).await.expect("checkout authority runner should exist");
+    let change_request_id = crate::checkout_integration::convoy_change_request_id_for_checkout(&convoy, &checkout);
+    let integration = crate::checkout_integration::inspect_convoy_checkout_integration(
+        &*runner,
+        Path::new(path),
+        &checkout.spec,
+        change_request_id.as_deref(),
+    )
+    .await;
+    apply_resource_status_patch(&checkouts, checkout_name, &flotilla_resources::CheckoutStatusPatch::UpdateIntegration {
+        integration: Box::new(integration),
+    })
+    .await
+    .expect("authority-side integration observation should persist");
 }
 
 async fn record_expected_checkout_for_convoy(daemon: &InProcessDaemon, namespace: &str, convoy_name: &str, checkout_name: &str) {
@@ -5174,6 +5196,7 @@ async fn convoy_delete_refuses_completed_convoy_with_unpushed_checkout_until_for
         "feature/missing-push",
     )
     .await;
+    observe_checkout_for_convoy(&daemon, "custom-ns", "completed-convoy", "checkout-missing-push").await;
 
     let mut events = daemon.subscribe();
     let command_id = daemon
@@ -5250,6 +5273,7 @@ async fn convoy_delete_refuses_diverged_checkout_without_a_change_request() {
         .expect("convoy create should succeed");
     create_ready_observed_checkout_for_convoy(&daemon, "flotilla", "diverged-convoy", "checkout-diverged", "/repo", "feature/diverged")
         .await;
+    observe_checkout_for_convoy(&daemon, "flotilla", "diverged-convoy", "checkout-diverged").await;
 
     let result = daemon.verify_convoy_teardown_gate("flotilla", "diverged-convoy", false).await;
 
@@ -5373,21 +5397,22 @@ async fn teardown_gate_does_not_rewrite_a_latched_terminal_change_request() {
         .expect("convoy create should succeed");
     create_ready_observed_checkout_for_convoy(&daemon, "flotilla", "merged-convoy", "checkout-merged", "/repo", "feature/merged").await;
 
-    let condition = |value, observed_at: &str| IntegrationCondition::builder().value(value).observed_at(observed_at.to_string()).build();
+    let observed_at = chrono::Utc::now().to_rfc3339();
+    let condition = |value| IntegrationCondition::builder().value(value).observed_at(observed_at.clone()).build();
     let evidence = flotilla_resources::LandedEvidence::builder().change_request_id("1162".to_string()).build();
     let change_request = flotilla_resources::ChangeRequestObservation::builder()
         .id("1162".to_string())
         .state(flotilla_resources::ChangeRequestState::Merged)
         .mergeability(flotilla_resources::ChangeRequestMergeability::Unknown)
-        .observed_at("2026-07-28T00:00:00Z".to_string())
+        .observed_at(observed_at.clone())
         .build();
     let checkouts = daemon.resource_backend().using::<ResourceCheckout>("flotilla");
     let checkout = checkouts.get("checkout-merged").await.expect("ready checkout");
     let mut status = checkout.status.expect("ready checkout status");
     status.integration = CheckoutIntegrationStatus {
-        clean: condition(ConditionValue::True, "2026-07-28T00:00:00Z"),
-        pushed: condition(ConditionValue::True, "2026-07-28T00:00:00Z"),
-        landed: condition(ConditionValue::True, "2026-07-28T00:00:00Z"),
+        clean: condition(ConditionValue::True),
+        pushed: condition(ConditionValue::True),
+        landed: condition(ConditionValue::True),
         landed_evidence: Some(evidence),
         change_request: Some(change_request),
     };
@@ -5404,7 +5429,7 @@ async fn teardown_gate_does_not_rewrite_a_latched_terminal_change_request() {
 }
 
 #[tokio::test]
-async fn landing_settlement_uses_latched_terminal_change_request_after_stale_reprobe() {
+async fn stale_latched_terminal_change_request_cannot_settle_landing() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");
     std::fs::create_dir_all(&config_base).expect("create config dir");
@@ -5465,8 +5490,8 @@ async fn landing_settlement_uses_latched_terminal_change_request_after_stale_rep
     checkouts.update_status("checkout-merged", &checkout.metadata.resource_version, &status).await.expect("persist landed checkout");
 
     assert!(
-        daemon.convoy_change_requests_settled("flotilla", "merged-convoy").await.expect("landing evaluation"),
-        "evidence-backed landed status must survive a stale reprobe that can no longer discover the merged PR"
+        !daemon.convoy_change_requests_settled("flotilla", "merged-convoy").await.expect("landing evaluation"),
+        "stale latched landed evidence must hold until the checkout authority publishes a fresh observation"
     );
     let stored = checkouts.get("checkout-merged").await.expect("checkout after landing evaluation");
     assert_eq!(
@@ -5543,7 +5568,6 @@ async fn completion_pr_from_another_branch_holds_landing_when_checkout_spec_ref_
         "provisioned-ref",
     )
     .await;
-
     assert!(
         !daemon.convoy_change_requests_settled("flotilla", "different-pr-branch").await.expect("evaluate settlement"),
         "the open completion PR must hold Landing even though its head differs from the checkout spec ref"
@@ -5551,7 +5575,7 @@ async fn completion_pr_from_another_branch_holds_landing_when_checkout_spec_ref_
 }
 
 #[tokio::test]
-async fn convoy_reclaim_refuses_when_missing_path_leaves_no_integration_evidence() {
+async fn convoy_reclaim_refuses_when_checkout_has_no_fresh_integration_evidence() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");
     std::fs::create_dir_all(&config_base).expect("create config dir");
@@ -5579,7 +5603,7 @@ async fn convoy_reclaim_refuses_when_missing_path_leaves_no_integration_evidence
         .verify_convoy_teardown_gate("flotilla", "half-reclaimed", false)
         .await
         .expect_err("a missing checkout path alone is not positive integration evidence");
-    assert!(refusal.contains("no checkout integration evidence"), "unexpected refusal: {refusal}");
+    assert!(refusal.contains("evidence is missing or stale"), "unexpected refusal: {refusal}");
 }
 
 #[tokio::test]
@@ -5741,6 +5765,7 @@ async fn convoy_delete_refuses_ignored_embedded_repository_with_local_commits() 
         "main",
     )
     .await;
+    observe_checkout_for_convoy(&daemon, "flotilla", "embedded-repo-convoy", "checkout-embedded-repo").await;
 
     let mut events = daemon.subscribe();
     let command_id = daemon
@@ -5817,7 +5842,7 @@ async fn convoy_delete_refuses_when_destroyed_environment_leaves_no_integration_
 
     let result = wait_for_command_result(&mut events, command_id).await;
     assert!(
-        matches!(&result, CommandValue::Error { message } if message.contains("no checkout integration evidence")),
+        matches!(&result, CommandValue::Error { message } if message.contains("evidence is missing or stale")),
         "unexpected delete result: {result:?}"
     );
     convoys.get("corpse-convoy").await.expect("refused convoy should remain");
@@ -6677,13 +6702,17 @@ async fn adopted_checkout_with_unlanded_change_request_refuses_reclaim_gate() {
         )
         .await
         .expect("create adopted checkout");
+    let observed_at = chrono::Utc::now().to_rfc3339();
     checkouts
         .update_status(&created.metadata.name, &created.metadata.resource_version, &ResourceCheckoutStatus {
             phase: ResourceCheckoutPhase::Ready,
             path: Some("/repo".to_string()),
             commit: None,
             branch_provenance: Default::default(),
-            integration: Default::default(),
+            integration: CheckoutIntegrationStatus {
+                landed: IntegrationCondition::builder().value(ConditionValue::False).observed_at(observed_at).build(),
+                ..Default::default()
+            },
             message: None,
         })
         .await
@@ -6699,13 +6728,13 @@ async fn adopted_checkout_with_unlanded_change_request_refuses_reclaim_gate() {
 }
 
 #[tokio::test]
-async fn landing_holds_when_fresh_probe_contradicts_stale_vacuous_landed() {
+async fn landing_holds_on_stale_vacuous_landed_without_probing() {
     // #1163 replay: a checkout's landed condition was recorded True while the
     // branch was untouched ("nothing to land"), the crew then pushed and
     // opened a change request, and the convoy entered Landing before any
-    // re-observation. The landing decision must re-probe, hold on the fresh
-    // open-change-request evidence, and the persisted condition must not be
-    // resurrected to True by the evidence latch.
+    // re-observation. The landing decision must hold until the checkout's
+    // authority publishes a fresh observation, without probing or rewriting
+    // the stored checkout itself.
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");
     std::fs::create_dir_all(&config_base).expect("create config dir");
@@ -6759,10 +6788,11 @@ async fn landing_holds_when_fresh_probe_contradicts_stale_vacuous_landed() {
         )
         .await
         .expect("checkout create should succeed");
+    let stale_observed_at = (chrono::Utc::now() - chrono::Duration::minutes(10)).to_rfc3339();
     let stale_vacuous = flotilla_resources::IntegrationCondition::builder()
         .value(flotilla_resources::ConditionValue::True)
         .details(vec!["no change request exists for branch".to_string()])
-        .observed_at((chrono::Utc::now() - chrono::Duration::minutes(10)).to_rfc3339())
+        .observed_at(stale_observed_at.clone())
         .build();
     checkouts
         .update_status(&checkout.metadata.name, &checkout.metadata.resource_version, &ResourceCheckoutStatus {
@@ -6783,13 +6813,11 @@ async fn landing_holds_when_fresh_probe_contradicts_stale_vacuous_landed() {
         .expect("checkout status should update");
     record_expected_checkout_for_convoy(&daemon, "flotilla", "split-convoy", "checkout-split").await;
 
-    // First pass: the stale True is re-probed; the open change request holds
-    // Landing and the fresh False observation is persisted un-latched.
+    // The convoy authority consumes only stored evidence. The stale True
+    // cannot release Landing, and evaluating it must not probe or rewrite a
+    // checkout that may be a replica from another host.
     assert!(!daemon.convoy_change_requests_settled("flotilla", "split-convoy").await.expect("landing evaluation should succeed"));
     let stored = checkouts.get("checkout-split").await.expect("checkout should exist").status.expect("checkout status");
-    assert_eq!(stored.integration.landed.value, flotilla_resources::ConditionValue::False);
-
-    // Second pass, within the evidence TTL: the recent False is trusted from
-    // cache and still holds Landing.
-    assert!(!daemon.convoy_change_requests_settled("flotilla", "split-convoy").await.expect("landing evaluation should succeed"));
+    assert_eq!(stored.integration.landed.value, flotilla_resources::ConditionValue::True);
+    assert_eq!(stored.integration.landed.observed_at, Some(stale_observed_at));
 }

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -6782,7 +6782,7 @@ async fn two_commands_can_run_concurrently() {
 }
 
 #[tokio::test]
-async fn convoy_landing_reprobes_after_injected_clock_crosses_evidence_ttl() {
+async fn convoy_landing_rejects_evidence_after_injected_clock_crosses_ttl() {
     let temp = tempfile::tempdir().expect("temp dir");
     let backend = flotilla_resources::ResourceBackend::InMemory(Default::default());
     let now = chrono::DateTime::parse_from_rfc3339("2026-07-28T12:00:00Z").expect("timestamp").with_timezone(&chrono::Utc);
@@ -6854,6 +6854,6 @@ async fn convoy_landing_reprobes_after_injected_clock_crosses_evidence_ttl() {
 
     assert!(
         !daemon.convoy_change_requests_settled("flotilla", "convoy-a").await.expect("stale decision"),
-        "stale cached evidence must be re-probed and a missing path must hold Landing"
+        "stale cached evidence must hold Landing until the checkout authority refreshes it"
     );
 }

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -17,7 +17,10 @@ use flotilla_controllers::reconcilers::{
 use flotilla_core::{
     agent_adapter::{AgentLaunchRequest, CapabilityTable},
     aggregator_projection::AggregatorProjectionState,
-    checkout_integration::{checkout_path_from_status_and_spec, inspect_checkout_integration},
+    checkout_integration::{
+        checkout_path_from_status_and_spec, convoy_change_request_id_for_checkout, inspect_checkout_integration,
+        inspect_convoy_checkout_integration,
+    },
     config::ConfigStore,
     in_process::InProcessDaemon,
     measure_available_space,
@@ -1473,12 +1476,16 @@ fn spawn_controller_loops(
                         let runner = state.daemon.local_command_runner().expect("local runner should exist");
                         ControllerLoop {
                             primary: backend.clone().using::<flotilla_resources::Checkout>(&namespace_string),
-                            secondaries: vec![],
+                            secondaries: CheckoutReconciler::<CheckoutControllerRuntime>::federated_secondary_watches(
+                                &backend,
+                                &namespace_string,
+                            ),
                             reconciler: CheckoutReconciler::new(
                                 Arc::new(CheckoutControllerRuntime { runner }),
                                 backend.clone(),
                                 &namespace_string,
-                            ),
+                            )
+                            .with_federated_convoys(&backend, &namespace_string),
                             resync_interval: controller_resync_interval,
                             backend,
                         }
@@ -2319,10 +2326,20 @@ impl CheckoutRuntime for CheckoutControllerRuntime {
         Ok(PreparedCheckout { commit, branch_provenance: CheckoutBranchProvenance::PreExisting })
     }
 
-    async fn inspect_integration(&self, checkout: &ResourceObject<Checkout>) -> Result<CheckoutIntegrationStatus, String> {
+    async fn inspect_integration(
+        &self,
+        checkout: &ResourceObject<Checkout>,
+        convoy: Option<&ResourceObject<Convoy>>,
+    ) -> Result<CheckoutIntegrationStatus, String> {
+        let runner = self.local_runner()?;
+        let path = Path::new(self.checkout_path(checkout)?);
+        if let Some(convoy) = convoy {
+            let change_request_id = convoy_change_request_id_for_checkout(convoy, checkout);
+            return Ok(inspect_convoy_checkout_integration(&*runner, path, &checkout.spec, change_request_id.as_deref()).await);
+        }
         Ok(inspect_checkout_integration(
-            &*self.local_runner()?,
-            Path::new(self.checkout_path(checkout)?),
+            &*runner,
+            path,
             &checkout.spec,
             checkout.metadata.labels.get(flotilla_resources::CHANGE_REQUEST_ID_LABEL).map(String::as_str),
         )
@@ -2847,11 +2864,12 @@ mod tests {
     };
     use flotilla_resources::{
         api_version,
+        controller::Reconciler,
         test_support::{
             run_transition_sequence, FixpointPredicate, LivenessEnrollment, LivenessScenario, LivenessStep, ReconcileStep, Transition,
             TransitionDriver, TransitionSequence, WorldBuilder,
         },
-        Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
+        Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec, CheckoutSpec as ResourceCheckoutSpec,
         CheckoutStatus as ResourceCheckoutStatus, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CredentialConsumer,
         CredentialGrant, CredentialLifecycle, CredentialPlacementRequirements, CredentialSource, CredentialSpec, CredentialSpecSpec,
         CrewSource, CrewSpec, LifecycleAuthority, MaterialPoolSpec, MaterialPoolUnitSpec,
@@ -5353,6 +5371,120 @@ mod tests {
         daemon_with_backend(tracked_repos, config, ResourceBackend::InMemory(Default::default())).await
     }
 
+    #[tokio::test]
+    async fn checkout_authority_observes_replicated_landing_and_convoy_authority_settles_from_evidence() {
+        let temp = TempDir::new().expect("tempdir");
+        let authority_root = flotilla_protocol::NodeId::new("authority-root");
+        let checkout_root = flotilla_protocol::NodeId::new("checkout-root");
+        let authority = ResourceBackend::InMemory(flotilla_resources::InMemoryBackend::default()).with_local_root(authority_root.clone());
+        let checkout_host =
+            ResourceBackend::InMemory(flotilla_resources::InMemoryBackend::default()).with_local_root(checkout_root.clone());
+        let config = Arc::new(ConfigStore::with_base(temp.path().join("authority-config")));
+        let authority_daemon = daemon_with_backend(Vec::new(), config, authority.clone()).await;
+        let repository_key = flotilla_resources::RepositoryKey("repo-a".to_string());
+
+        let convoys = authority.clone().using::<Convoy>(NAMESPACE);
+        let convoy = convoys
+            .create(
+                &flotilla_resources::InputMeta::builder().name("cross-host".to_string()).build(),
+                &ConvoySpec::builder()
+                    .workflow_ref("review-and-fix".to_string())
+                    .adopted_checkout_refs(BTreeMap::from([(repository_key.clone(), "checkout-b".to_string())]))
+                    .build(),
+            )
+            .await
+            .expect("create authority convoy");
+        convoys
+            .update_status(&convoy.metadata.name, &convoy.metadata.resource_version, &ConvoyStatus {
+                phase: ConvoyPhase::Landing,
+                workflow_snapshot: Some(flotilla_resources::WorkflowSnapshot {
+                    vessels: vec![VesselRequirement::builder().name("work".to_string()).crew(Vec::new()).build()],
+                }),
+                work: BTreeMap::from([("work".to_string(), flotilla_resources::WorkState::builder().phase(WorkPhase::Complete).build())]),
+                observed_workflow_ref: Some("review-and-fix".to_string()),
+                ..Default::default()
+            })
+            .await
+            .expect("mark authority convoy Landing");
+        checkout_host
+            .replica_writer::<Convoy>(authority_root, NAMESPACE)
+            .replace(&convoys.list().await.expect("list authority convoys"), chrono::Utc::now())
+            .await
+            .expect("replicate Landing convoy to checkout host");
+
+        let git_repo = TestGitRepo::init(temp.path().join("checkout")).with_initial_commit();
+        let checkouts = checkout_host.clone().using::<Checkout>(NAMESPACE);
+        let checkout = checkouts
+            .create(
+                &flotilla_resources::InputMeta::builder()
+                    .name("checkout-b".to_string())
+                    .labels(BTreeMap::from([
+                        (flotilla_resources::CONVOY_LABEL.to_string(), "cross-host".to_string()),
+                        (flotilla_resources::CHANGE_REQUEST_ID_LABEL.to_string(), "1367".to_string()),
+                    ]))
+                    .annotations(BTreeMap::from([(
+                        flotilla_resources::ACTUATOR_SOURCE_ROOT_ANNOTATION.to_string(),
+                        "authority-root".to_string(),
+                    )]))
+                    .build(),
+                &CheckoutSpec::Observed(ResourceObservedCheckoutSpec {
+                    r#ref: "feature/cross-host".to_string(),
+                    path: git_repo.path().display().to_string(),
+                    repo_ref: repository_key,
+                    host_ref: "checkout-host".to_string(),
+                    is_main: false,
+                }),
+            )
+            .await
+            .expect("create checkout on authority host B");
+        checkouts
+            .update_status(&checkout.metadata.name, &checkout.metadata.resource_version, &ResourceCheckoutStatus {
+                phase: ResourceCheckoutPhase::Ready,
+                path: Some(git_repo.path().display().to_string()),
+                integration: CheckoutIntegrationStatus::default(),
+                ..Default::default()
+            })
+            .await
+            .expect("mark checkout ready");
+
+        let checkout = checkouts.get("checkout-b").await.expect("get checkout on authority host B");
+        let observer = CheckoutReconciler::new(
+            Arc::new(CheckoutControllerRuntime { runner: Arc::new(MergedPrProcessRunner::new(1367)) }),
+            checkout_host.clone(),
+            NAMESPACE,
+        )
+        .with_federated_convoys(&checkout_host, NAMESPACE);
+        let dependencies = observer.fetch_dependencies(&checkout).await.expect("observe integration on checkout authority");
+        let observation = observer.reconcile(&checkout, &dependencies, chrono::Utc::now());
+        let patch = observation.patch.expect("Landing observation should update checkout evidence");
+        flotilla_resources::apply_status_patch(&checkouts, "checkout-b", &patch).await.expect("persist authority-local observation");
+        assert_eq!(
+            checkouts.get("checkout-b").await.expect("observed checkout").status.expect("checkout status").integration.landed.value,
+            ConditionValue::True,
+            "checkout authority B must observe the merged change request",
+        );
+
+        authority
+            .replica_writer::<Checkout>(checkout_root, NAMESPACE)
+            .replace(&checkouts.list().await.expect("list checkout authority resources"), chrono::Utc::now())
+            .await
+            .expect("replicate fresh evidence to convoy authority A");
+        let current = convoys.get("cross-host").await.expect("get Landing convoy");
+        let reconciler = ConvoyReconciler::new(authority.clone().using::<WorkflowTemplate>(NAMESPACE))
+            .with_federated_checkouts(authority.including_replicas::<Checkout>(NAMESPACE))
+            .with_teardown_runtime(Arc::new(DaemonConvoyTeardownRuntime::new(authority_daemon)));
+        let dependencies = reconciler.fetch_dependencies(&current).await.expect("consume replicated checkout evidence");
+        let outcome = reconciler.reconcile(&current, &dependencies, chrono::Utc::now());
+        let patch = outcome.patch.expect("fresh replicated evidence should settle the convoy");
+        flotilla_resources::apply_status_patch(&convoys, "cross-host", &patch).await.expect("persist Landed phase");
+
+        assert_eq!(convoys.get("cross-host").await.expect("settled convoy").status.expect("convoy status").phase, ConvoyPhase::Landed,);
+        assert!(
+            authority.clone().using::<Checkout>(NAMESPACE).list().await.expect("list authority-local checkouts").items.is_empty(),
+            "convoy authority A must not re-author or write the replicated checkout",
+        );
+    }
+
     async fn sqlite_daemon(tracked_repos: Vec<PathBuf>, config: Arc<ConfigStore>) -> Arc<InProcessDaemon> {
         std::fs::create_dir_all(config.state_dir()).expect("state dir");
         let backend = ResourceBackend::Sqlite(SqliteBackend::open(config.state_dir().join("resources.sqlite")).expect("sqlite backend"));
@@ -5847,6 +5979,13 @@ mod tests {
                 let status = ProcessCommand::new("git").arg("-C").arg(&checkout_path).args(args).status().expect("prepare pushed state");
                 assert!(status.success());
             }
+            let current = checkouts.get(&checkout.metadata.name).await.expect("checkout should still exist");
+            let mut status = current.status.expect("checkout should remain ready");
+            status.integration.pushed.observed_at = None;
+            checkouts
+                .update_status(&checkout.metadata.name, &current.metadata.resource_version, &status)
+                .await
+                .expect("filesystem mutation should invalidate cached integration evidence");
             Some(checkout_path)
         } else {
             None
@@ -5860,7 +5999,10 @@ mod tests {
                 action: CommandAction::ConvoyWorkForceComplete {
                     convoy: "convoy-a".to_string(),
                     work: "implement".to_string(),
-                    message: Some("done".to_string()),
+                    message: Some(match completion_action {
+                        CompletionAction::Delete => "https://github.com/flotilla-org/flotilla/pull/884".to_string(),
+                        CompletionAction::Retain => "done".to_string(),
+                    }),
                 },
             })
             .await
@@ -7180,6 +7322,8 @@ mod tests {
             .await
             .expect("convoy completion command should start");
         assert_eq!(wait_for_command_result(&mut rx, complete_id).await, CommandValue::Ok);
+
+        daemon.reconcile_adopted_checkouts(NAMESPACE).await.expect("Landing should refresh adopted checkout integration evidence");
 
         wait_until(|| {
             let convoys = convoys.clone();

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -309,6 +309,56 @@ impl<W: Resource, P: Resource> SecondaryWatch for ReplicaLabelMappedWatch<W, P> 
     }
 }
 
+/// Watch federated convoys and enqueue every checkout they currently claim.
+#[derive(Clone)]
+pub struct ReplicaConvoyCheckoutWatch {
+    pub resolver: ReplicaReadResolver<crate::Convoy>,
+}
+
+impl ReplicaConvoyCheckoutWatch {
+    async fn enqueue_checkouts(sender: &mpsc::Sender<String>, convoy: &ResourceObject<crate::Convoy>) -> Result<(), ResourceError> {
+        for checkout_name in crate::expected_checkout_refs(convoy).unwrap_or_default() {
+            sender
+                .send(checkout_name)
+                .await
+                .map_err(|_| ResourceError::other("controller queue closed while forwarding federated convoy checkout event"))?;
+        }
+        Ok(())
+    }
+}
+
+impl SecondaryWatch for ReplicaConvoyCheckoutWatch {
+    type Primary = crate::Checkout;
+
+    fn clone_box(&self) -> Box<dyn SecondaryWatch<Primary = Self::Primary>> {
+        Box::new(self.clone())
+    }
+
+    fn spawn(
+        self: Box<Self>,
+        _backend: ResourceBackend,
+        _namespace: String,
+        sender: mpsc::Sender<String>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), ResourceError>> + Send>> {
+        Box::pin(async move {
+            let mut watch = self.resolver.watch().await?;
+            let listed = self.resolver.list().await?;
+            for source in &listed.items {
+                Self::enqueue_checkouts(&sender, &source.object).await?;
+            }
+            while let Some(event) = watch.next().await {
+                let source = match event? {
+                    crate::ReadWatchEvent::Added(source)
+                    | crate::ReadWatchEvent::Modified(source)
+                    | crate::ReadWatchEvent::Deleted(source) => source,
+                };
+                Self::enqueue_checkouts(&sender, &source.object).await?;
+            }
+            Ok(())
+        })
+    }
+}
+
 #[derive(Clone)]
 pub struct LabelJoinWatch<W: Resource, P: Resource> {
     pub label_key: &'static str,


### PR DESCRIPTION
## Summary

- move Landing and teardown integration evaluation to fresh stored checkout evidence only
- make checkout-authority reconcilers react to local or replicated owning convoys and probe with convoy change-request context
- log named missing/stale evidence and reject stale latched landed results
- add a two-backend regression proving the checkout authority probes while the convoy authority lands from replicated evidence

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Fleet verification of the four affected production convoys is intentionally post-deploy and remains to be recorded on #1367 after this change lands.

Closes #1367