### PR TITLE
feat: spike facet-backed convoy leaf reflection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-fnv1a-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,6 +977,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet"
+version = "0.46.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df488bcda61dde160301ee6bce43d42397db599ffc689381a1873b5f035135f9"
+dependencies = [
+ "autocfg",
+ "facet-core",
+ "facet-macros",
+ "facet-reflect",
+]
+
+[[package]]
+name = "facet-core"
+version = "0.46.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33cf9d80307e9a29f93e5a65ddb65b227b5fa082d649c65d4083345f5d398d0"
+dependencies = [
+ "autocfg",
+ "chrono",
+ "const-fnv1a-hash",
+ "iddqd",
+ "impls",
+]
+
+[[package]]
+name = "facet-macro-parse"
+version = "0.46.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ab349bd1823fbfa129e595a826ef7fb4d1b9c7215428b28de18044d009dbc1"
+dependencies = [
+ "facet-macro-types",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "facet-macro-types"
+version = "0.46.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79622a74665b47d1744998dd0d15b73eb0eecdfeb16630b436c5f03365b02e55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unsynn",
+]
+
+[[package]]
+name = "facet-macros"
+version = "0.46.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6656fc7457975f5e1c86791b7a810c40ba53993823ae655f7c331e808c4b5ff"
+dependencies = [
+ "facet-macros-impl",
+]
+
+[[package]]
+name = "facet-macros-impl"
+version = "0.46.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f462bad2b5a574b2c94e9ad54162704ceacf3200741b4f0fb88020936b9003ec"
+dependencies = [
+ "facet-macro-parse",
+ "facet-macro-types",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "unsynn",
+]
+
+[[package]]
+name = "facet-path"
+version = "0.46.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20670a58be24eb604b76ed3a9ca719e5cc5e11b0885dc3847ebb899aa95bf1bc"
+dependencies = [
+ "facet-core",
+]
+
+[[package]]
+name = "facet-reflect"
+version = "0.46.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399876f2bded4a572385dc414336aad0002ce4b4154cd0d1cfe9d1881243c400"
+dependencies = [
+ "facet-core",
+ "facet-path",
+ "hashbrown 0.17.1",
+ "regex",
+ "smallvec 2.0.0-alpha.12",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,6 +1335,7 @@ dependencies = [
  "base64",
  "bon",
  "chrono",
+ "facet",
  "gethostname",
  "indexmap",
  "percent-encoding",
@@ -1258,6 +1357,7 @@ dependencies = [
  "bon",
  "bytes",
  "chrono",
+ "facet",
  "flotilla-controllers",
  "flotilla-core",
  "flotilla-protocol",
@@ -1587,6 +1687,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,7 +1798,7 @@ dependencies = [
  "itoa",
  "pin-project-lite",
  "pin-utils",
- "smallvec",
+ "smallvec 1.15.1",
  "tokio",
  "want",
 ]
@@ -1793,7 +1904,7 @@ dependencies = [
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
- "smallvec",
+ "smallvec 1.15.1",
  "zerovec",
 ]
 
@@ -1855,6 +1966,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "iddqd"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8450e1521a7518a32addf0b805ffcfbc8f9c558d2ad5769f068f2aeef5a81126"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1867,7 +1990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
- "smallvec",
+ "smallvec 1.15.1",
  "utf8_iter",
 ]
 
@@ -1905,6 +2028,12 @@ dependencies = [
  "byteorder-lite",
  "quick-error",
 ]
+
+[[package]]
+name = "impls"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a46645bbd70538861a90d0f26c31537cdf1e44aae99a794fb75a664b70951bc"
 
 [[package]]
 name = "indenter"
@@ -2305,6 +2434,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mutants"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2367,7 +2502,7 @@ dependencies = [
  "num-iter",
  "num-traits",
  "rand 0.8.5",
- "smallvec",
+ "smallvec 1.15.1",
  "zeroize",
 ]
 
@@ -2575,7 +2710,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec",
+ "smallvec 1.15.1",
  "windows-link",
 ]
 
@@ -3249,7 +3384,7 @@ dependencies = [
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
- "smallvec",
+ "smallvec 1.15.1",
 ]
 
 [[package]]
@@ -3257,6 +3392,12 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3643,6 +3784,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smallvec"
+version = "2.0.0-alpha.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef784004ca8777809dcdad6ac37629f0a97caee4c685fcea805278d81dd8b857"
 
 [[package]]
 name = "socket2"
@@ -4226,7 +4373,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec",
+ "smallvec 1.15.1",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -4296,6 +4443,17 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsynn"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501a7adf1a4bd9951501e5c66621e972ef8874d787628b7f90e64f936ef7ec0a"
+dependencies = [
+ "mutants",
+ "proc-macro2",
+ "rustc-hash",
+]
 
 [[package]]
 name = "untrusted"

--- a/crates/flotilla-protocol/Cargo.toml
+++ b/crates/flotilla-protocol/Cargo.toml
@@ -9,6 +9,7 @@ default = []
 test-support = []
 
 [dependencies]
+facet = "0.46.5"
 base64 = "0.22"
 bon = { workspace = true }
 chrono = { version = "0.4", default-features = false, features = ["serde"] }

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -51,8 +51,9 @@ pub use view_address::ViewAddress;
 /// This is the routing key for peer discovery, vector clocks, replay cursors,
 /// and event attribution. `HostName` remains only for display metadata and
 /// legacy execution/path contexts that are not mesh identity.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, facet::Facet)]
 #[serde(transparent)]
+#[facet(transparent)]
 pub struct NodeId(String);
 
 impl NodeId {
@@ -72,7 +73,7 @@ impl fmt::Display for NodeId {
 }
 
 /// Stable reference to the human principal whose attention Flotilla may route.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, facet::Facet)]
 pub struct PrincipalRef {
     pub namespace: String,
     pub name: String,

--- a/crates/flotilla-protocol/src/placement.rs
+++ b/crates/flotilla-protocol/src/placement.rs
@@ -1,27 +1,29 @@
+use facet::Facet;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet, bon::Builder)]
 pub struct PlacementTargetHost {
     #[serde(rename = "ref")]
+    #[facet(rename = "ref")]
     pub reference: String,
     pub display_name: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet, bon::Builder)]
 pub struct PlacementRefusal {
     pub policy_name: String,
     pub target_host: PlacementTargetHost,
     pub reason: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet, bon::Builder)]
 pub struct PlacementViableCandidate {
     pub policy_name: String,
     pub target_host: PlacementTargetHost,
     pub reason: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet, bon::Builder)]
 pub struct PlacementDecision {
     pub policy_name: String,
     pub target_host: PlacementTargetHost,

--- a/crates/flotilla-protocol/src/provider_data.rs
+++ b/crates/flotilla-protocol/src/provider_data.rs
@@ -1,6 +1,7 @@
 use std::{cmp::Ordering, path::PathBuf};
 
 use chrono::{DateTime, Utc};
+use facet::Facet;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
@@ -98,13 +99,13 @@ impl std::fmt::Display for ChangeRequestStatus {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, Facet)]
 pub struct IssueSource {
     pub service: String,
     pub scope: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, Facet)]
 pub struct IssueRef {
     pub source: IssueSource,
     pub id: String,
@@ -125,8 +126,10 @@ impl IssueRef {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Facet)]
+#[repr(u8)]
 #[serde(rename_all = "snake_case")]
+#[facet(rename_all = "snake_case")]
 pub enum IssueState {
     Open,
     Closed,

--- a/crates/flotilla-protocol/src/repository.rs
+++ b/crates/flotilla-protocol/src/repository.rs
@@ -1,5 +1,6 @@
 //! Portable repository identity types shared by resources and query scopes.
 
+use facet::Facet;
 use serde::{Deserialize, Serialize};
 
 pub const UNKNOWN_REPOSITORY_LABEL: &str = "Unknown repository";
@@ -28,8 +29,9 @@ pub struct RepositoryUpstream {
 ///
 /// The key is opaque on the wire. Its derivation and referent verification
 /// remain owned by `flotilla-resources`.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Facet)]
 #[serde(transparent)]
+#[facet(transparent)]
 pub struct RepositoryKey(pub String);
 
 impl std::fmt::Display for RepositoryKey {

--- a/crates/flotilla-resources/Cargo.toml
+++ b/crates/flotilla-resources/Cargo.toml
@@ -18,6 +18,7 @@ tokio = { workspace = true }
 async-trait = { workspace = true }
 bon = { workspace = true }
 futures = "0.3"
+facet = { version = "0.46.5", features = ["chrono", "reflect"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 reqwest = { workspace = true, features = ["json", "query", "stream"] }
 rustls = { workspace = true }

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use chrono::{DateTime, Utc};
+use facet::Facet;
 use flotilla_protocol::{IssueRef, IssueState, PlacementDecision, PrincipalRef};
 use serde::{Deserialize, Serialize};
 
@@ -10,13 +11,13 @@ mod reconcile;
 
 pub use reconcile::{reconcile, ConvoyEvent, ConvoyReconciler, ConvoyTeardownRuntime, ReconcileOutcome};
 
-define_resource!(Convoy, "convoys", ConvoySpec, ConvoyStatus, ConvoyStatusPatch, replication = ReplicationClass::HomeBoundRuntime);
+define_resource!(Convoy, "convoys", ConvoySpec, ConvoyStatus, ConvoyStatusPatch, replication = ReplicationClass::HomeBoundRuntime, facet);
 
 pub const WORKFLOW_SNAPSHOT_ANNOTATION: &str = "flotilla.work/workflow-snapshot";
 pub const PLACEMENT_SNAPSHOT_ANNOTATION: &str = "flotilla.work/placement-snapshot";
 pub const PREPARED_SNAPSHOT_PENDING_ANNOTATION: &str = "flotilla.work/prepared-snapshot-pending";
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet, bon::Builder)]
 pub struct ConvoySpec {
     pub workflow_ref: String,
     #[builder(default)]
@@ -31,6 +32,7 @@ pub struct ConvoySpec {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub repositories: Vec<ConvoyRepositorySpec>,
     #[serde(default, rename = "ref", skip_serializing_if = "Option::is_none")]
+    #[facet(rename = "ref")]
     pub r#ref: Option<String>,
     /// The [`Project`](crate::Project) whose repository set was snapshotted at admission.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -99,7 +101,7 @@ pub fn prepared_snapshot_pending(convoy: &crate::ResourceObject<Convoy>) -> bool
 /// Durable source-qualified issue context captured when a convoy is admitted.
 /// The reference remains stable if the Project later changes its Issue Source;
 /// the snapshot records exactly what the crew was asked to act on.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet)]
 pub struct ConvoyIssue {
     pub reference: IssueRef,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -107,7 +109,7 @@ pub struct ConvoyIssue {
     pub snapshot: IssueSnapshot,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet)]
 pub struct IssueSnapshot {
     pub title: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -118,14 +120,14 @@ pub struct IssueSnapshot {
     pub as_of: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet, bon::Builder)]
 pub struct BoundChangeRequest {
     pub id: String,
     pub repository_ref: RepositoryKey,
     pub title: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet, bon::Builder)]
 pub struct ConvoyRepositorySpec {
     pub url: String,
     pub repo_ref: RepositoryKey,
@@ -136,15 +138,17 @@ pub struct ConvoyRepositorySpec {
     pub subpaths: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet)]
+#[repr(C)]
 #[serde(untagged)]
+#[facet(untagged)]
 pub enum InputValue {
     // Keep inputs untagged so today's plain strings serialize naturally while leaving room
     // for future structured input sources without changing the field shape.
     String(String),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet, Default)]
 pub struct ConvoyStatus {
     pub phase: ConvoyPhase,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -177,7 +181,7 @@ pub struct ConvoyStatus {
     pub target_mismatches: Vec<TargetMismatch>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet, bon::Builder)]
 pub struct TargetMismatch {
     pub repo_ref: RepositoryKey,
     pub change_request_id: String,
@@ -185,12 +189,13 @@ pub struct TargetMismatch {
     pub observed_target_ref: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet)]
 pub struct WorkflowSnapshot {
     pub vessels: Vec<VesselRequirement>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Facet, Default)]
+#[repr(u8)]
 pub enum ConvoyPhase {
     #[default]
     Pending,
@@ -210,7 +215,7 @@ impl ConvoyPhase {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet, bon::Builder)]
 pub struct WorkState {
     pub phase: WorkPhase,
     /// A human explicitly completed this vessel's work at the roll-up level.
@@ -230,7 +235,8 @@ pub struct WorkState {
     pub placement: Option<PlacementStatus>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Facet)]
+#[repr(u8)]
 pub enum WorkPhase {
     Pending,
     Ready,
@@ -249,7 +255,8 @@ impl WorkPhase {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Facet, Default)]
+#[repr(u8)]
 pub enum WorkCompletionAuthority {
     #[default]
     CrewRollup,
@@ -262,7 +269,7 @@ impl WorkCompletionAuthority {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet, bon::Builder)]
 pub struct CrewWorkState {
     pub phase: CrewWorkPhase,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -275,7 +282,8 @@ pub struct CrewWorkState {
     pub disposition: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Facet, Default)]
+#[repr(u8)]
 pub enum CrewWorkPhase {
     #[default]
     Pending,
@@ -286,9 +294,10 @@ pub enum CrewWorkPhase {
     Failed,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet, Default)]
 pub struct PlacementStatus {
     #[serde(flatten)]
+    #[facet(flatten, opaque)]
     pub fields: BTreeMap<String, serde_json::Value>,
 }
 

--- a/crates/flotilla-resources/src/leaf.rs
+++ b/crates/flotilla-resources/src/leaf.rs
@@ -1,6 +1,9 @@
 use std::cmp::Ordering;
 
 use chrono::{DateTime, Utc};
+use facet::Peek;
+#[cfg(test)]
+use facet::{Def, Shape, Type, UserType};
 use flotilla_protocol::{Leaf, LeafKind, LeafOperator};
 
 use crate::{Convoy, CrewWorkPhase, CrewWorkState, ResourceObject, Vessel, WorkState};
@@ -136,6 +139,65 @@ impl LeafSubject for ConvoyLeafSubject<'_> {
     }
 }
 
+/// Spike-only descriptor-backed Convoy subject. The handwritten
+/// [`ConvoyLeafSubject`] remains the active implementation used by core.
+pub struct FacetConvoyLeafSubject<'a>(pub &'a ResourceObject<Convoy>);
+
+impl LeafSubject for FacetConvoyLeafSubject<'_> {
+    fn kind(&self) -> LeafKind {
+        LeafKind::Convoy
+    }
+
+    fn value(&self, field_path: &str) -> Option<LeafValue> {
+        let value = facet_value_at_path(Peek::new(self.0), field_path)?;
+        let variant = value.into_enum().ok()?.active_variant().ok()?;
+        Some(LeafValue::Text(variant.rename.unwrap_or(variant.name).to_string()))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg(test)]
+enum FacetComparableType {
+    Text,
+}
+
+fn facet_value_at_path<'mem, 'facet>(mut value: Peek<'mem, 'facet>, field_path: &str) -> Option<Peek<'mem, 'facet>> {
+    for segment in field_path.strip_prefix('.')?.split('.') {
+        if let Ok(option) = value.into_option() {
+            value = option.value()?;
+        }
+        let structure = value.into_struct().ok()?;
+        let index = structure.ty().fields.iter().position(|field| field.rename.unwrap_or(field.name) == segment)?;
+        value = structure.field(index).ok()?;
+    }
+    if let Ok(option) = value.into_option() {
+        value = option.value()?;
+    }
+    Some(value)
+}
+
+#[cfg(test)]
+fn facet_schema_at_path(mut shape: &'static Shape, field_path: &str) -> Option<FacetComparableType> {
+    for segment in field_path.strip_prefix('.')?.split('.') {
+        if let Def::Option(option) = shape.def {
+            shape = option.t();
+        }
+        let Type::User(UserType::Struct(structure)) = shape.ty else {
+            return None;
+        };
+        shape = structure.fields.iter().find(|field| field.rename.unwrap_or(field.name) == segment)?.shape();
+    }
+    if let Def::Option(option) = shape.def {
+        shape = option.t();
+    }
+    match shape.ty {
+        Type::User(UserType::Enum(enumeration)) if enumeration.variants.iter().all(|variant| variant.data.fields.is_empty()) => {
+            Some(FacetComparableType::Text)
+        }
+        _ => None,
+    }
+}
+
 pub struct VesselLeafSubject<'a>(pub &'a ResourceObject<Vessel>);
 
 impl LeafSubject for VesselLeafSubject<'_> {
@@ -187,6 +249,7 @@ impl LeafSubject for WorkLeafSubject<'_> {
 
 #[cfg(test)]
 mod tests {
+    use facet::{Facet, Type, UserType};
     use flotilla_protocol::LeafAddress;
 
     use super::*;
@@ -241,5 +304,108 @@ mod tests {
         let error = admit_leaf(&leaf).expect_err("text ordering should be rejected");
         assert!(error.contains("operator `>` is not admitted"));
         assert!(error.contains("use `==` or `!=`"));
+    }
+
+    #[test]
+    fn facet_convoy_subject_matches_the_active_handwritten_subject() {
+        let timestamp = "2026-08-03T20:00:00Z".parse().expect("timestamp");
+        let mut object = ResourceObject {
+            metadata: crate::ObjectMeta {
+                name: "demo".to_string(),
+                namespace: "flotilla".to_string(),
+                resource_version: "1".to_string(),
+                labels: Default::default(),
+                annotations: Default::default(),
+                owner_references: Vec::new(),
+                finalizers: Vec::new(),
+                deletion_timestamp: None,
+                creation_timestamp: timestamp,
+                merge: None,
+            },
+            spec: crate::ConvoySpec::builder().workflow_ref("workflow".to_string()).build(),
+            status: None,
+        };
+        object.status = Some(crate::ConvoyStatus { phase: crate::ConvoyPhase::Landing, ..Default::default() });
+
+        let handwritten = ConvoyLeafSubject(&object);
+        let descriptor_backed = FacetConvoyLeafSubject(&object);
+        assert_eq!(descriptor_backed.value(".status.phase"), handwritten.value(".status.phase"));
+        assert_eq!(descriptor_backed.value(".status.nope"), None);
+    }
+
+    #[test]
+    fn facet_shape_validates_a_comparable_path_without_a_value() {
+        let shape = <ResourceObject<Convoy> as Facet>::SHAPE;
+        assert_eq!(facet_schema_at_path(shape, ".status.phase"), Some(FacetComparableType::Text));
+        assert_eq!(facet_schema_at_path(shape, ".status.nope"), None);
+        assert_eq!(facet_schema_at_path(shape, ".spec.workflow_ref"), None);
+    }
+
+    #[test]
+    fn facet_attributes_match_serde_names_and_shapes() {
+        assert_struct_field_rename::<crate::ConvoySpec>("ref", "ref");
+        assert_struct_field_rename::<crate::ObjectMeta>("owner_references", "ownerReferences");
+        assert_struct_field_rename::<crate::OwnerReference>("api_version", "apiVersion");
+        assert_struct_field_rename::<flotilla_protocol::PlacementTargetHost>("reference", "ref");
+        assert_enum_variant_rename::<flotilla_protocol::IssueState>("Open", "open");
+        assert_enum_variant_rename::<crate::Stance>("WorkspaceWrite", "workspace-write");
+
+        let spec = crate::ConvoySpec::builder().workflow_ref("workflow".to_string()).r#ref("branch".to_string()).build();
+        let spec_json = serde_json::to_value(spec).expect("serialize ConvoySpec");
+        assert_eq!(spec_json.get("ref"), Some(&serde_json::json!("branch")));
+        let metadata = crate::ObjectMeta {
+            name: "demo".to_string(),
+            namespace: "flotilla".to_string(),
+            resource_version: "1".to_string(),
+            labels: Default::default(),
+            annotations: Default::default(),
+            owner_references: vec![crate::OwnerReference {
+                api_version: "flotilla.work/v1".to_string(),
+                kind: "Convoy".to_string(),
+                name: "parent".to_string(),
+                controller: true,
+            }],
+            finalizers: Vec::new(),
+            deletion_timestamp: None,
+            creation_timestamp: "2026-08-03T20:00:00Z".parse().expect("timestamp"),
+            merge: None,
+        };
+        let metadata_json = serde_json::to_value(metadata).expect("serialize ObjectMeta");
+        assert_eq!(metadata_json["ownerReferences"][0]["apiVersion"], serde_json::json!("flotilla.work/v1"));
+        let target =
+            flotilla_protocol::PlacementTargetHost::builder().reference("host-a".to_string()).display_name("Host A".to_string()).build();
+        let target_json = serde_json::to_value(target).expect("serialize PlacementTargetHost");
+        assert_eq!(target_json.get("ref"), Some(&serde_json::json!("host-a")));
+        assert_eq!(serde_json::to_value(flotilla_protocol::IssueState::Open).expect("serialize IssueState"), serde_json::json!("open"));
+        assert_eq!(serde_json::to_value(crate::Stance::WorkspaceWrite).expect("serialize Stance"), serde_json::json!("workspace-write"));
+
+        let Type::User(UserType::Struct(placement)) = <crate::PlacementStatus as Facet>::SHAPE.ty else {
+            panic!("PlacementStatus should have a struct shape");
+        };
+        assert!(placement.fields.iter().find(|field| field.name == "fields").expect("fields shape").is_flattened());
+        assert!(<crate::InputValue as Facet>::SHAPE.is_untagged());
+
+        let placement = crate::PlacementStatus { fields: [("host".to_string(), serde_json::json!("host-a"))].into() };
+        assert_eq!(serde_json::to_value(placement).expect("serialize PlacementStatus"), serde_json::json!({ "host": "host-a" }));
+        assert_eq!(
+            serde_json::to_value(crate::InputValue::String("value".to_string())).expect("serialize InputValue"),
+            serde_json::json!("value")
+        );
+    }
+
+    fn assert_struct_field_rename<T: for<'facet> Facet<'facet>>(rust_name: &str, serialized_name: &str) {
+        let Type::User(UserType::Struct(structure)) = T::SHAPE.ty else {
+            panic!("expected struct shape");
+        };
+        let field = structure.fields.iter().find(|field| field.name == rust_name).expect("field shape");
+        assert_eq!(field.rename.unwrap_or(field.name), serialized_name);
+    }
+
+    fn assert_enum_variant_rename<T: for<'facet> Facet<'facet>>(rust_name: &str, serialized_name: &str) {
+        let Type::User(UserType::Enum(enumeration)) = T::SHAPE.ty else {
+            panic!("expected enum shape");
+        };
+        let variant = enumeration.variants.iter().find(|variant| variant.name == rust_name).expect("variant shape");
+        assert_eq!(variant.rename.unwrap_or(variant.name), serialized_name);
     }
 }

--- a/crates/flotilla-resources/src/leaf.rs
+++ b/crates/flotilla-resources/src/leaf.rs
@@ -141,7 +141,8 @@ impl LeafSubject for ConvoyLeafSubject<'_> {
 
 /// Spike-only descriptor-backed Convoy subject. The handwritten
 /// [`ConvoyLeafSubject`] remains the active implementation used by core.
-pub struct FacetConvoyLeafSubject<'a>(pub &'a ResourceObject<Convoy>);
+#[allow(dead_code)]
+struct FacetConvoyLeafSubject<'a>(&'a ResourceObject<Convoy>);
 
 impl LeafSubject for FacetConvoyLeafSubject<'_> {
     fn kind(&self) -> LeafKind {
@@ -161,6 +162,7 @@ enum FacetComparableType {
     Text,
 }
 
+#[allow(dead_code)]
 fn facet_value_at_path<'mem, 'facet>(mut value: Peek<'mem, 'facet>, field_path: &str) -> Option<Peek<'mem, 'facet>> {
     for segment in field_path.strip_prefix('.')?.split('.') {
         if let Ok(option) = value.into_option() {
@@ -309,7 +311,7 @@ mod tests {
     #[test]
     fn facet_convoy_subject_matches_the_active_handwritten_subject() {
         let timestamp = "2026-08-03T20:00:00Z".parse().expect("timestamp");
-        let mut object = ResourceObject {
+        let object = ResourceObject {
             metadata: crate::ObjectMeta {
                 name: "demo".to_string(),
                 namespace: "flotilla".to_string(),
@@ -323,9 +325,8 @@ mod tests {
                 merge: None,
             },
             spec: crate::ConvoySpec::builder().workflow_ref("workflow".to_string()).build(),
-            status: None,
+            status: Some(crate::ConvoyStatus { phase: crate::ConvoyPhase::Landing, ..Default::default() }),
         };
-        object.status = Some(crate::ConvoyStatus { phase: crate::ConvoyPhase::Landing, ..Default::default() });
 
         let handwritten = ConvoyLeafSubject(&object);
         let descriptor_backed = FacetConvoyLeafSubject(&object);

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -77,8 +77,8 @@ pub use labels::{
     REPO_LABEL, RESERVED_PREFIX, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 pub use leaf::{
-    admit_leaf, evaluate_leaf, ConvoyLeafSubject, LeafEvaluation, LeafSubject, LeafValue, ThreeValue, VesselLeafSubject, WorkLeafSubject,
-    ADMITTED_LEAF_VOCABULARY,
+    admit_leaf, evaluate_leaf, ConvoyLeafSubject, FacetConvoyLeafSubject, LeafEvaluation, LeafSubject, LeafValue, ThreeValue,
+    VesselLeafSubject, WorkLeafSubject, ADMITTED_LEAF_VOCABULARY,
 };
 pub use material_pool::{
     MaterialPool, MaterialPoolLease, MaterialPoolSpec, MaterialPoolStatus, MaterialPoolStatusPatch, MaterialPoolUnitSpec,

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -77,8 +77,8 @@ pub use labels::{
     REPO_LABEL, RESERVED_PREFIX, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 pub use leaf::{
-    admit_leaf, evaluate_leaf, ConvoyLeafSubject, FacetConvoyLeafSubject, LeafEvaluation, LeafSubject, LeafValue, ThreeValue,
-    VesselLeafSubject, WorkLeafSubject, ADMITTED_LEAF_VOCABULARY,
+    admit_leaf, evaluate_leaf, ConvoyLeafSubject, LeafEvaluation, LeafSubject, LeafValue, ThreeValue, VesselLeafSubject, WorkLeafSubject,
+    ADMITTED_LEAF_VOCABULARY,
 };
 pub use material_pool::{
     MaterialPool, MaterialPoolLease, MaterialPoolSpec, MaterialPoolStatus, MaterialPoolStatusPatch, MaterialPoolUnitSpec,

--- a/crates/flotilla-resources/src/resource.rs
+++ b/crates/flotilla-resources/src/resource.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeMap, fmt::Debug};
 
 use chrono::{DateTime, Utc};
+use facet::Facet;
 use flotilla_protocol::NodeId;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
@@ -12,6 +13,20 @@ use crate::{
 };
 
 macro_rules! define_resource {
+    ($name:ident, $plural:literal, $spec:ty, $status:ty, $patch:ty, replication = $replication:expr, facet) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, facet::Facet)]
+        pub struct $name;
+
+        impl $crate::resource::Resource for $name {
+            type Spec = $spec;
+            type Status = $status;
+            type StatusPatch = $patch;
+
+            const API_PATHS: $crate::resource::ApiPaths =
+                $crate::resource::ApiPaths { group: "flotilla.work", version: "v1", plural: $plural, kind: stringify!($name) };
+            const REPLICATION_CLASS: $crate::ReplicationClass = $replication;
+        }
+    };
     ($name:ident, $plural:literal, $spec:ty, $status:ty, $patch:ty, validate_spec_update = $validator:path) => {
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
         pub struct $name;
@@ -106,9 +121,10 @@ pub trait Resource: Send + Sync + 'static {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet)]
 pub struct OwnerReference {
     #[serde(rename = "apiVersion")]
+    #[facet(rename = "apiVersion")]
     pub api_version: String,
     pub kind: String,
     pub name: String,
@@ -116,7 +132,7 @@ pub struct OwnerReference {
 }
 
 /// One causally unique write in a definitions-class record.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Facet)]
 pub struct CausalDot {
     pub author_root: NodeId,
     pub author_counter: u64,
@@ -126,7 +142,7 @@ pub struct CausalDot {
 ///
 /// The field-local context keeps a later disjoint-field edit from
 /// accidentally resolving an existing conflict in this field.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet)]
 pub struct FieldMergeMetadata {
     pub dot: CausalDot,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -135,15 +151,16 @@ pub struct FieldMergeMetadata {
 }
 
 /// One causally-maximal value shown when a definitions field conflicts.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet)]
 pub struct MergeConflictSibling {
+    #[facet(opaque)]
     pub value: serde_json::Value,
     pub dot: CausalDot,
     pub written_at: DateTime<Utc>,
 }
 
 /// Store-authored causal metadata for a definitions-class object.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet)]
 pub struct MergeMetadata {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub fields: BTreeMap<String, FieldMergeMetadata>,
@@ -203,7 +220,7 @@ impl InputMeta {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet)]
 pub struct ObjectMeta {
     pub name: String,
     pub namespace: String,
@@ -211,6 +228,7 @@ pub struct ObjectMeta {
     pub labels: BTreeMap<String, String>,
     pub annotations: BTreeMap<String, String>,
     #[serde(default, rename = "ownerReferences", skip_serializing_if = "Vec::is_empty")]
+    #[facet(rename = "ownerReferences")]
     pub owner_references: Vec<OwnerReference>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub finalizers: Vec<String>,
@@ -238,7 +256,8 @@ impl ObjectMeta {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Facet)]
+#[facet(where T::Spec: Facet<'static>, T::Status: Facet<'static>)]
 #[serde(bound(
     serialize = "T::Spec: Serialize, T::Status: Serialize",
     deserialize = "T::Spec: DeserializeOwned, T::Status: DeserializeOwned"

--- a/crates/flotilla-resources/src/workflow_template.rs
+++ b/crates/flotilla-resources/src/workflow_template.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use facet::Facet;
 use serde::{Deserialize, Serialize};
 
 use crate::{resource::define_resource, status_patch::NoStatusPatch, RepositoryKey};
@@ -21,7 +22,7 @@ pub struct InputDefinition {
     pub description: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet, bon::Builder)]
 pub struct VesselRequirement {
     pub name: String,
     #[builder(default)]
@@ -67,8 +68,10 @@ impl VesselRequirement {
 }
 
 /// The minimum isolation guarantee required while a vessel runs.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Facet)]
+#[repr(u8)]
 #[serde(rename_all = "kebab-case")]
+#[facet(rename_all = "kebab-case")]
 pub enum Stance {
     #[default]
     Trusted,
@@ -86,18 +89,21 @@ impl std::fmt::Display for Stance {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet, bon::Builder)]
 pub struct CrewSpec {
     pub role: String,
     #[serde(flatten)]
+    #[facet(flatten)]
     pub source: CrewSource,
     #[builder(default)]
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub labels: BTreeMap<String, String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet)]
+#[repr(C)]
 #[serde(untagged, deny_unknown_fields)]
+#[facet(untagged, deny_unknown_fields)]
 pub enum CrewSource {
     Agent {
         selector: Selector,
@@ -111,7 +117,7 @@ pub enum CrewSource {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Facet)]
 pub struct Selector {
     pub capability: String,
 }


### PR DESCRIPTION
Closes #1371

## Outcome

This spike derives current stable `facet` over `ResourceObject<Convoy>` and its transitive local/protocol type graph, adds a dormant `FacetConvoyLeafSubject` behind the unchanged `LeafSubject` trait, and leaves the handwritten `ConvoyLeafSubject` active in `flotilla-core`.

**Recommendation: reject-with-reasons.** Keep the shared declared-table module as the designed architecture and sequence #1368 on it. None of the research note's adoption triggers has fired: operator vocabulary remains declared and small; leaving serde is not a live plan; and facet remains a fast-moving 0.x admission-control dependency. The spike confirms the unique value-free-schema capability, but today it requires a duplicated naming/schema description and adds a material incremental check cost.

## Current API checked

Checked against current docs.rs/crates.io on 2026-08-10. The latest non-prerelease is `facet 0.46.5` (published 2026-05-26); `0.50.0-rc.5` is prerelease. `0.46.5` has Rust 1.90 MSRV; this measurement host used `rustc 1.94.0 (4a4ef493e 2026-03-02)`.

Current APIs used by the spike:

- `Facet::SHAPE` / `Shape::{ty,def}` for value-free traversal
- `Type::User(UserType::Struct|Enum)` and `Def::Option`
- `Peek::{new,into_struct,into_option,into_enum}` for value traversal
- `Field::{name,rename,is_flattened}` and `Shape::is_untagged`

## OPEN 1: attribute parity

**Representable, but not automatically shared with serde.** Facet does not consume `#[serde(...)]`; each relevant site needs a mirrored facet attribute. For example:

```rust
#[serde(default, rename = "ref", skip_serializing_if = "Option::is_none")]
#[facet(rename = "ref")]
pub r#ref: Option<String>,

#[serde(rename_all = "snake_case")]
#[facet(rename_all = "snake_case")]
pub enum IssueState { Open, Closed }
```

Evidence in `facet_attributes_match_serde_names_and_shapes` compares the facet effective names and serde JSON for every rename family in the Convoy graph:

- `ConvoySpec.ref` -> `ref`
- `ObjectMeta.owner_references` -> `ownerReferences`
- `OwnerReference.api_version` -> `apiVersion`
- `PlacementTargetHost.reference` -> `ref`
- `IssueState::Open` -> `open` (`snake_case`)
- `Stance::WorkspaceWrite` -> `workspace-write` (`kebab-case`)

Standalone shape probes also pass:

```rust
#[serde(flatten)]
#[facet(flatten, opaque)]
pub fields: BTreeMap<String, serde_json::Value>,

#[serde(untagged)]
#[facet(untagged)]
pub enum InputValue { String(String) }
```

`PlacementStatus`'s facet field reports `is_flattened()`, while serde produces `{ "host": "host-a" }`; `InputValue::SHAPE.is_untagged()` is true, while serde produces the plain string `"value"`.

Constraints found:

- Facet requires explicit enum layout, so reflected enums gained `#[repr(u8)]` or `#[repr(C)]`.
- `serde_json::Value` has no usable foreign `Facet` implementation under Rust's orphan rules. Those leaves are marked field-level `#[facet(opaque)]`; facet can retain flatten metadata but cannot statically enumerate arbitrary dynamic keys.
- Serde-only controls such as `skip_serializing_if` are not needed for path identity, but a future facet serializer would require those to be duplicated too.

So serialized path names match exactly in this spike, but only because tests enforce a second, manually mirrored attribute set. That is the primary correctness/stability blocker.

## OPEN 2: derive cost

Method: one baseline clone at the PR base and this checkout were measured on the same host with separate empty target directories. Clean command:

```text
CARGO_TARGET_DIR=<empty> CARGO_INCREMENTAL=0 cargo check -p flotilla-resources --locked
```

Incremental command: touch `crates/flotilla-resources/src/convoy.rs`, then repeat the same package check against the already-populated target (without forcing `CARGO_INCREMENTAL=0`). `/usr/bin/time` wall clock is reported. This package check includes both crates gaining derives (`flotilla-protocol` and `flotilla-resources`). One paired sample:

| check | baseline | facet | delta |
|---|---:|---:|---:|
| clean | 16.44 s | 17.90 s | +1.46 s (+8.9%) |
| touched `convoy.rs` | 0.66 s | 1.08 s | +0.42 s (+63.6%) |

Peak RSS on the clean checks was 323,564 KiB baseline vs 348,428 KiB facet (+24,864 KiB, +7.7%). These are local paired measurements, not a statistically sampled benchmark; the direction and incremental magnitude are enough to reject “derive cost is negligible” for this graph.

## OPEN 3: value-free schema walk

**Yes.** `facet_schema_at_path` starts from `<ResourceObject<Convoy> as Facet>::SHAPE`, unwraps `Def::Option`, selects struct fields by `field.rename.unwrap_or(field.name)`, and classifies a unit enum leaf as comparable text without constructing a Convoy:

```rust
assert_eq!(
    facet_schema_at_path(shape, ".status.phase"),
    Some(FacetComparableType::Text),
);
assert_eq!(facet_schema_at_path(shape, ".status.nope"), None);
```

The runtime sibling uses the same serialized-name rule over `Peek`; `FacetConvoyLeafSubject` and the active handwritten subject both return `Landing` for `.status.phase`. This proves the admission-validation and declared projection capability. Extending the classifier to scalar/timestamp types is straightforward; dynamic map keys remain runtime data rather than value-free schema.

## Trigger mapping

- **Arbitrary operator-authored paths / vocabulary outgrows declared tables:** not fired; current admitted paths remain closed and small.
- **#929 makes leaving serde live:** not fired; facet would duplicate serde rather than replace it.
- **Facet reaches admission-control stability posture:** not fired; stable release remains 0.46.x while the next API line is 0.50 RC, and the derive imposed layout/attribute duplication.

The schema walk is technically clean, but it does not outweigh those blockers or the measured compile cost.

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

The full suite passed. One first-run unrelated ETXTBSY race in `zellij_pipe_sink_retries_patch_after_child_stdin_closes` passed alone and the complete suite then passed on rerun.

