### PR TITLE
fix: narrow landed evidence latch scope

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -36,10 +36,10 @@ use flotilla_protocol::{
 use flotilla_resources::{
     api_version, apply_resource_document, apply_status_patch as apply_resource_status_patch,
     apply_status_patch_checked as apply_resource_status_patch_checked, external_patches as convoy_external_patches, get_resource_kind,
-    latch_evidence_backed_integration, list_resource_kind, list_resource_kind_including_replicas, normalize_project_spec,
-    repository_display_labels, resolve_project_issue_sources, terminal_session_attach_target, watch_resource_kind,
-    watch_resource_kind_from, watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, BoundChangeRequest,
-    Checkout as ResourceCheckout, CheckoutIntegrationStatus, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
+    list_resource_kind, list_resource_kind_including_replicas, normalize_project_spec, repository_display_labels,
+    resolve_project_issue_sources, terminal_session_attach_target, watch_resource_kind, watch_resource_kind_from,
+    watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, BoundChangeRequest, Checkout as ResourceCheckout,
+    CheckoutIntegrationStatus, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
     CheckoutStatus as ResourceCheckoutStatus, Clock, ConditionValue, Convoy as ResourceConvoy, ConvoyIssue, ConvoyRepositorySpec,
     ConvoySpec, ConvoyStatusPatch, CredentialGrant, CredentialSpec, CrewCompletionPending, CrewSource, Environment as ResourceEnvironment,
     Host as ResourceHost, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus,
@@ -2401,7 +2401,7 @@ impl InProcessDaemon {
                     );
                     (origin_matches && association_matches).then_some(source.object)
                 });
-            let mut integration = if let Some(convoy) = convoy.as_ref() {
+            let integration = if let Some(convoy) = convoy.as_ref() {
                 let change_request_id = convoy_change_request_id_for_checkout(convoy, &checkout);
                 inspect_convoy_checkout_integration(&*runner, Path::new(path), &checkout.spec, change_request_id.as_deref()).await
             } else {
@@ -2413,9 +2413,6 @@ impl InProcessDaemon {
                 )
                 .await
             };
-            if let Some(existing) = checkout.status.as_ref() {
-                latch_evidence_backed_integration(&existing.integration, &mut integration);
-            }
             apply_resource_status_patch(&checkouts, &checkout.metadata.name, &flotilla_resources::CheckoutStatusPatch::UpdateIntegration {
                 integration: Box::new(integration),
             })

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1711,7 +1711,10 @@ fn checkout_integration_summary(checkout: &ResourceObject<ResourceCheckout>, int
 }
 
 fn latch_evidence_backed_integration(existing: &CheckoutIntegrationStatus, observed: &mut CheckoutIntegrationStatus) {
-    if existing.landed.value != ConditionValue::True || existing.landed_evidence.is_none() {
+    if existing.landed.value != ConditionValue::True
+        || existing.landed_evidence.is_none()
+        || observed.landed.value != ConditionValue::Unknown
+    {
         return;
     }
     observed.landed.value = ConditionValue::True;

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -36,10 +36,10 @@ use flotilla_protocol::{
 use flotilla_resources::{
     api_version, apply_resource_document, apply_status_patch as apply_resource_status_patch,
     apply_status_patch_checked as apply_resource_status_patch_checked, external_patches as convoy_external_patches, get_resource_kind,
-    list_resource_kind, list_resource_kind_including_replicas, normalize_project_spec, repository_display_labels,
-    resolve_project_issue_sources, terminal_session_attach_target, watch_resource_kind, watch_resource_kind_from,
-    watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, BoundChangeRequest, Checkout as ResourceCheckout,
-    CheckoutIntegrationStatus, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
+    latch_evidence_backed_integration, list_resource_kind, list_resource_kind_including_replicas, normalize_project_spec,
+    repository_display_labels, resolve_project_issue_sources, terminal_session_attach_target, watch_resource_kind,
+    watch_resource_kind_from, watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, BoundChangeRequest,
+    Checkout as ResourceCheckout, CheckoutIntegrationStatus, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
     CheckoutStatus as ResourceCheckoutStatus, Clock, ConditionValue, Convoy as ResourceConvoy, ConvoyIssue, ConvoyRepositorySpec,
     ConvoySpec, ConvoyStatusPatch, CredentialGrant, CredentialSpec, CrewCompletionPending, CrewSource, Environment as ResourceEnvironment,
     Host as ResourceHost, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus,
@@ -1707,23 +1707,6 @@ fn checkout_integration_summary(checkout: &ResourceObject<ResourceCheckout>, int
         None
     } else {
         Some(format!("{} [{}]: {}", checkout.metadata.name, checkout_path(checkout).unwrap_or("<unknown path>"), problems.join("; ")))
-    }
-}
-
-fn latch_evidence_backed_integration(existing: &CheckoutIntegrationStatus, observed: &mut CheckoutIntegrationStatus) {
-    if existing.landed.value != ConditionValue::True
-        || existing.landed_evidence.is_none()
-        || observed.landed.value != ConditionValue::Unknown
-    {
-        return;
-    }
-    observed.landed.value = ConditionValue::True;
-    if observed.landed_evidence.is_none() {
-        observed.landed_evidence = existing.landed_evidence.clone();
-    }
-    if observed.change_request.is_none() {
-        observed.change_request =
-            existing.change_request.clone().filter(|change_request| change_request.state != flotilla_resources::ChangeRequestState::Open);
     }
 }
 

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -58,6 +58,143 @@ use crate::{
 const TEST_LOCAL_ATTACH_HOST: &str = "local";
 
 #[test]
+fn fresh_false_replaces_premature_latched_landed_evidence() {
+    let existing = CheckoutIntegrationStatus {
+        landed: IntegrationCondition::builder().value(ConditionValue::True).build(),
+        landed_evidence: Some(flotilla_resources::LandedEvidence::builder().change_request_id("1343".to_string()).build()),
+        ..Default::default()
+    };
+    let mut observed =
+        CheckoutIntegrationStatus { landed: IntegrationCondition::builder().value(ConditionValue::False).build(), ..Default::default() };
+
+    latch_evidence_backed_integration(&existing, &mut observed);
+
+    assert_eq!(observed.landed.value, ConditionValue::False);
+    assert_eq!(observed.landed_evidence, None);
+}
+
+#[test]
+fn fresh_unknown_is_absorbed_by_latched_landed_evidence() {
+    let evidence = flotilla_resources::LandedEvidence::builder().change_request_id("1343".to_string()).build();
+    let existing = CheckoutIntegrationStatus {
+        landed: IntegrationCondition::builder().value(ConditionValue::True).build(),
+        landed_evidence: Some(evidence.clone()),
+        ..Default::default()
+    };
+    let mut observed =
+        CheckoutIntegrationStatus { landed: IntegrationCondition::builder().value(ConditionValue::Unknown).build(), ..Default::default() };
+
+    latch_evidence_backed_integration(&existing, &mut observed);
+
+    assert_eq!(observed.landed.value, ConditionValue::True);
+    assert_eq!(observed.landed_evidence, Some(evidence));
+}
+
+#[tokio::test]
+async fn reopened_change_request_replaces_authority_observation_and_holds_landing() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+    let runner = DiscoveryMockRunner::builder()
+        .on_run("git", &["--version"], Ok("git version 2.43.0".into()))
+        .on_run("git", &["status", "--porcelain"], Ok(String::new()))
+        .on_run("git", &["status", "--porcelain"], Ok(String::new()))
+        .on_run("find", &[".", "-path", "./.git", "-prune", "-o", "-mindepth", "2", "-name", ".git", "-print", "-prune"], Ok(String::new()))
+        .on_run("find", &[".", "-path", "./.git", "-prune", "-o", "-mindepth", "2", "-name", ".git", "-print", "-prune"], Ok(String::new()))
+        .on_run("git", &["rev-parse", "--abbrev-ref", "@{upstream}"], Ok("origin/feature/reopened\n".into()))
+        .on_run("git", &["rev-parse", "--abbrev-ref", "@{upstream}"], Ok("origin/feature/reopened\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/feature/reopened..HEAD"], Ok("0\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/feature/reopened..HEAD"], Ok("0\n".into()))
+        .on_run("git", &["rev-parse", "--abbrev-ref", "origin/HEAD"], Ok("origin/main\n".into()))
+        .on_run("git", &["rev-parse", "--abbrev-ref", "origin/HEAD"], Ok("origin/main\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/main..HEAD"], Ok("1\n".into()))
+        .on_run("git", &["rev-list", "--count", "origin/main..HEAD"], Ok("1\n".into()))
+        .on_run(
+            "gh",
+            &["pr", "view", "1343", "--json", "number,state,mergedAt,baseRefName,mergeable"],
+            Ok(r#"{"number":1343,"state":"MERGED","mergedAt":"2026-08-03T12:00:00Z","baseRefName":"main"}"#.into()),
+        )
+        .on_run(
+            "gh",
+            &["pr", "view", "1343", "--json", "number,state,mergedAt,baseRefName,mergeable"],
+            Ok(r#"{"number":1343,"state":"OPEN","mergedAt":null,"baseRefName":"main"}"#.into()),
+        )
+        .build();
+    let daemon = InProcessDaemon::new(
+        vec![],
+        Arc::new(ConfigStore::with_base(&config_base)),
+        fake_discovery_with_runner(false, Arc::new(runner)),
+        HostName::local(),
+    )
+    .await;
+    let repo_ref = flotilla_resources::RepositoryKey("repo".to_string());
+    let convoys = daemon.resource_backend().using::<Convoy>("flotilla");
+    let convoy = convoys
+        .create(
+            &empty_input_meta("reopened-convoy"),
+            &ConvoySpec::builder()
+                .workflow_ref("review-and-fix".to_string())
+                .adopted_checkout_refs(BTreeMap::from([(repo_ref.clone(), "checkout-reopened".to_string())]))
+                .change_request(
+                    BoundChangeRequest::builder()
+                        .id("1343".to_string())
+                        .repository_ref(repo_ref.clone())
+                        .title("landed evidence latch".to_string())
+                        .build(),
+                )
+                .build(),
+        )
+        .await
+        .expect("create Landing convoy");
+    convoys
+        .update_status(&convoy.metadata.name, &convoy.metadata.resource_version, &ConvoyStatus {
+            phase: ConvoyPhase::Landing,
+            ..Default::default()
+        })
+        .await
+        .expect("set Landing phase");
+    let checkouts = daemon.resource_backend().using::<ResourceCheckout>("flotilla");
+    let checkout = checkouts
+        .create(
+            &InputMeta::builder()
+                .name("checkout-reopened".to_string())
+                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "reopened-convoy".to_string())]))
+                .build()
+                .with_lifecycle_authority(LifecycleAuthority::Adopted),
+            &ResourceCheckoutSpec::Observed(ResourceObservedCheckoutSpec {
+                r#ref: "feature/reopened".to_string(),
+                path: "/repo".to_string(),
+                repo_ref,
+                host_ref: "host-01".to_string(),
+                is_main: false,
+            }),
+        )
+        .await
+        .expect("create authority checkout");
+    checkouts
+        .update_status(&checkout.metadata.name, &checkout.metadata.resource_version, &ResourceCheckoutStatus {
+            phase: ResourceCheckoutPhase::Ready,
+            path: Some("/repo".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("ready authority checkout");
+
+    daemon.reconcile_adopted_checkouts("flotilla").await.expect("observe merged change request");
+    let merged = checkouts.get("checkout-reopened").await.expect("merged observation");
+    assert_eq!(merged.status.expect("checkout status").integration.landed.value, ConditionValue::True);
+
+    daemon.reconcile_adopted_checkouts("flotilla").await.expect("observe reopened change request");
+    let reopened = checkouts.get("checkout-reopened").await.expect("reopened observation");
+    let integration = reopened.status.expect("checkout status").integration;
+    assert_eq!(integration.landed.value, ConditionValue::False, "reopened observation: {integration:?}");
+    assert_eq!(integration.landed_evidence, None);
+    assert!(!daemon.convoy_change_requests_settled("flotilla", "reopened-convoy").await.expect("evaluate settlement"));
+    assert_eq!(convoys.get("reopened-convoy").await.expect("Landing convoy").status.expect("convoy status").phase, ConvoyPhase::Landing);
+}
+
+#[test]
 fn completion_message_extracts_github_and_forgejo_change_request_urls_from_prose() {
     assert_eq!(
         crate::checkout_integration::change_request_id_from_completion_message(

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -20,19 +20,19 @@ use flotilla_protocol::{
     TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
-    Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
-    CheckoutStatus as ResourceCheckoutStatus, ConditionValue, Convoy, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus,
-    CredentialConsumer, CredentialGrant, CredentialGrantSelector, CredentialGrantSpec, CredentialLifecycle,
-    CredentialPlacementRequirements, CredentialSource, CredentialSpec, CredentialSpecSpec, CrewSource, CrewSpec, CrewWorkPhase,
-    CrewWorkState, Environment as ResourceEnvironment, EnvironmentSpec as ResourceEnvironmentSpec, Host as ResourceHost, HostCondition,
-    HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputMeta,
-    LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, PlacementStatus,
-    Project, ProjectRepositorySpec, ProjectSpec, Regard, RegardSource, Repository, RepositorySpec, RepositoryStatus, Selector, Stance,
-    TerminalBrief, TerminalCrewContext, TerminalSession as ResourceTerminalSession, TerminalSessionPhase as ResourceTerminalSessionPhase,
-    TerminalSessionSource, TerminalSessionSpec as ResourceTerminalSessionSpec, TerminalSessionStatus as ResourceTerminalSessionStatus,
-    Vessel, VesselPhase, VesselRequirement, VesselSpec, VesselStatus, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot,
-    WorkflowTemplate, WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY, CONVOY_LABEL, CREW_ORDINAL_LABEL, MANAGED_BY_LABEL, ROLE_LABEL,
-    VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
+    latch_evidence_backed_integration, Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase,
+    CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus, ConditionValue, Convoy, ConvoyPhase,
+    ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CredentialConsumer, CredentialGrant, CredentialGrantSelector, CredentialGrantSpec,
+    CredentialLifecycle, CredentialPlacementRequirements, CredentialSource, CredentialSpec, CredentialSpecSpec, CrewSource, CrewSpec,
+    CrewWorkPhase, CrewWorkState, Environment as ResourceEnvironment, EnvironmentSpec as ResourceEnvironmentSpec, Host as ResourceHost,
+    HostCondition, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus,
+    InputMeta, LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec,
+    PlacementStatus, Project, ProjectRepositorySpec, ProjectSpec, Regard, RegardSource, Repository, RepositorySpec, RepositoryStatus,
+    Selector, Stance, TerminalBrief, TerminalCrewContext, TerminalSession as ResourceTerminalSession,
+    TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec as ResourceTerminalSessionSpec,
+    TerminalSessionStatus as ResourceTerminalSessionStatus, Vessel, VesselPhase, VesselRequirement, VesselSpec, VesselStatus,
+    WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate, WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY,
+    CONVOY_LABEL, CREW_ORDINAL_LABEL, MANAGED_BY_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 
 use super::*;

--- a/crates/flotilla-resources/src/checkout.rs
+++ b/crates/flotilla-resources/src/checkout.rs
@@ -213,6 +213,22 @@ pub enum CheckoutStatusPatch {
     UpdateIntegration { integration: Box<CheckoutIntegrationStatus> },
 }
 
+pub fn latch_evidence_backed_integration(existing: &CheckoutIntegrationStatus, observed: &mut CheckoutIntegrationStatus) {
+    if existing.landed.value != ConditionValue::True
+        || existing.landed_evidence.is_none()
+        || observed.landed.value != ConditionValue::Unknown
+    {
+        return;
+    }
+    observed.landed.value = ConditionValue::True;
+    if observed.landed_evidence.is_none() {
+        observed.landed_evidence = existing.landed_evidence.clone();
+    }
+    if observed.change_request.is_none() {
+        observed.change_request = existing.change_request.clone().filter(|change_request| change_request.state != ChangeRequestState::Open);
+    }
+}
+
 impl StatusPatch<CheckoutStatus> for CheckoutStatusPatch {
     fn apply(&self, status: &mut CheckoutStatus) {
         match self {
@@ -235,7 +251,9 @@ impl StatusPatch<CheckoutStatus> for CheckoutStatusPatch {
                 status.message = Some(message.clone());
             }
             Self::UpdateIntegration { integration } => {
-                status.integration = integration.as_ref().clone();
+                let mut observed = integration.as_ref().clone();
+                latch_evidence_backed_integration(&status.integration, &mut observed);
+                status.integration = observed;
             }
         }
     }

--- a/crates/flotilla-resources/src/checkout.rs
+++ b/crates/flotilla-resources/src/checkout.rs
@@ -251,6 +251,8 @@ impl StatusPatch<CheckoutStatus> for CheckoutStatusPatch {
                 status.message = Some(message.clone());
             }
             Self::UpdateIntegration { integration } => {
+                // The shared patch is the authority-side latch point for every
+                // integration writer: only Unknown yields to prior evidence.
                 let mut observed = integration.as_ref().clone();
                 latch_evidence_backed_integration(&status.integration, &mut observed);
                 status.integration = observed;

--- a/crates/flotilla-resources/src/checkout.rs
+++ b/crates/flotilla-resources/src/checkout.rs
@@ -235,27 +235,7 @@ impl StatusPatch<CheckoutStatus> for CheckoutStatusPatch {
                 status.message = Some(message.clone());
             }
             Self::UpdateIntegration { integration } => {
-                // Only evidence-backed landings latch: a merged change request
-                // does not unmerge, so a later observation may not lower it.
-                // A vacuous True ("nothing to land yet" on an untouched
-                // branch) is not a landing fact and must yield to fresh
-                // evidence — latching it would let a convoy land against an
-                // observation that predates its change request (#1163).
-                let landed_was_latched =
-                    status.integration.landed.value == ConditionValue::True && status.integration.landed_evidence.is_some();
-                let landed_evidence = status.integration.landed_evidence.clone();
-                let terminal_change_request =
-                    status.integration.change_request.clone().filter(|change_request| change_request.state != ChangeRequestState::Open);
                 status.integration = integration.as_ref().clone();
-                if landed_was_latched {
-                    status.integration.landed.value = ConditionValue::True;
-                    if status.integration.landed_evidence.is_none() {
-                        status.integration.landed_evidence = landed_evidence;
-                    }
-                    if status.integration.change_request.is_none() {
-                        status.integration.change_request = terminal_change_request;
-                    }
-                }
             }
         }
     }
@@ -290,22 +270,11 @@ mod tests {
     }
 
     #[test]
-    fn evidence_backed_landed_true_latches_over_later_observations() {
-        // A merged change request does not unmerge: evidence-backed landings
-        // stay landed even if a later probe cannot see the change request.
+    fn evidence_backed_landed_true_yields_to_fresh_false_observation() {
         let evidence = LandedEvidence::builder().change_request_id("1162".to_string()).build();
-        let observation = ChangeRequestObservation::builder()
-            .id("1162".to_string())
-            .state(ChangeRequestState::Merged)
-            .mergeability(ChangeRequestMergeability::Unknown)
-            .observed_at("2026-07-27T00:00:00Z".to_string())
-            .build();
-        let mut initial = integration(ConditionValue::True, Some(evidence.clone()));
-        initial.change_request = Some(observation.clone());
-        let mut status = CheckoutStatus { integration: initial, ..Default::default() };
+        let mut status = CheckoutStatus { integration: integration(ConditionValue::True, Some(evidence)), ..Default::default() };
         CheckoutStatusPatch::UpdateIntegration { integration: Box::new(integration(ConditionValue::False, None)) }.apply(&mut status);
-        assert_eq!(status.integration.landed.value, ConditionValue::True);
-        assert_eq!(status.integration.landed_evidence, Some(evidence));
-        assert_eq!(status.integration.change_request, Some(observation));
+        assert_eq!(status.integration.landed.value, ConditionValue::False);
+        assert_eq!(status.integration.landed_evidence, None);
     }
 }

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -43,9 +43,9 @@ pub use change_request::{
     ChangeRequestStatusPatch, Observation, ObservedChangeRequestState, ObservedChecks, ObservedMergeability,
 };
 pub use checkout::{
-    ChangeRequestMergeability, ChangeRequestObservation, ChangeRequestState, Checkout, CheckoutBranchProvenance, CheckoutIntegrationStatus,
-    CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutStatusPatch, CheckoutWorktreeSpec, ConditionValue, FreshCloneCheckoutSpec,
-    IntegrationCondition, LandedEvidence, ObservedCheckoutSpec,
+    latch_evidence_backed_integration, ChangeRequestMergeability, ChangeRequestObservation, ChangeRequestState, Checkout,
+    CheckoutBranchProvenance, CheckoutIntegrationStatus, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutStatusPatch,
+    CheckoutWorktreeSpec, ConditionValue, FreshCloneCheckoutSpec, IntegrationCondition, LandedEvidence, ObservedCheckoutSpec,
 };
 #[cfg(any(test, feature = "test-support"))]
 pub use clock::VirtualClock;

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -125,7 +125,8 @@ async fn reconcile_once_with_resources(
     reconciler.reconcile(&current, &deps, now)
 }
 
-async fn reconcile_landing_with_observed_change_request(
+async fn reconcile_with_observed_change_request(
+    phase: ConvoyPhase,
     condition: Option<ConditionValue>,
     observed_target_ref: Option<&str>,
 ) -> flotilla_resources::controller::ReconcileOutcome<Convoy> {
@@ -134,7 +135,7 @@ async fn reconcile_landing_with_observed_change_request(
     let convoys = backend.clone().using::<Convoy>("flotilla");
     let checkouts = backend.clone().using::<Checkout>("flotilla");
     let mut status = bootstrapped_convoy_status();
-    status.phase = ConvoyPhase::Landing;
+    status.phase = phase;
     for work in status.work.values_mut() {
         work.phase = WorkPhase::Complete;
     }
@@ -659,7 +660,7 @@ fn reconciler_does_not_write_the_completion_claim_edge() {
 
 #[tokio::test]
 async fn landing_with_open_change_request_stays_warm() {
-    let outcome = reconcile_landing_with_observed_change_request(Some(ConditionValue::False), None).await;
+    let outcome = reconcile_with_observed_change_request(ConvoyPhase::Landing, Some(ConditionValue::False), None).await;
 
     assert_eq!(outcome.patch, None);
     assert!(!outcome.actuations.iter().any(|actuation| matches!(
@@ -670,14 +671,14 @@ async fn landing_with_open_change_request_stays_warm() {
 
 #[tokio::test]
 async fn landing_with_settled_change_request_becomes_landed() {
-    let outcome = reconcile_landing_with_observed_change_request(Some(ConditionValue::True), Some("main")).await;
+    let outcome = reconcile_with_observed_change_request(ConvoyPhase::Landing, Some(ConditionValue::True), Some("main")).await;
 
     assert_eq!(outcome.patch, Some(controller_patches::settle(Vec::new(), timestamp(40))));
 }
 
 #[tokio::test]
 async fn landing_on_a_different_target_records_a_fact_and_still_becomes_landed() {
-    let outcome = reconcile_landing_with_observed_change_request(Some(ConditionValue::True), Some("release")).await;
+    let outcome = reconcile_with_observed_change_request(ConvoyPhase::Landing, Some(ConditionValue::True), Some("release")).await;
 
     let expected_mismatch = TargetMismatch::builder()
         .repo_ref(RepositoryKey("repo-a".to_string()))
@@ -694,9 +695,17 @@ async fn landing_on_a_different_target_records_a_fact_and_still_becomes_landed()
 
 #[tokio::test]
 async fn landing_without_checkout_evidence_stays_landing() {
-    let outcome = reconcile_landing_with_observed_change_request(None, None).await;
+    let outcome = reconcile_with_observed_change_request(ConvoyPhase::Landing, None, None).await;
 
     assert_eq!(outcome.patch, None);
+}
+
+#[tokio::test]
+async fn landed_with_reopened_change_request_does_not_write_phase() {
+    let outcome = reconcile_with_observed_change_request(ConvoyPhase::Landed, Some(ConditionValue::False), None).await;
+
+    assert_eq!(outcome.patch, None);
+    assert!(outcome.events.is_empty());
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/tests/provisioning_status_patch.rs
+++ b/crates/flotilla-resources/tests/provisioning_status_patch.rs
@@ -108,7 +108,7 @@ fn checkout_status_patch_marks_ready_and_failed() {
 }
 
 #[test]
-fn checkout_integration_patch_updates_conditions_and_latches_landed() {
+fn checkout_integration_patch_replaces_conditions_without_latching() {
     let mut status = CheckoutStatus::default();
 
     CheckoutStatusPatch::UpdateIntegration {
@@ -140,8 +140,8 @@ fn checkout_integration_patch_updates_conditions_and_latches_landed() {
     }
     .apply(&mut status);
 
-    assert_eq!(status.integration.landed.value, ConditionValue::True);
-    assert_eq!(status.integration.landed_evidence.as_ref().map(|evidence| evidence.change_request_id.as_str()), Some("815"));
+    assert_eq!(status.integration.landed.value, ConditionValue::False);
+    assert_eq!(status.integration.landed_evidence, None);
 }
 
 #[test]

--- a/crates/flotilla-resources/tests/provisioning_status_patch.rs
+++ b/crates/flotilla-resources/tests/provisioning_status_patch.rs
@@ -145,6 +145,30 @@ fn checkout_integration_patch_replaces_conditions_without_latching() {
 }
 
 #[test]
+fn checkout_integration_patch_absorbs_unknown_with_landed_evidence() {
+    let evidence = LandedEvidence::builder().change_request_id("815".to_string()).build();
+    let mut status = CheckoutStatus {
+        integration: CheckoutIntegrationStatus {
+            landed: IntegrationCondition::builder().value(ConditionValue::True).build(),
+            landed_evidence: Some(evidence.clone()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    CheckoutStatusPatch::UpdateIntegration {
+        integration: Box::new(CheckoutIntegrationStatus {
+            landed: IntegrationCondition::builder().value(ConditionValue::Unknown).build(),
+            ..Default::default()
+        }),
+    }
+    .apply(&mut status);
+
+    assert_eq!(status.integration.landed.value, ConditionValue::True);
+    assert_eq!(status.integration.landed_evidence, Some(evidence));
+}
+
+#[test]
 fn terminal_session_status_patch_marks_running_and_stopped() {
     let mut status = TerminalSessionStatus::default();
     let started_at = Utc.timestamp_opt(10, 0).single().expect("timestamp");


### PR DESCRIPTION
Closes #1343

## Summary

- allow fresh evidence-backed `False` observations to replace a latched `True`
- keep the evidence latch only for `Unknown` observations at the authority observer
- preserve terminal `Landed` convoys under later contrary observations

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`