### PR TITLE
feat: compose vessel gitconfig fragments

### DIFF
--- a/crates/flotilla-daemon/src/credential.rs
+++ b/crates/flotilla-daemon/src/credential.rs
@@ -281,11 +281,7 @@ impl CredentialStore {
             composed_fragments.extend(new_git_config_fragments);
             let gitconfig = match compose(TargetId::GitConfig, composed_fragments.values().cloned()) {
                 Ok(gitconfig) => gitconfig,
-                Err(error) => {
-                    let (name, adapter, cache_key) = git_config_owner.expect("Git config fragments have an owner");
-                    self.materials.lock().await.remove(&cache_key);
-                    return Err(bounded_adapter_error(&name, &adapter, &format!("compose shared Git config: {error}")));
-                }
+                Err(error) => return Err(format!("compose shared Git config: {error}")),
             };
             if let Err(error) = runner.write_file(Path::new(GIT_CONFIG_PATH), &gitconfig.contents).await {
                 let (name, adapter, cache_key) = git_config_owner.expect("Git config fragments have an owner");
@@ -710,13 +706,13 @@ impl CredentialStore {
 }
 
 fn git_credential_fragment(credential_name: &str, adapter: &str, credential_url: impl Into<String>, helper: impl Into<String>) -> Fragment {
-    Fragment::new(
-        TargetId::GitConfig,
-        TargetKey::GitConfig(GitConfigKey::subsection("credential", credential_url, "helper")),
-        helper,
-        Provenance::new(format!("credential/{adapter} {credential_name}")),
-    )
-    .with_merge(Merge::Append)
+    Fragment::builder()
+        .target(TargetId::GitConfig)
+        .key(TargetKey::GitConfig(GitConfigKey::subsection("credential", credential_url, "helper")))
+        .value(helper)
+        .merge(Merge::Append)
+        .provenance(Provenance::new(format!("credential/{adapter} {credential_name}")))
+        .build()
 }
 
 async fn api_key_preflight(runner: &dyn CommandRunner, url: &str, headers: &[(&str, &str)]) -> Result<(), String> {

--- a/crates/flotilla-daemon/src/credential.rs
+++ b/crates/flotilla-daemon/src/credential.rs
@@ -18,6 +18,8 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use url::Url;
 
+use crate::vessel_config::{compose, Fragment, GitConfigKey, Merge, Provenance, TargetId, TargetKey};
+
 const GIT_CONFIG_PATH: &str = "/run/flotilla/credentials/gitconfig";
 
 #[derive(Serialize)]
@@ -47,7 +49,7 @@ pub(crate) struct CredentialStore {
     state_dir: PathBuf,
     prepared: Mutex<BTreeSet<(String, String)>>,
     materials: Mutex<BTreeMap<(String, String), String>>,
-    git_config_fragments: Mutex<BTreeMap<String, BTreeMap<String, GitConfigFragment>>>,
+    git_config_fragments: Mutex<BTreeMap<String, BTreeMap<String, Fragment>>>,
     registry_configs: Mutex<BTreeMap<String, PathBuf>>,
 }
 
@@ -58,14 +60,8 @@ struct AdapterDelivery {
 }
 
 struct GitCredentialContribution {
-    fragment: GitConfigFragment,
+    fragment: Fragment,
     preflight: Option<GitCredentialPreflight>,
-}
-
-#[derive(Clone)]
-struct GitConfigFragment {
-    target: String,
-    content: String,
 }
 
 #[derive(bon::Builder)]
@@ -75,14 +71,6 @@ struct PendingGitPreflight {
     material: String,
     cache_key: (String, String),
     preflight: GitCredentialPreflight,
-}
-
-fn render_gitconfig<'a>(fragments: impl IntoIterator<Item = &'a GitConfigFragment>) -> String {
-    fragments
-        .into_iter()
-        .map(|fragment| format!("[credential \"{}\"]\n\thelper = {}\n", fragment.target, fragment.content))
-        .collect::<Vec<_>>()
-        .join("\n")
 }
 
 enum GitCredentialPreflight {
@@ -291,8 +279,15 @@ impl CredentialStore {
             let mut fragments_by_environment = self.git_config_fragments.lock().await;
             let mut composed_fragments = fragments_by_environment.get(environment_ref).cloned().unwrap_or_default();
             composed_fragments.extend(new_git_config_fragments);
-            let gitconfig = render_gitconfig(composed_fragments.values());
-            if let Err(error) = runner.write_file(Path::new(GIT_CONFIG_PATH), &gitconfig).await {
+            let gitconfig = match compose(TargetId::GitConfig, composed_fragments.values().cloned()) {
+                Ok(gitconfig) => gitconfig,
+                Err(error) => {
+                    let (name, adapter, cache_key) = git_config_owner.expect("Git config fragments have an owner");
+                    self.materials.lock().await.remove(&cache_key);
+                    return Err(bounded_adapter_error(&name, &adapter, &format!("compose shared Git config: {error}")));
+                }
+            };
+            if let Err(error) = runner.write_file(Path::new(GIT_CONFIG_PATH), &gitconfig.contents).await {
                 let (name, adapter, cache_key) = git_config_owner.expect("Git config fragments have an owner");
                 self.materials.lock().await.remove(&cache_key);
                 return Err(bounded_adapter_error(&name, &adapter, &format!("write shared Git config: {error}")));
@@ -582,10 +577,7 @@ impl CredentialStore {
                 }
                 env.insert("GH_TOKEN".to_string(), material.to_string());
                 git_credential = Some(GitCredentialContribution {
-                    fragment: GitConfigFragment {
-                        target: "https://github.com".to_string(),
-                        content: "!gh auth git-credential".to_string(),
-                    },
+                    fragment: git_credential_fragment(name, "gh", "https://github.com", "!gh auth git-credential"),
                     preflight: (!already_prepared).then_some(GitCredentialPreflight::Gh),
                 });
             }
@@ -602,10 +594,7 @@ impl CredentialStore {
                     .map_err(|error| format!("installation authentication preflight failed: {error}"))?;
                 env.insert("GH_TOKEN".to_string(), material.to_string());
                 git_credential = Some(GitCredentialContribution {
-                    fragment: GitConfigFragment {
-                        target: "https://github.com".to_string(),
-                        content: "!gh auth git-credential".to_string(),
-                    },
+                    fragment: git_credential_fragment(name, "github-app", "https://github.com", "!gh auth git-credential"),
                     preflight: Some(GitCredentialPreflight::Gh),
                 });
             }
@@ -656,7 +645,7 @@ impl CredentialStore {
                 env.insert("FORGEJO_API_URL".to_string(), format!("{server_url}/api/v1"));
                 env.insert("FORGEJO_USERNAME".to_string(), username.to_string());
                 git_credential = Some(GitCredentialContribution {
-                    fragment: GitConfigFragment { target: credential_url, content: format!("!{helper_path}") },
+                    fragment: git_credential_fragment(name, "forgejo", credential_url, format!("!{helper_path}")),
                     preflight: (!already_prepared).then(|| GitCredentialPreflight::Forgejo {
                         host: match parsed_url.port() {
                             Some(port) => format!("{host}:{port}"),
@@ -718,6 +707,16 @@ impl CredentialStore {
         }
         Ok(AdapterDelivery { env, git_credential })
     }
+}
+
+fn git_credential_fragment(credential_name: &str, adapter: &str, credential_url: impl Into<String>, helper: impl Into<String>) -> Fragment {
+    Fragment::new(
+        TargetId::GitConfig,
+        TargetKey::GitConfig(GitConfigKey::subsection("credential", credential_url, "helper")),
+        helper,
+        Provenance::new(format!("credential/{adapter} {credential_name}")),
+    )
+    .with_merge(Merge::Append)
 }
 
 async fn api_key_preflight(runner: &dyn CommandRunner, url: &str, headers: &[(&str, &str)]) -> Result<(), String> {
@@ -1074,10 +1073,10 @@ interactions:
         for environment_ref in ["env-a", "env-b"] {
             store.git_config_fragments.lock().await.insert(
                 environment_ref.to_string(),
-                BTreeMap::from([("github".to_string(), GitConfigFragment {
-                    target: "https://github.com".to_string(),
-                    content: "!gh auth git-credential".to_string(),
-                })]),
+                BTreeMap::from([(
+                    "github".to_string(),
+                    git_credential_fragment("github", "gh", "https://github.com", "!gh auth git-credential"),
+                )]),
             );
         }
 
@@ -1122,7 +1121,7 @@ interactions:
         let writes = runner.writes.lock().expect("writes lock");
         assert_eq!(writes.as_slice(), &[(
             PathBuf::from("/run/flotilla/credentials/gitconfig"),
-            "[credential \"https://github.com\"]\n\thelper = !gh auth git-credential\n".to_string()
+            "# fragment: credential/gh github\n[credential \"https://github.com\"]\n\thelper = !gh auth git-credential\n".to_string()
         )]);
         let calls = runner.calls.lock().expect("calls lock");
         assert!(calls.iter().any(|(cmd, args, input)| {
@@ -1168,7 +1167,9 @@ interactions:
 
         assert_eq!(delivered.get("GIT_CONFIG_GLOBAL"), Some(&"/run/flotilla/credentials/gitconfig".to_string()));
         assert_eq!(delivered.get("GIT_TERMINAL_PROMPT"), Some(&"0".to_string()));
-        assert!(!delivered.keys().any(|key| key.starts_with("GIT_CONFIG_KEY_") || key.starts_with("GIT_CONFIG_VALUE_")));
+        assert!(!delivered
+            .keys()
+            .any(|key| key == "GIT_CONFIG_COUNT" || key.starts_with("GIT_CONFIG_KEY_") || key.starts_with("GIT_CONFIG_VALUE_")));
         let writes = runner.writes.lock().expect("writes lock");
         let gitconfig = writes
             .iter()
@@ -1179,6 +1180,8 @@ interactions:
         assert!(gitconfig.contains("[credential \"https://github.com\"]\n\thelper = !gh auth git-credential"));
         assert!(gitconfig
             .contains("[credential \"https://forgejo.lab\"]\n\thelper = !/run/flotilla/credentials/lab-forgejo/git-credential-forgejo"));
+        assert!(gitconfig.contains("# fragment: credential/gh github"));
+        assert!(gitconfig.contains("# fragment: credential/forgejo lab-forgejo"));
         let calls = runner.calls.lock().expect("calls lock");
         assert!(calls.iter().any(|(cmd, args, _)| {
             cmd == "sh"
@@ -1275,8 +1278,7 @@ interactions:
             writes[2],
             (
                 PathBuf::from("/run/flotilla/credentials/gitconfig"),
-                "[credential \"https://forgejo.lab\"]\n\thelper = !/run/flotilla/credentials/lab-forgejo/git-credential-forgejo\n"
-                    .to_string()
+                "# fragment: credential/forgejo lab-forgejo\n[credential \"https://forgejo.lab\"]\n\thelper = !/run/flotilla/credentials/lab-forgejo/git-credential-forgejo\n".to_string()
             )
         );
         let calls = runner.calls.lock().expect("calls lock");

--- a/crates/flotilla-daemon/src/lib.rs
+++ b/crates/flotilla-daemon/src/lib.rs
@@ -8,6 +8,7 @@ mod resource_limits;
 pub mod resource_manifest;
 mod restart_history;
 mod sleep_inhibitor;
+pub mod vessel_config;
 pub use aggregator::{Aggregator, AggregatorResolvers};
 
 pub mod cli;

--- a/crates/flotilla-daemon/src/vessel_config.rs
+++ b/crates/flotilla-daemon/src/vessel_config.rs
@@ -54,6 +54,12 @@ impl GitConfigKey {
     pub fn subsection(section: impl Into<String>, subsection: impl Into<String>, name: impl Into<String>) -> Self {
         Self { section: section.into(), subsection: Some(subsection.into()), name: name.into() }
     }
+
+    fn contains_line_break(&self) -> bool {
+        self.section.contains(['\r', '\n'])
+            || self.subsection.as_ref().is_some_and(|subsection| subsection.contains(['\r', '\n']))
+            || self.name.contains(['\r', '\n'])
+    }
 }
 
 impl fmt::Display for GitConfigKey {
@@ -115,6 +121,8 @@ pub struct ComposedFile {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ComposeError {
     InvalidProvenance { provenance: Provenance },
+    InvalidKey { provenance: Provenance },
+    InvalidValue { key: TargetKey, provenance: Provenance },
     TargetKeyMismatch { target: TargetId, key: TargetKey, provenance: Provenance },
     SetConflict { key: TargetKey, first: Provenance, second: Provenance },
     MergePolicyConflict { key: TargetKey, first: Provenance, second: Provenance },
@@ -126,6 +134,12 @@ impl fmt::Display for ComposeError {
         match self {
             Self::InvalidProvenance { provenance } => {
                 write!(formatter, "fragment provenance `{provenance}` contains a line break")
+            }
+            Self::InvalidKey { provenance } => {
+                write!(formatter, "fragment from `{provenance}` has a key containing a line break")
+            }
+            Self::InvalidValue { key, provenance } => {
+                write!(formatter, "fragment from `{provenance}` has a value containing a line break for key `{key}`")
             }
             Self::TargetKeyMismatch { target, key, provenance } => {
                 write!(formatter, "fragment from `{provenance}` uses key `{key}` with incompatible target `{target}`")
@@ -159,12 +173,15 @@ pub fn compose(target: TargetId, fragments: impl IntoIterator<Item = Fragment>) 
 
 fn compose_gitconfig(fragments: Vec<Fragment>) -> Result<ComposedFile, ComposeError> {
     for fragment in &fragments {
-        if !matches!(fragment.key, TargetKey::GitConfig(_)) {
-            return Err(ComposeError::TargetKeyMismatch {
-                target: fragment.target,
-                key: fragment.key.clone(),
-                provenance: fragment.provenance.clone(),
-            });
+        match &fragment.key {
+            TargetKey::GitConfig(key) => {
+                if key.contains_line_break() {
+                    return Err(ComposeError::InvalidKey { provenance: fragment.provenance.clone() });
+                }
+            }
+        }
+        if fragment.value.contains(['\r', '\n']) {
+            return Err(ComposeError::InvalidValue { key: fragment.key.clone(), provenance: fragment.provenance.clone() });
         }
     }
 
@@ -362,5 +379,34 @@ mod tests {
         .to_string();
 
         assert!(error.contains("contains a line break"));
+    }
+
+    #[test]
+    fn gitconfig_key_with_a_line_break_is_rejected_before_rendering() {
+        let error = compose(TargetId::GitConfig, [git_fragment(
+            GitConfigKey::new("user\n[injected]", "email"),
+            "crew@example.com",
+            "credential/first",
+        )])
+        .expect_err("gitconfig keys must remain one line")
+        .to_string();
+
+        assert!(error.contains("key containing a line break"));
+        assert!(error.contains("credential/first"));
+    }
+
+    #[test]
+    fn gitconfig_value_with_a_line_break_is_rejected_before_rendering() {
+        let error = compose(TargetId::GitConfig, [git_fragment(
+            GitConfigKey::new("user", "email"),
+            "crew@example.com\n[injected]",
+            "credential/first",
+        )])
+        .expect_err("gitconfig values must remain one line")
+        .to_string();
+
+        assert!(error.contains("value containing a line break"));
+        assert!(error.contains("user.email"));
+        assert!(error.contains("credential/first"));
     }
 }

--- a/crates/flotilla-daemon/src/vessel_config.rs
+++ b/crates/flotilla-daemon/src/vessel_config.rs
@@ -1,0 +1,334 @@
+use std::{collections::BTreeMap, fmt};
+
+pub mod order {
+    pub const FIRST: u16 = 0;
+    pub const EARLY: u16 = 500;
+    pub const DEFAULT: u16 = 1000;
+    pub const LATE: u16 = 1500;
+}
+
+pub mod priority {
+    pub const FORCE: u16 = 50;
+    pub const NORMAL: u16 = 100;
+    pub const DEFAULT: u16 = 1000;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TargetId {
+    GitConfig,
+}
+
+impl fmt::Display for TargetId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::GitConfig => formatter.write_str("gitconfig"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TargetKey {
+    GitConfig(GitConfigKey),
+}
+
+impl fmt::Display for TargetKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::GitConfig(key) => key.fmt(formatter),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct GitConfigKey {
+    section: String,
+    subsection: Option<String>,
+    name: String,
+}
+
+impl GitConfigKey {
+    pub fn new(section: impl Into<String>, name: impl Into<String>) -> Self {
+        Self { section: section.into(), subsection: None, name: name.into() }
+    }
+
+    pub fn subsection(section: impl Into<String>, subsection: impl Into<String>, name: impl Into<String>) -> Self {
+        Self { section: section.into(), subsection: Some(subsection.into()), name: name.into() }
+    }
+}
+
+impl fmt::Display for GitConfigKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.subsection {
+            Some(subsection) => write!(formatter, "{}.\"{}\".{}", self.section, subsection, self.name),
+            None => write!(formatter, "{}.{}", self.section, self.name),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Merge {
+    Set,
+    Append,
+    ErrorOnDuplicate,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Provenance(String);
+
+impl Provenance {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+}
+
+impl fmt::Display for Provenance {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
+#[builder(on(String, into))]
+pub struct Fragment {
+    pub target: TargetId,
+    pub key: TargetKey,
+    pub value: String,
+    #[builder(default = order::DEFAULT)]
+    pub order: u16,
+    #[builder(default = priority::NORMAL)]
+    pub priority: u16,
+    #[builder(default = Merge::Set)]
+    pub merge: Merge,
+    pub provenance: Provenance,
+}
+
+impl Fragment {
+    pub fn new(target: TargetId, key: TargetKey, value: impl Into<String>, provenance: Provenance) -> Self {
+        Self { target, key, value: value.into(), order: order::DEFAULT, priority: priority::NORMAL, merge: Merge::Set, provenance }
+    }
+
+    pub fn with_order(mut self, order: u16) -> Self {
+        self.order = order;
+        self
+    }
+
+    pub fn with_priority(mut self, priority: u16) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    pub fn with_merge(mut self, merge: Merge) -> Self {
+        self.merge = merge;
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComposedFile {
+    pub target: TargetId,
+    pub contents: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ComposeError {
+    TargetKeyMismatch { target: TargetId, key: TargetKey, provenance: Provenance },
+    SetConflict { key: TargetKey, first: Provenance, second: Provenance },
+    MergePolicyConflict { key: TargetKey, first: Provenance, second: Provenance },
+    Duplicate { key: TargetKey, first: Provenance, second: Provenance },
+}
+
+impl fmt::Display for ComposeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TargetKeyMismatch { target, key, provenance } => {
+                write!(formatter, "fragment from `{provenance}` uses key `{key}` with incompatible target `{target}`")
+            }
+            Self::SetConflict { key, first, second } => {
+                write!(formatter, "equal-priority Set fragments from `{first}` and `{second}` conflict for key `{key}`")
+            }
+            Self::MergePolicyConflict { key, first, second } => {
+                write!(formatter, "fragments from `{first}` and `{second}` declare different merge policies for key `{key}`")
+            }
+            Self::Duplicate { key, first, second } => {
+                write!(formatter, "duplicate fragments from `{first}` and `{second}` are forbidden for key `{key}`")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ComposeError {}
+
+pub fn compose(target: TargetId, fragments: impl IntoIterator<Item = Fragment>) -> Result<ComposedFile, ComposeError> {
+    let mut fragments = fragments.into_iter().filter(|fragment| fragment.target == target).collect::<Vec<_>>();
+    fragments.sort_by(|left, right| (left.order, &left.provenance).cmp(&(right.order, &right.provenance)));
+
+    match target {
+        TargetId::GitConfig => compose_gitconfig(fragments),
+    }
+}
+
+fn compose_gitconfig(fragments: Vec<Fragment>) -> Result<ComposedFile, ComposeError> {
+    for fragment in &fragments {
+        if !matches!(fragment.key, TargetKey::GitConfig(_)) {
+            return Err(ComposeError::TargetKeyMismatch {
+                target: fragment.target,
+                key: fragment.key.clone(),
+                provenance: fragment.provenance.clone(),
+            });
+        }
+    }
+
+    let minimum_priorities = fragments.iter().fold(BTreeMap::<TargetKey, u16>::new(), |mut priorities, fragment| {
+        priorities
+            .entry(fragment.key.clone())
+            .and_modify(|priority| *priority = (*priority).min(fragment.priority))
+            .or_insert(fragment.priority);
+        priorities
+    });
+    let mut winners = BTreeMap::<TargetKey, Vec<&Fragment>>::new();
+    for fragment in &fragments {
+        if minimum_priorities.get(&fragment.key) == Some(&fragment.priority) {
+            winners.entry(fragment.key.clone()).or_default().push(fragment);
+        }
+    }
+
+    let mut rendered = Vec::new();
+    for fragments_for_key in winners.values() {
+        let first = fragments_for_key[0];
+        if let Some(other) = fragments_for_key.iter().skip(1).find(|fragment| fragment.merge != first.merge) {
+            return Err(ComposeError::MergePolicyConflict {
+                key: first.key.clone(),
+                first: first.provenance.clone(),
+                second: other.provenance.clone(),
+            });
+        }
+        match first.merge {
+            Merge::Set => {
+                if let Some(other) = fragments_for_key.iter().skip(1).find(|fragment| fragment.value != first.value) {
+                    return Err(ComposeError::SetConflict {
+                        key: first.key.clone(),
+                        first: first.provenance.clone(),
+                        second: other.provenance.clone(),
+                    });
+                }
+                rendered.push(RenderedGitConfigEntry {
+                    fragment: first,
+                    provenances: fragments_for_key.iter().map(|fragment| &fragment.provenance).collect(),
+                });
+            }
+            Merge::Append => rendered.extend(
+                fragments_for_key.iter().map(|fragment| RenderedGitConfigEntry { fragment, provenances: vec![&fragment.provenance] }),
+            ),
+            Merge::ErrorOnDuplicate => {
+                if let Some(other) = fragments_for_key.get(1) {
+                    return Err(ComposeError::Duplicate {
+                        key: first.key.clone(),
+                        first: first.provenance.clone(),
+                        second: other.provenance.clone(),
+                    });
+                }
+                rendered.push(RenderedGitConfigEntry { fragment: first, provenances: vec![&first.provenance] });
+            }
+        }
+    }
+    rendered
+        .sort_by(|left, right| (left.fragment.order, &left.fragment.provenance).cmp(&(right.fragment.order, &right.fragment.provenance)));
+
+    let contents = rendered.into_iter().map(render_gitconfig_entry).collect::<Vec<_>>().join("\n");
+    Ok(ComposedFile { target: TargetId::GitConfig, contents })
+}
+
+struct RenderedGitConfigEntry<'a> {
+    fragment: &'a Fragment,
+    provenances: Vec<&'a Provenance>,
+}
+
+fn render_gitconfig_entry(entry: RenderedGitConfigEntry<'_>) -> String {
+    let TargetKey::GitConfig(key) = &entry.fragment.key;
+    let comments = entry.provenances.into_iter().map(|provenance| format!("# fragment: {provenance}\n")).collect::<String>();
+    let section = match &key.subsection {
+        Some(subsection) => format!("[{} \"{}\"]", key.section, escape_gitconfig_subsection(subsection)),
+        None => format!("[{}]", key.section),
+    };
+    format!("{comments}{section}\n\t{} = {}\n", key.name, entry.fragment.value)
+}
+
+fn escape_gitconfig_subsection(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn git_fragment(key: GitConfigKey, value: &str, provenance: &str) -> Fragment {
+        Fragment::new(TargetId::GitConfig, TargetKey::GitConfig(key), value, Provenance::new(provenance))
+    }
+
+    #[test]
+    fn sugar_constants_match_the_ratified_order_and_priority_contract() {
+        assert_eq!((order::FIRST, order::EARLY, order::DEFAULT, order::LATE), (0, 500, 1000, 1500));
+        assert_eq!((priority::FORCE, priority::NORMAL, priority::DEFAULT), (50, 100, 1000));
+    }
+
+    #[test]
+    fn equal_priority_different_set_values_name_the_key_and_both_contributors() {
+        let key = GitConfigKey::new("user", "email");
+        let error = compose(TargetId::GitConfig, [
+            git_fragment(key.clone(), "first@example.com", "credential/first"),
+            git_fragment(key, "second@example.com", "credential/second"),
+        ])
+        .expect_err("equal-priority Set values must conflict")
+        .to_string();
+
+        assert!(error.contains("user.email"), "error must name the key: {error}");
+        assert!(error.contains("credential/first"), "error must name the first contributor: {error}");
+        assert!(error.contains("credential/second"), "error must name the second contributor: {error}");
+    }
+
+    #[test]
+    fn lower_priority_number_overrides_set_fragments() {
+        let key = GitConfigKey::new("user", "email");
+        let composed = compose(TargetId::GitConfig, [
+            git_fragment(key.clone(), "default@example.com", "credential/default").with_priority(priority::DEFAULT),
+            git_fragment(key, "forced@example.com", "credential/forced").with_priority(priority::FORCE),
+        ])
+        .expect("explicit override should compose");
+
+        assert!(composed.contents.contains("forced@example.com"));
+        assert!(!composed.contents.contains("default@example.com"));
+    }
+
+    #[test]
+    fn append_follows_order_then_provenance_stably() {
+        let key = GitConfigKey::subsection("credential", "https://example.com", "helper");
+        let composed = compose(TargetId::GitConfig, [
+            git_fragment(key.clone(), "late", "credential/alpha").with_order(order::LATE).with_merge(Merge::Append),
+            git_fragment(key.clone(), "same-order-z", "credential/zulu").with_order(order::EARLY).with_merge(Merge::Append),
+            git_fragment(key.clone(), "same-order-a-first", "credential/alpha").with_order(order::EARLY).with_merge(Merge::Append),
+            git_fragment(key, "same-order-a-second", "credential/alpha").with_order(order::EARLY).with_merge(Merge::Append),
+        ])
+        .expect("append fragments should compose");
+
+        let alpha_first = composed.contents.find("same-order-a-first").expect("first alpha fragment");
+        let alpha_second = composed.contents.find("same-order-a-second").expect("second alpha fragment");
+        let zulu = composed.contents.find("same-order-z").expect("zulu fragment");
+        let late = composed.contents.find("late").expect("late fragment");
+        assert!(alpha_first < alpha_second && alpha_second < zulu && zulu < late, "unexpected append order:\n{}", composed.contents);
+    }
+
+    #[test]
+    fn error_on_duplicate_rejects_a_second_winning_fragment() {
+        let key = GitConfigKey::new("core", "hooksPath");
+        let error = compose(TargetId::GitConfig, [
+            git_fragment(key.clone(), "/first", "workspace/first").with_merge(Merge::ErrorOnDuplicate),
+            git_fragment(key, "/second", "workspace/second").with_merge(Merge::ErrorOnDuplicate),
+        ])
+        .expect_err("ErrorOnDuplicate must reject a second contributor")
+        .to_string();
+
+        assert!(error.contains("core.hooksPath"));
+        assert!(error.contains("workspace/first"));
+        assert!(error.contains("workspace/second"));
+    }
+}

--- a/crates/flotilla-daemon/src/vessel_config.rs
+++ b/crates/flotilla-daemon/src/vessel_config.rs
@@ -79,6 +79,10 @@ impl Provenance {
     pub fn new(value: impl Into<String>) -> Self {
         Self(value.into())
     }
+
+    fn contains_line_break(&self) -> bool {
+        self.0.contains(['\r', '\n'])
+    }
 }
 
 impl fmt::Display for Provenance {
@@ -102,27 +106,6 @@ pub struct Fragment {
     pub provenance: Provenance,
 }
 
-impl Fragment {
-    pub fn new(target: TargetId, key: TargetKey, value: impl Into<String>, provenance: Provenance) -> Self {
-        Self { target, key, value: value.into(), order: order::DEFAULT, priority: priority::NORMAL, merge: Merge::Set, provenance }
-    }
-
-    pub fn with_order(mut self, order: u16) -> Self {
-        self.order = order;
-        self
-    }
-
-    pub fn with_priority(mut self, priority: u16) -> Self {
-        self.priority = priority;
-        self
-    }
-
-    pub fn with_merge(mut self, merge: Merge) -> Self {
-        self.merge = merge;
-        self
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ComposedFile {
     pub target: TargetId,
@@ -131,6 +114,7 @@ pub struct ComposedFile {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ComposeError {
+    InvalidProvenance { provenance: Provenance },
     TargetKeyMismatch { target: TargetId, key: TargetKey, provenance: Provenance },
     SetConflict { key: TargetKey, first: Provenance, second: Provenance },
     MergePolicyConflict { key: TargetKey, first: Provenance, second: Provenance },
@@ -140,6 +124,9 @@ pub enum ComposeError {
 impl fmt::Display for ComposeError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::InvalidProvenance { provenance } => {
+                write!(formatter, "fragment provenance `{provenance}` contains a line break")
+            }
             Self::TargetKeyMismatch { target, key, provenance } => {
                 write!(formatter, "fragment from `{provenance}` uses key `{key}` with incompatible target `{target}`")
             }
@@ -160,6 +147,9 @@ impl std::error::Error for ComposeError {}
 
 pub fn compose(target: TargetId, fragments: impl IntoIterator<Item = Fragment>) -> Result<ComposedFile, ComposeError> {
     let mut fragments = fragments.into_iter().filter(|fragment| fragment.target == target).collect::<Vec<_>>();
+    if let Some(fragment) = fragments.iter().find(|fragment| fragment.provenance.contains_line_break()) {
+        return Err(ComposeError::InvalidProvenance { provenance: fragment.provenance.clone() });
+    }
     fragments.sort_by(|left, right| (left.order, &left.provenance).cmp(&(right.order, &right.provenance)));
 
     match target {
@@ -262,7 +252,12 @@ mod tests {
     use super::*;
 
     fn git_fragment(key: GitConfigKey, value: &str, provenance: &str) -> Fragment {
-        Fragment::new(TargetId::GitConfig, TargetKey::GitConfig(key), value, Provenance::new(provenance))
+        Fragment::builder()
+            .target(TargetId::GitConfig)
+            .key(TargetKey::GitConfig(key))
+            .value(value)
+            .provenance(Provenance::new(provenance))
+            .build()
     }
 
     #[test]
@@ -289,11 +284,11 @@ mod tests {
     #[test]
     fn lower_priority_number_overrides_set_fragments() {
         let key = GitConfigKey::new("user", "email");
-        let composed = compose(TargetId::GitConfig, [
-            git_fragment(key.clone(), "default@example.com", "credential/default").with_priority(priority::DEFAULT),
-            git_fragment(key, "forced@example.com", "credential/forced").with_priority(priority::FORCE),
-        ])
-        .expect("explicit override should compose");
+        let mut default = git_fragment(key.clone(), "default@example.com", "credential/default");
+        default.priority = priority::DEFAULT;
+        let mut forced = git_fragment(key, "forced@example.com", "credential/forced");
+        forced.priority = priority::FORCE;
+        let composed = compose(TargetId::GitConfig, [default, forced]).expect("explicit override should compose");
 
         assert!(composed.contents.contains("forced@example.com"));
         assert!(!composed.contents.contains("default@example.com"));
@@ -302,11 +297,21 @@ mod tests {
     #[test]
     fn append_follows_order_then_provenance_stably() {
         let key = GitConfigKey::subsection("credential", "https://example.com", "helper");
+        let fragment = |key, value, provenance, order| {
+            Fragment::builder()
+                .target(TargetId::GitConfig)
+                .key(TargetKey::GitConfig(key))
+                .value(value)
+                .order(order)
+                .merge(Merge::Append)
+                .provenance(Provenance::new(provenance))
+                .build()
+        };
         let composed = compose(TargetId::GitConfig, [
-            git_fragment(key.clone(), "late", "credential/alpha").with_order(order::LATE).with_merge(Merge::Append),
-            git_fragment(key.clone(), "same-order-z", "credential/zulu").with_order(order::EARLY).with_merge(Merge::Append),
-            git_fragment(key.clone(), "same-order-a-first", "credential/alpha").with_order(order::EARLY).with_merge(Merge::Append),
-            git_fragment(key, "same-order-a-second", "credential/alpha").with_order(order::EARLY).with_merge(Merge::Append),
+            fragment(key.clone(), "late", "credential/alpha", order::LATE),
+            fragment(key.clone(), "same-order-z", "credential/zulu", order::EARLY),
+            fragment(key.clone(), "same-order-a-first", "credential/alpha", order::EARLY),
+            fragment(key, "same-order-a-second", "credential/alpha", order::EARLY),
         ])
         .expect("append fragments should compose");
 
@@ -320,15 +325,42 @@ mod tests {
     #[test]
     fn error_on_duplicate_rejects_a_second_winning_fragment() {
         let key = GitConfigKey::new("core", "hooksPath");
-        let error = compose(TargetId::GitConfig, [
-            git_fragment(key.clone(), "/first", "workspace/first").with_merge(Merge::ErrorOnDuplicate),
-            git_fragment(key, "/second", "workspace/second").with_merge(Merge::ErrorOnDuplicate),
-        ])
-        .expect_err("ErrorOnDuplicate must reject a second contributor")
-        .to_string();
+        let mut first = git_fragment(key.clone(), "/first", "workspace/first");
+        first.merge = Merge::ErrorOnDuplicate;
+        let mut second = git_fragment(key, "/second", "workspace/second");
+        second.merge = Merge::ErrorOnDuplicate;
+        let error =
+            compose(TargetId::GitConfig, [first, second]).expect_err("ErrorOnDuplicate must reject a second contributor").to_string();
 
         assert!(error.contains("core.hooksPath"));
         assert!(error.contains("workspace/first"));
         assert!(error.contains("workspace/second"));
+    }
+
+    #[test]
+    fn different_merge_policies_name_the_key_and_both_contributors() {
+        let key = GitConfigKey::new("user", "email");
+        let first = git_fragment(key.clone(), "first@example.com", "credential/first");
+        let mut second = git_fragment(key, "second@example.com", "credential/second");
+        second.merge = Merge::Append;
+
+        let error = compose(TargetId::GitConfig, [first, second]).expect_err("winning fragments must agree on merge policy").to_string();
+
+        assert!(error.contains("user.email"));
+        assert!(error.contains("credential/first"));
+        assert!(error.contains("credential/second"));
+    }
+
+    #[test]
+    fn provenance_with_a_line_break_is_rejected_before_rendering() {
+        let error = compose(TargetId::GitConfig, [git_fragment(
+            GitConfigKey::new("user", "email"),
+            "crew@example.com",
+            "credential/first\ninjected",
+        )])
+        .expect_err("provenance comments must remain one line")
+        .to_string();
+
+        assert!(error.contains("contains a line break"));
     }
 }


### PR DESCRIPTION
Closes #1377

## Summary

- add the pure `vessel_config` fragment/composer contract with typed gitconfig keys, ordering and priority sugar, explicit merge policies, and provenance rendering
- fail composition on equal-priority conflicting `Set` values while preserving deterministic `Append` ordering
- migrate GitHub and Forgejo credential helpers to one composed staged gitconfig behind `GIT_CONFIG_GLOBAL`, with no `GIT_CONFIG_COUNT/KEY_n/VALUE_n` delivery
- retain both adapters' existing authentication and Git credential preflights

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
