### PR TITLE
feat: add project declaration registration

### DIFF
--- a/crates/flotilla-commands/src/commands/project.rs
+++ b/crates/flotilla-commands/src/commands/project.rs
@@ -42,6 +42,16 @@ pub enum ProjectVerb {
         #[arg(long = "file", short = 'f')]
         file: PathBuf,
     },
+    /// Register a project from project.yaml in a bootstrap repository
+    Register {
+        /// Local bootstrap repository path or tracked repository catalog slug
+        target: String,
+    },
+    /// Re-read and converge a registered project's declaration
+    Refresh {
+        /// Project resource name
+        name: String,
+    },
 }
 
 impl ProjectNoun {
@@ -53,6 +63,8 @@ impl ProjectNoun {
                 let spec_yaml = std::fs::read_to_string(&file).map_err(|e| format!("read {}: {e}", file.display()))?;
                 CommandAction::ProjectApply { name, spec_yaml }
             }
+            ProjectVerb::Register { target } => CommandAction::ProjectRegister { target },
+            ProjectVerb::Refresh { name } => CommandAction::ProjectRefresh { name },
         };
         Ok(Resolved::NeedsContext {
             command: Command { node_id: None, provisioning_target: None, context_repo: None, action },
@@ -82,6 +94,8 @@ impl std::fmt::Display for ProjectNoun {
             ProjectVerb::Apply { name, file } => {
                 write!(f, " apply {} --file {}", quote_value(name), quote_value(&file.display().to_string()))?;
             }
+            ProjectVerb::Register { target } => write!(f, " register {}", quote_value(target))?,
+            ProjectVerb::Refresh { name } => write!(f, " refresh {}", quote_value(name))?,
         }
         Ok(())
     }
@@ -179,6 +193,8 @@ mod tests {
         ]);
         assert_round_trip::<ProjectNoun>(&["project", "apply", "core", "--file", "/tmp/project.yaml"]);
         assert_round_trip::<ProjectNoun>(&["project", "list"]);
+        assert_round_trip::<ProjectNoun>(&["project", "register", "/src/bootstrap"]);
+        assert_round_trip::<ProjectNoun>(&["project", "refresh", "core"]);
     }
 
     #[test]

--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -364,6 +364,8 @@ pub async fn build_plan(
         | CommandAction::WorkflowTemplateApply { .. }
         | CommandAction::ProjectAdd { .. }
         | CommandAction::ProjectApply { .. }
+        | CommandAction::ProjectRegister { .. }
+        | CommandAction::ProjectRefresh { .. }
         | CommandAction::TrackRepoPath { .. }
         | CommandAction::UntrackRepo { .. }
         | CommandAction::Refresh { .. }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -8177,15 +8177,24 @@ impl InProcessDaemon {
                 Ok(spec) => match normalize_project_spec(spec) {
                     Ok(spec) => {
                         let outcome = match projects.get(name).await {
-                            Ok(existing) => projects.apply(&InputMeta::from(&existing.metadata), &spec).await.map(|_| ()),
-                            Err(ResourceError::NotFound { .. }) => {
-                                projects.apply(&InputMeta::builder().name(name.clone()).build(), &spec).await.map(|_| ())
+                            Ok(existing) if is_declaration_backed_project(&existing) => {
+                                Err(format!("project {name} is managed by a declaration; use project refresh to update it"))
                             }
-                            Err(error) => Err(error),
+                            Ok(existing) => projects
+                                .apply(&InputMeta::from(&existing.metadata), &spec)
+                                .await
+                                .map(|_| ())
+                                .map_err(|error| error.to_string()),
+                            Err(ResourceError::NotFound { .. }) => projects
+                                .apply(&InputMeta::builder().name(name.clone()).build(), &spec)
+                                .await
+                                .map(|_| ())
+                                .map_err(|error| error.to_string()),
+                            Err(error) => Err(error.to_string()),
                         };
                         match outcome {
                             Ok(()) => flotilla_protocol::CommandValue::ProjectApplied { name: name.clone() },
-                            Err(err) => flotilla_protocol::CommandValue::Error { message: err.to_string() },
+                            Err(message) => flotilla_protocol::CommandValue::Error { message },
                         }
                     }
                     Err(message) => flotilla_protocol::CommandValue::Error { message },

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3831,6 +3831,9 @@ async fn reconcile_whole_repository_project_definition(
     existing: ResourceObject<Project>,
     generated: &ProjectSpec,
 ) -> Result<ResourceObject<Project>, String> {
+    if is_declaration_backed_project(&existing) {
+        return Ok(existing);
+    }
     let generator_fields_diverged =
         existing.spec.default_workflow_ref != generated.default_workflow_ref || existing.spec.repositories != generated.repositories;
     let managed_by_generator =
@@ -3855,6 +3858,10 @@ async fn reconcile_whole_repository_project_definition(
         );
     }
     Ok(reconciled)
+}
+
+fn is_declaration_backed_project(project: &ResourceObject<Project>) -> bool {
+    project.metadata.annotations.contains_key(BOOTSTRAP_REPOSITORY_ANNOTATION)
 }
 
 fn is_whole_repository_project(spec: &ProjectSpec, repository_key: &RepositoryKey) -> bool {
@@ -4905,12 +4912,36 @@ impl InProcessDaemon {
                 });
             };
             let key = RepositoryKey(repository.metadata.name.clone());
-            self.repository_keys_by_path
+            let mut paths = self
+                .repository_keys_by_path
                 .read()
                 .await
                 .iter()
-                .find_map(|(path, candidate)| (candidate == &key).then(|| path.clone()))
-                .ok_or_else(|| format!("bootstrap repository `{target}` has no local checkout on this host"))?
+                .filter(|(_, candidate)| *candidate == &key)
+                .map(|(path, _)| path.clone())
+                .collect::<Vec<_>>();
+            paths.sort();
+            match paths.as_slice() {
+                [] => return Err(format!("bootstrap repository `{target}` has no local checkout on this host")),
+                [path] => path.clone(),
+                _ => {
+                    let inspector = self.repository_inspector().await?;
+                    let mut main_paths = Vec::new();
+                    for path in paths {
+                        if inspector.inspect_path(&path, None).await?.checkout.is_main {
+                            main_paths.push(path);
+                        }
+                    }
+                    match main_paths.as_slice() {
+                        [path] => path.clone(),
+                        _ => {
+                            return Err(format!(
+                                "bootstrap repository `{target}` has multiple local checkouts; pass the intended checkout path explicitly"
+                            ));
+                        }
+                    }
+                }
+            }
         };
         let inspection = self.repository_inspector().await?.inspect_project_declaration(&path).await?;
         let declaration = parse_project_declaration(&inspection.yaml)?;
@@ -4979,7 +5010,6 @@ impl InProcessDaemon {
         let provenance = BTreeMap::from([
             (BOOTSTRAP_REPOSITORY_ANNOTATION.to_string(), bootstrap_key.to_string()),
             (BOOTSTRAP_COMMIT_ANNOTATION.to_string(), inspection.commit.clone()),
-            (BOOTSTRAP_PATH_ANNOTATION.to_string(), bootstrap_path),
             (DECLARATION_FILE_ANNOTATION.to_string(), DECLARATION_FILE.to_string()),
         ]);
         let mut converged = false;
@@ -5032,6 +5062,7 @@ impl InProcessDaemon {
         for (annotation, value) in provenance {
             meta.annotations.insert(annotation, value);
         }
+        meta.annotations.insert(BOOTSTRAP_PATH_ANNOTATION.to_string(), bootstrap_path);
         converged |=
             existing_project.as_ref().is_none_or(|project| project.spec != spec || project.metadata.annotations != meta.annotations);
         projects.apply(&meta, &spec).await.map_err(|error| error.to_string())?;
@@ -5111,6 +5142,9 @@ impl InProcessDaemon {
         let projects = self.resource_backend.clone().definitions::<Project>(&namespace);
         match projects.get(&project_name).await {
             Ok(existing) => {
+                if is_declaration_backed_project(&existing) {
+                    return Err(format!("project {project_name} is managed by a declaration; use project refresh to update it"));
+                }
                 if !is_whole_repository_project(&existing.spec, &key) {
                     return Err(format!("project {project_name} already exists with a different repository definition"));
                 }
@@ -5214,6 +5248,9 @@ impl InProcessDaemon {
         }
         let mut migrated_project_names = BTreeSet::new();
         for project in &mut project_objects {
+            if is_declaration_backed_project(project) {
+                continue;
+            }
             let mut updated = project.spec.clone();
             let mut changed = false;
             for entry in &mut updated.repositories {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -35,8 +35,8 @@ use flotilla_protocol::{
 };
 use flotilla_resources::{
     api_version, apply_resource_document, apply_status_patch as apply_resource_status_patch,
-    apply_status_patch_checked as apply_resource_status_patch_checked, external_patches as convoy_external_patches, get_resource_kind,
-    list_resource_kind, list_resource_kind_including_replicas, normalize_project_spec, repository_display_labels,
+    apply_status_patch_checked as apply_resource_status_patch_checked, ensure_repository, external_patches as convoy_external_patches,
+    get_resource_kind, list_resource_kind, list_resource_kind_including_replicas, normalize_project_spec, repository_display_labels,
     resolve_project_issue_sources, terminal_session_attach_target, watch_resource_kind, watch_resource_kind_from,
     watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, BoundChangeRequest, Checkout as ResourceCheckout,
     CheckoutIntegrationStatus, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
@@ -45,8 +45,8 @@ use flotilla_resources::{
     Host as ResourceHost, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus,
     InMemoryBackend, InputMeta, InputValue, IntegrationCondition, IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable,
     LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project,
-    ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError,
-    ResourceObject, ResourceProvenance, SystemClock, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
+    ProjectRepositoryRole, ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend,
+    ResourceError, ResourceObject, ResourceProvenance, SystemClock, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
     TerminalSession as ResourceTerminalSession, TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase,
     TerminalSessionSource, TerminalSessionStatusPatch, Vessel, WatchEvent, WatchStart, WorkCompletionAuthority,
     WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec, ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL,
@@ -87,6 +87,10 @@ use crate::{
     model::{provider_names_from_registry, repo_name, RepoModel},
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     placement_policy::reconcile_registered_policy,
+    project_declaration::{
+        parse_project_declaration, ProjectDeclaration, BOOTSTRAP_COMMIT_ANNOTATION, BOOTSTRAP_PATH_ANNOTATION,
+        BOOTSTRAP_REPOSITORY_ANNOTATION, DECLARATION_FILE, DECLARATION_FILE_ANNOTATION,
+    },
     providers::{
         ai_utility::{AiUtility, ConvoyNames},
         discovery::{
@@ -100,7 +104,7 @@ use crate::{
     refresh::RefreshSnapshot,
     regard_lifecycle::{RegardLifecycle, SurfaceGestureOutcome, DEFAULT_REGARD_DECAY_SECONDS, DEFAULT_REGARD_REFRESH_SECONDS},
     repo_state::{RepoRootState, RepoState, SnapshotBuildContext},
-    repository_inspection::{GitRepositoryInspector, RepositoryInspection, RepositoryInspector},
+    repository_inspection::{GitRepositoryInspector, ProjectDeclarationInspection, RepositoryInspection, RepositoryInspector},
     step::{
         run_step_plan_with_remote_executor, RemoteStepBatchRequest, RemoteStepExecutor, RemoteStepProgressSink, StepOutcome, StepResolver,
     },
@@ -3801,7 +3805,13 @@ fn whole_repository_project_spec(repository_key: RepositoryKey, display_name: St
         display_name,
         default_workflow_ref: "single-agent-trusted".to_string(),
         issue_source: None,
-        repositories: vec![ProjectRepositorySpec { repo: repository_key, subpath: None, default_branch: None }],
+        repositories: vec![ProjectRepositorySpec {
+            repo: repository_key,
+            alias: None,
+            roles: Default::default(),
+            subpath: None,
+            default_branch: None,
+        }],
     })
 }
 
@@ -4814,6 +4824,9 @@ impl InProcessDaemon {
         let mut unresolved = Vec::new();
         let mut snapshots = BTreeMap::<RepositoryKey, (String, RepositorySpec, Option<String>, BTreeSet<String>)>::new();
         for entry in &project.spec.repositories {
+            if !entry.roles.is_empty() && !entry.roles.contains(&ProjectRepositoryRole::Code) {
+                continue;
+            }
             match repositories.get(&entry.repo.to_string()).await {
                 Ok(repository) => {
                     if let Err(error) = repository.spec.verify_key(&entry.repo) {
@@ -4867,6 +4880,162 @@ impl InProcessDaemon {
             .collect::<Vec<_>>();
         repositories.sort_by(|left, right| left.workspace_slug.cmp(&right.workspace_slug).then_with(|| left.repo_ref.cmp(&right.repo_ref)));
         Ok(repositories)
+    }
+
+    async fn project_register(&self, target: &str) -> Result<(String, usize), String> {
+        let namespace = self.provisioning_namespace().await;
+        let path = if Path::new(target).exists() {
+            PathBuf::from(target)
+        } else {
+            let matches = self
+                .resource_backend
+                .clone()
+                .using::<Repository>(&namespace)
+                .list()
+                .await
+                .map_err(|error| error.to_string())?
+                .items
+                .into_iter()
+                .filter(|repository| repository_matches_target(repository, target))
+                .collect::<Vec<_>>();
+            let [repository] = matches.as_slice() else {
+                return Err(match matches.len() {
+                    0 => format!("`{target}` is neither a bootstrap repository path nor a repository catalog slug"),
+                    _ => format!("bootstrap repository slug `{target}` is ambiguous"),
+                });
+            };
+            let key = RepositoryKey(repository.metadata.name.clone());
+            self.repository_keys_by_path
+                .read()
+                .await
+                .iter()
+                .find_map(|(path, candidate)| (candidate == &key).then(|| path.clone()))
+                .ok_or_else(|| format!("bootstrap repository `{target}` has no local checkout on this host"))?
+        };
+        let inspection = self.repository_inspector().await?.inspect_project_declaration(&path).await?;
+        let declaration = parse_project_declaration(&inspection.yaml)?;
+        let name = declaration.name.clone();
+        self.materialize_project_declaration(declaration, inspection).await?;
+        let project =
+            self.resource_backend.clone().definitions::<Project>(&namespace).get(&name).await.map_err(|error| error.to_string())?;
+        Ok((name, project.spec.repositories.len()))
+    }
+
+    async fn project_refresh(&self, name: &str) -> Result<(usize, bool), String> {
+        validate_project_name(name)?;
+        let namespace = self.provisioning_namespace().await;
+        let project =
+            self.resource_backend.clone().definitions::<Project>(&namespace).get(name).await.map_err(|error| error.to_string())?;
+        let bootstrap_path = project
+            .metadata
+            .annotations
+            .get(BOOTSTRAP_PATH_ANNOTATION)
+            .ok_or_else(|| format!("project {name} was registered without a declaration"))?;
+        let inspection = self.repository_inspector().await?.inspect_project_declaration(Path::new(bootstrap_path)).await?;
+        let declaration = parse_project_declaration(&inspection.yaml)?;
+        if declaration.name != name {
+            return Err(format!(
+                "{} now declares project `{}` instead of `{name}`",
+                Path::new(bootstrap_path).join(DECLARATION_FILE).display(),
+                declaration.name
+            ));
+        }
+        let converged = self.materialize_project_declaration(declaration, inspection).await?;
+        let members = self
+            .resource_backend
+            .clone()
+            .definitions::<Project>(&namespace)
+            .get(name)
+            .await
+            .map_err(|error| error.to_string())?
+            .spec
+            .repositories
+            .len();
+        Ok((members, converged))
+    }
+
+    async fn materialize_project_declaration(
+        &self,
+        declaration: ProjectDeclaration,
+        inspection: ProjectDeclarationInspection,
+    ) -> Result<bool, String> {
+        validate_project_name(&declaration.name)?;
+        let namespace = self.provisioning_namespace().await;
+        let projects = self.resource_backend.clone().definitions::<Project>(&namespace);
+        let repositories = self.resource_backend.clone().using::<Repository>(&namespace);
+        let existing_project = match projects.get(&declaration.name).await {
+            Ok(project) => Some(project),
+            Err(ResourceError::NotFound { .. }) => None,
+            Err(error) => return Err(error.to_string()),
+        };
+        let aliases = existing_project
+            .as_ref()
+            .into_iter()
+            .flat_map(|project| &project.spec.repositories)
+            .filter_map(|member| member.alias.as_ref().map(|alias| (alias.clone(), member.repo.clone())))
+            .collect::<BTreeMap<_, _>>();
+        let bootstrap_key = inspection.repository.key();
+        let bootstrap_path = inspection.repository.checkout.path.to_string_lossy().into_owned();
+        let provenance = BTreeMap::from([
+            (BOOTSTRAP_REPOSITORY_ANNOTATION.to_string(), bootstrap_key.to_string()),
+            (BOOTSTRAP_COMMIT_ANNOTATION.to_string(), inspection.commit.clone()),
+            (BOOTSTRAP_PATH_ANNOTATION.to_string(), bootstrap_path),
+            (DECLARATION_FILE_ANNOTATION.to_string(), DECLARATION_FILE.to_string()),
+        ]);
+        let mut converged = false;
+        let mut members = Vec::with_capacity(declaration.members.len());
+        for member in declaration.members {
+            let declared_spec = RepositorySpec::remote(member.url)?;
+            let key = aliases.get(&member.alias).cloned().unwrap_or_else(|| declared_spec.key());
+            let mut repository = if key == declared_spec.key() {
+                ensure_repository(&repositories, &key, &declared_spec).await.map_err(|error| error.to_string())?
+            } else {
+                repositories
+                    .get(&key.to_string())
+                    .await
+                    .map_err(|error| format!("project member alias `{}` refers to unavailable repository {key}: {error}", member.alias))?
+            };
+            let mut repository_meta = InputMeta::from(&repository.metadata);
+            for (annotation, value) in &provenance {
+                if repository_meta.annotations.get(annotation) != Some(value) {
+                    converged = true;
+                    repository_meta.annotations.insert(annotation.clone(), value.clone());
+                }
+            }
+            if repository_meta.annotations != repository.metadata.annotations {
+                repository = repositories
+                    .update(&repository_meta, &repository.metadata.resource_version, &repository.spec)
+                    .await
+                    .map_err(|error| error.to_string())?;
+            }
+            repository
+                .spec
+                .verify_key(&key)
+                .map_err(|error| format!("project member alias `{}` resolved to invalid repository {key}: {error}", member.alias))?;
+            members.push(ProjectRepositorySpec {
+                repo: key,
+                alias: Some(member.alias),
+                roles: member.roles,
+                subpath: None,
+                default_branch: None,
+            });
+        }
+        let spec = normalize_project_spec(ProjectSpec {
+            display_name: declaration.name.clone(),
+            default_workflow_ref: "single-agent-trusted".to_string(),
+            issue_source: None,
+            repositories: members,
+        })?;
+        let mut meta = existing_project
+            .as_ref()
+            .map_or_else(|| InputMeta::builder().name(declaration.name.clone()).build(), |project| InputMeta::from(&project.metadata));
+        for (annotation, value) in provenance {
+            meta.annotations.insert(annotation, value);
+        }
+        converged |=
+            existing_project.as_ref().is_none_or(|project| project.spec != spec || project.metadata.annotations != meta.annotations);
+        projects.apply(&meta, &spec).await.map_err(|error| error.to_string())?;
+        Ok(converged)
     }
 
     async fn project_add(
@@ -7985,6 +8154,52 @@ impl InProcessDaemon {
                     Err(message) => flotilla_protocol::CommandValue::Error { message },
                 },
                 Err(err) => flotilla_protocol::CommandValue::Error { message: err },
+            };
+            let _ = self.event_tx.send(DaemonEvent::CommandFinished {
+                command_id: id,
+                node_id: self.node_id.clone(),
+                repo_identity: empty_identity,
+                repo: None,
+                result,
+            });
+            return Ok(id);
+        }
+
+        if let flotilla_protocol::CommandAction::ProjectRegister { target } = &command.action {
+            let empty_identity = empty_repo_identity();
+            let _ = self.event_tx.send(DaemonEvent::CommandStarted {
+                command_id: id,
+                node_id: self.node_id.clone(),
+                repo_identity: empty_identity.clone(),
+                repo: None,
+                description: command.description().to_string(),
+            });
+            let result = match self.project_register(target).await {
+                Ok((name, members)) => CommandValue::ProjectRegistered { name, members },
+                Err(message) => CommandValue::Error { message },
+            };
+            let _ = self.event_tx.send(DaemonEvent::CommandFinished {
+                command_id: id,
+                node_id: self.node_id.clone(),
+                repo_identity: empty_identity,
+                repo: None,
+                result,
+            });
+            return Ok(id);
+        }
+
+        if let flotilla_protocol::CommandAction::ProjectRefresh { name } = &command.action {
+            let empty_identity = empty_repo_identity();
+            let _ = self.event_tx.send(DaemonEvent::CommandStarted {
+                command_id: id,
+                node_id: self.node_id.clone(),
+                repo_identity: empty_identity.clone(),
+                repo: None,
+                description: command.description().to_string(),
+            });
+            let result = match self.project_refresh(name).await {
+                Ok((members, converged)) => CommandValue::ProjectRefreshed { name: name.clone(), members, converged },
+                Err(message) => CommandValue::Error { message },
             };
             let _ = self.event_tx.send(DaemonEvent::CommandFinished {
                 command_id: id,

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -4675,9 +4675,27 @@ async fn convoy_admission_snapshots_every_project_repository() {
             default_workflow_ref: "single-agent-contained".to_string(),
             issue_source: None,
             repositories: vec![
-                ProjectRepositorySpec { repo: flotilla.key(), subpath: Some("crates/flotilla-core".to_string()), default_branch: None },
-                ProjectRepositorySpec { repo: flotilla.key(), subpath: Some("crates/flotilla-tui".to_string()), default_branch: None },
-                ProjectRepositorySpec { repo: cleat.key(), subpath: None, default_branch: Some("stable".to_string()) },
+                ProjectRepositorySpec {
+                    repo: flotilla.key(),
+                    alias: None,
+                    roles: Default::default(),
+                    subpath: Some("crates/flotilla-core".to_string()),
+                    default_branch: None,
+                },
+                ProjectRepositorySpec {
+                    repo: flotilla.key(),
+                    alias: None,
+                    roles: Default::default(),
+                    subpath: Some("crates/flotilla-tui".to_string()),
+                    default_branch: None,
+                },
+                ProjectRepositorySpec {
+                    repo: cleat.key(),
+                    alias: None,
+                    roles: Default::default(),
+                    subpath: None,
+                    default_branch: Some("stable".to_string()),
+                },
             ],
         })
         .await

--- a/crates/flotilla-core/src/lib.rs
+++ b/crates/flotilla-core/src/lib.rs
@@ -26,6 +26,7 @@ pub(crate) mod observed_resources;
 pub mod path_context;
 pub mod path_policy;
 pub mod placement_policy;
+pub mod project_declaration;
 pub mod provider_data;
 pub mod providers;
 pub mod query_registry;

--- a/crates/flotilla-core/src/project_declaration.rs
+++ b/crates/flotilla-core/src/project_declaration.rs
@@ -1,0 +1,82 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use flotilla_resources::{canonicalize_repo_url, ProjectRepositoryRole};
+use serde::Deserialize;
+
+pub const DECLARATION_FILE: &str = "project.yaml";
+pub const BOOTSTRAP_REPOSITORY_ANNOTATION: &str = "flotilla.work/project-bootstrap-repository";
+pub const BOOTSTRAP_COMMIT_ANNOTATION: &str = "flotilla.work/project-bootstrap-commit";
+pub const BOOTSTRAP_PATH_ANNOTATION: &str = "flotilla.work/project-bootstrap-path";
+pub const DECLARATION_FILE_ANNOTATION: &str = "flotilla.work/project-declaration-file";
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectDeclaration {
+    pub name: String,
+    pub members: Vec<ProjectDeclarationMember>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectDeclarationMember {
+    pub alias: String,
+    pub url: String,
+    pub roles: BTreeSet<ProjectRepositoryRole>,
+}
+
+pub fn parse_project_declaration(yaml: &str) -> Result<ProjectDeclaration, String> {
+    let mut declaration: ProjectDeclaration = serde_yml::from_str(yaml).map_err(|error| format!("invalid {DECLARATION_FILE}: {error}"))?;
+    declaration.name = required(declaration.name, "name")?;
+    if declaration.members.is_empty() {
+        return Err("project declaration must contain at least one member".to_string());
+    }
+    let mut aliases = BTreeMap::new();
+    for member in &mut declaration.members {
+        member.alias = required(std::mem::take(&mut member.alias), "members[].alias")?;
+        member.url = canonicalize_repo_url(&member.url)?;
+        if member.roles.is_empty() {
+            return Err(format!("project member `{}` must declare at least one role", member.alias));
+        }
+        if aliases.insert(member.alias.clone(), ()).is_some() {
+            return Err(format!("project declaration contains duplicate alias `{}`", member.alias));
+        }
+    }
+    declaration.members.sort_by(|left, right| left.alias.cmp(&right.alias));
+    Ok(declaration)
+}
+
+fn required(value: String, field: &str) -> Result<String, String> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        Err(format!("project declaration {field} cannot be empty"))
+    } else {
+        Ok(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_project_declaration, ProjectRepositoryRole};
+
+    #[test]
+    fn parses_multi_role_members_as_a_set() {
+        let declaration = parse_project_declaration(
+            "name: flotilla\nmembers:\n  - alias: flotilla\n    url: https://github.com/flotilla-org/flotilla.git\n    roles: [code, ops, knowledge]\n",
+        )
+        .expect("declaration");
+        assert_eq!(declaration.members[0].url, "https://github.com/flotilla-org/flotilla");
+        assert!(declaration.members[0].roles.contains(&ProjectRepositoryRole::Ops));
+    }
+
+    #[test]
+    fn rejects_duplicate_aliases_and_empty_roles() {
+        assert!(parse_project_declaration(
+            "name: demo\nmembers:\n  - alias: app\n    url: https://github.com/o/a\n    roles: [code]\n  - alias: app\n    url: https://github.com/o/b\n    roles: [ops]\n",
+        )
+        .unwrap_err()
+        .contains("duplicate alias"));
+        assert!(parse_project_declaration("name: demo\nmembers:\n  - alias: app\n    url: https://github.com/o/a\n    roles: []\n",)
+            .unwrap_err()
+            .contains("at least one role"));
+    }
+}

--- a/crates/flotilla-core/src/repository_inspection.rs
+++ b/crates/flotilla-core/src/repository_inspection.rs
@@ -29,6 +29,13 @@ pub struct RepositoryInspection {
     pub transport_url: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectDeclarationInspection {
+    pub repository: RepositoryInspection,
+    pub yaml: String,
+    pub commit: String,
+}
+
 impl RepositoryInspection {
     pub fn key(&self) -> RepositoryKey {
         self.spec.key()
@@ -50,6 +57,13 @@ pub trait RepositoryInspector: Send + Sync {
 
     async fn resolve_remote(&self, remote: &str) -> Result<RepositorySpec, String> {
         RepositorySpec::remote(remote)
+    }
+
+    async fn inspect_project_declaration(&self, path: &Path) -> Result<ProjectDeclarationInspection, String> {
+        let repository = self.inspect_path(path, None).await?;
+        let declaration_path = repository.checkout.path.join(crate::project_declaration::DECLARATION_FILE);
+        let yaml = std::fs::read_to_string(&declaration_path).map_err(|error| format!("read {}: {error}", declaration_path.display()))?;
+        Ok(ProjectDeclarationInspection { commit: repository.checkout.git_ref.clone(), repository, yaml })
     }
 }
 
@@ -184,6 +198,19 @@ impl RepositoryInspector for GitRepositoryInspector {
             },
             transport_url,
         })
+    }
+
+    async fn inspect_project_declaration(&self, path: &Path) -> Result<ProjectDeclarationInspection, String> {
+        let repository = self.inspect_path(path, None).await?;
+        let commit = self.git(&repository.checkout.path, &["rev-parse", "HEAD"]).await?;
+        let declaration_ref = format!("{commit}:{}", crate::project_declaration::DECLARATION_FILE);
+        let yaml = self.git(&repository.checkout.path, &["show", &declaration_ref]).await.map_err(|error| {
+            format!(
+                "read {} from bootstrap commit {commit}: {error}",
+                repository.checkout.path.join(crate::project_declaration::DECLARATION_FILE).display()
+            )
+        })?;
+        Ok(ProjectDeclarationInspection { repository, yaml, commit })
     }
 
     async fn resolve_remote(&self, remote: &str) -> Result<RepositorySpec, String> {

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -949,7 +949,13 @@ async fn create_test_convoy_project(backend: &flotilla_resources::ResourceBacken
             display_name: "Flotilla".into(),
             default_workflow_ref: "single-agent-contained".into(),
             issue_source,
-            repositories: vec![ProjectRepositorySpec { repo: repository.key(), subpath: None, default_branch: Some("main".into()) }],
+            repositories: vec![ProjectRepositorySpec {
+                repo: repository.key(),
+                alias: None,
+                roles: Default::default(),
+                subpath: None,
+                default_branch: Some("main".into()),
+            }],
         })
         .await
         .expect("project create");
@@ -989,7 +995,13 @@ async fn fork_stance_refuses_reviewless_dispatch_and_admits_implement_review() {
             display_name: "Zellij".into(),
             default_workflow_ref: "single-agent-contained".into(),
             issue_source: Some(IssueSource { service: "https://forgejo.lab".into(), scope: "fork-issues/zellij".into() }),
-            repositories: vec![ProjectRepositorySpec { repo: repository.key(), subpath: None, default_branch: Some("main".into()) }],
+            repositories: vec![ProjectRepositorySpec {
+                repo: repository.key(),
+                alias: None,
+                roles: Default::default(),
+                subpath: None,
+                default_branch: Some("main".into()),
+            }],
         })
         .await
         .expect("project create");
@@ -1085,6 +1097,8 @@ async fn convoy_start_adopts_pr_identity_and_defaults_to_shepherd_workflow() {
             issue_source: None,
             repositories: vec![ProjectRepositorySpec {
                 repo: repository_key.clone(),
+                alias: None,
+                roles: Default::default(),
                 subpath: None,
                 default_branch: Some("trunk".to_string()),
             }],
@@ -1255,7 +1269,13 @@ async fn bare_convoy_start_uses_priority_and_records_every_placement_candidate()
             display_name: "Flotilla".into(),
             default_workflow_ref: "single-agent-trusted".into(),
             issue_source: None,
-            repositories: vec![ProjectRepositorySpec { repo: repository.key(), subpath: None, default_branch: Some("main".into()) }],
+            repositories: vec![ProjectRepositorySpec {
+                repo: repository.key(),
+                alias: None,
+                roles: Default::default(),
+                subpath: None,
+                default_branch: Some("main".into()),
+            }],
         })
         .await
         .expect("project create");
@@ -1339,7 +1359,13 @@ async fn convoy_start_rejects_agent_adapter_missing_from_docker_placement() {
             display_name: "Flotilla".into(),
             default_workflow_ref: "single-agent-contained".into(),
             issue_source: None,
-            repositories: vec![ProjectRepositorySpec { repo: repository.key(), subpath: None, default_branch: Some("main".into()) }],
+            repositories: vec![ProjectRepositorySpec {
+                repo: repository.key(),
+                alias: None,
+                roles: Default::default(),
+                subpath: None,
+                default_branch: Some("main".into()),
+            }],
         })
         .await
         .expect("project create");
@@ -1456,7 +1482,13 @@ async fn convoy_start_accepts_project_list_identifier() {
             display_name: "Flotilla".into(),
             default_workflow_ref: "single-agent-contained".into(),
             issue_source: None,
-            repositories: vec![ProjectRepositorySpec { repo: repository.key(), subpath: None, default_branch: Some("main".into()) }],
+            repositories: vec![ProjectRepositorySpec {
+                repo: repository.key(),
+                alias: None,
+                roles: Default::default(),
+                subpath: None,
+                default_branch: Some("main".into()),
+            }],
         })
         .await
         .expect("project create");
@@ -1590,7 +1622,13 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
             display_name: "Flotilla".into(),
             default_workflow_ref: "single-agent-contained".into(),
             issue_source: Some(reference.source.clone()),
-            repositories: vec![ProjectRepositorySpec { repo: repository.key(), subpath: None, default_branch: Some("main".into()) }],
+            repositories: vec![ProjectRepositorySpec {
+                repo: repository.key(),
+                alias: None,
+                roles: Default::default(),
+                subpath: None,
+                default_branch: Some("main".into()),
+            }],
         })
         .await
         .expect("project create");
@@ -1787,7 +1825,13 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
             display_name: "Explicit workflow".into(),
             default_workflow_ref: "missing-default".into(),
             issue_source: None,
-            repositories: vec![ProjectRepositorySpec { repo: repository.key(), subpath: None, default_branch: Some("main".into()) }],
+            repositories: vec![ProjectRepositorySpec {
+                repo: repository.key(),
+                alias: None,
+                roles: Default::default(),
+                subpath: None,
+                default_branch: Some("main".into()),
+            }],
         })
         .await
         .expect("project with unresolved default should persist");
@@ -1938,7 +1982,13 @@ async fn convoy_start_completes_both_names_with_one_ai_call() {
             display_name: "Flotilla".into(),
             default_workflow_ref: "single-agent-contained".into(),
             issue_source: None,
-            repositories: vec![ProjectRepositorySpec { repo: repository.key(), subpath: None, default_branch: Some("main".into()) }],
+            repositories: vec![ProjectRepositorySpec {
+                repo: repository.key(),
+                alias: None,
+                roles: Default::default(),
+                subpath: None,
+                default_branch: Some("main".into()),
+            }],
         })
         .await
         .expect("project create");
@@ -3762,11 +3812,10 @@ async fn whole_repository_materialization_skips_generated_name_occupied_by_multi
             display_name: "repo suite".to_string(),
             default_workflow_ref: "single-agent-contained".to_string(),
             issue_source: None,
-            repositories: vec![ProjectRepositorySpec { repo: tracked.key(), subpath: None, default_branch: None }, ProjectRepositorySpec {
-                repo: other.key(),
-                subpath: None,
-                default_branch: None,
-            }],
+            repositories: vec![
+                ProjectRepositorySpec { repo: tracked.key(), alias: None, roles: Default::default(), subpath: None, default_branch: None },
+                ProjectRepositorySpec { repo: other.key(), alias: None, roles: Default::default(), subpath: None, default_branch: None },
+            ],
         })
         .await
         .expect("generated-name occupant should be creatable");

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -13,7 +13,7 @@ use flotilla_core::{
     config::ConfigStore,
     daemon::DaemonHandle,
     in_process::InProcessDaemon,
-    project_declaration::{BOOTSTRAP_COMMIT_ANNOTATION, BOOTSTRAP_REPOSITORY_ANNOTATION},
+    project_declaration::{BOOTSTRAP_COMMIT_ANNOTATION, BOOTSTRAP_PATH_ANNOTATION, BOOTSTRAP_REPOSITORY_ANNOTATION},
     providers::discovery::test_support::fake_discovery,
     repository_inspection::{LocalCheckoutInspection, ProjectDeclarationInspection, RepositoryInspection, RepositoryInspector},
 };
@@ -272,7 +272,43 @@ async fn project_declarations_register_single_and_multi_member_projects_with_pro
     for member in &split.spec.repositories {
         let repository = backend.using::<Repository>("flotilla").get(&member.repo.to_string()).await.expect("member repository");
         assert_eq!(repository.metadata.annotations.get(BOOTSTRAP_COMMIT_ANNOTATION).map(String::as_str), Some("0123456789abcdef"));
+        assert!(!repository.metadata.annotations.contains_key(BOOTSTRAP_PATH_ANNOTATION));
     }
+}
+
+#[tokio::test]
+async fn declaration_adoption_survives_whole_repository_project_reconciliation() {
+    let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
+    let checkout = tmp.path().join("flotilla");
+    std::fs::create_dir(&checkout).expect("checkout dir");
+    std::fs::write(
+        checkout.join("project.yaml"),
+        "name: flotilla\nmembers:\n  - alias: flotilla\n    url: https://github.com/flotilla-org/flotilla\n    roles: [code, ops, knowledge]\n",
+    )
+    .expect("write declaration");
+    let commit = Arc::new(RwLock::new("declaration-commit".to_string()));
+    daemon
+        .set_repository_inspector(Arc::new(DeclarationInspector {
+            bootstrap: RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("bootstrap spec"),
+            commit,
+        }))
+        .await;
+    daemon.add_repo(&checkout).await.expect("track bootstrap member");
+    let mut rx = daemon.subscribe();
+    assert_eq!(
+        execute_project_command(&daemon, &mut rx, CommandAction::ProjectRegister { target: checkout.to_string_lossy().into_owned() },)
+            .await,
+        CommandValue::ProjectRegistered { name: "flotilla".to_string(), members: 1 }
+    );
+    let projects = backend.definitions::<Project>("flotilla");
+    let registered = projects.get("flotilla").await.expect("registered project");
+
+    daemon.materialize_tracked_repo_projects().await.expect("whole-repository reconciliation");
+
+    let reconciled = projects.get("flotilla").await.expect("reconciled project");
+    assert_eq!(reconciled.metadata.resource_version, registered.metadata.resource_version);
+    assert_eq!(reconciled.spec.repositories[0].alias.as_deref(), Some("flotilla"));
+    assert_eq!(reconciled.spec.repositories[0].roles.len(), 3);
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -302,6 +302,23 @@ async fn declaration_adoption_survives_whole_repository_project_reconciliation()
     );
     let projects = backend.definitions::<Project>("flotilla");
     let registered = projects.get("flotilla").await.expect("registered project");
+    let registered_repo = &registered.spec.repositories[0].repo;
+
+    for result in [
+        execute_project_add(&daemon, &mut rx, checkout.to_string_lossy().into_owned(), Some("flotilla"), None).await,
+        execute_project_command(&daemon, &mut rx, CommandAction::ProjectApply {
+            name: "flotilla".to_string(),
+            spec_yaml: format!(
+                "display_name: overwritten\ndefault_workflow_ref: single-agent-contained\nrepositories:\n  - repo: {registered_repo}\n"
+            ),
+        })
+        .await,
+    ] {
+        assert!(
+            matches!(&result, CommandValue::Error { message } if message.contains("managed by a declaration") && message.contains("project refresh")),
+            "unexpected command result: {result:?}"
+        );
+    }
 
     daemon.materialize_tracked_repo_projects().await.expect("whole-repository reconciliation");
 

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -13,14 +13,15 @@ use flotilla_core::{
     config::ConfigStore,
     daemon::DaemonHandle,
     in_process::InProcessDaemon,
+    project_declaration::{BOOTSTRAP_COMMIT_ANNOTATION, BOOTSTRAP_REPOSITORY_ANNOTATION},
     providers::discovery::test_support::fake_discovery,
-    repository_inspection::{LocalCheckoutInspection, RepositoryInspection, RepositoryInspector},
+    repository_inspection::{LocalCheckoutInspection, ProjectDeclarationInspection, RepositoryInspection, RepositoryInspector},
 };
 use flotilla_daemon::runtime::{DaemonRuntime, RuntimeOptions};
 use flotilla_protocol::{commands::RepositoryIdentityChange, Command, CommandAction, CommandValue, DaemonEvent, HostName, RepoSelector};
 use flotilla_resources::{
-    Checkout, CheckoutSpec, Convoy, InMemoryBackend, InputMeta, IssueSource, ObservedCheckoutSpec, Project, ProjectSpec, Repository,
-    RepositoryKey, RepositorySpec, RepositoryStatus, ResourceBackend, MANAGED_BY_LABEL,
+    Checkout, CheckoutSpec, Convoy, InMemoryBackend, InputMeta, IssueSource, ObservedCheckoutSpec, Project, ProjectRepositoryRole,
+    ProjectSpec, Repository, RepositoryKey, RepositorySpec, RepositoryStatus, ResourceBackend, MANAGED_BY_LABEL,
 };
 
 #[derive(Clone)]
@@ -75,6 +76,35 @@ struct FixedInspector {
 #[derive(Clone)]
 struct MutableInspector {
     spec: Arc<RwLock<RepositorySpec>>,
+}
+
+#[derive(Clone)]
+struct DeclarationInspector {
+    bootstrap: RepositorySpec,
+    commit: Arc<RwLock<String>>,
+}
+
+#[async_trait]
+impl RepositoryInspector for DeclarationInspector {
+    async fn inspect_path(&self, path: &Path, _remote: Option<&str>) -> Result<RepositoryInspection, String> {
+        Ok(RepositoryInspection {
+            spec: self.bootstrap.clone(),
+            checkout: LocalCheckoutInspection {
+                path: path.to_path_buf(),
+                host_ref: "host-01".to_string(),
+                git_ref: "main".to_string(),
+                is_main: true,
+            },
+            transport_url: None,
+        })
+    }
+
+    async fn inspect_project_declaration(&self, path: &Path) -> Result<ProjectDeclarationInspection, String> {
+        let repository = self.inspect_path(path, None).await?;
+        let yaml = std::fs::read_to_string(path.join("project.yaml")).map_err(|error| error.to_string())?;
+        let commit = self.commit.read().expect("commit lock should not be poisoned").clone();
+        Ok(ProjectDeclarationInspection { repository, yaml, commit })
+    }
 }
 
 #[async_trait]
@@ -187,6 +217,110 @@ async fn execute_project_add(
     await_command_result(rx, id).await
 }
 
+async fn execute_project_command(
+    daemon: &Arc<InProcessDaemon>,
+    rx: &mut tokio::sync::broadcast::Receiver<DaemonEvent>,
+    action: CommandAction,
+) -> CommandValue {
+    let id = daemon.execute(Command { node_id: None, provisioning_target: None, context_repo: None, action }).await.expect("execute");
+    await_command_result(rx, id).await
+}
+
+#[tokio::test]
+async fn project_declarations_register_single_and_multi_member_projects_with_provenance() {
+    let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
+    let bootstrap = RepositorySpec::remote("https://github.com/example/bootstrap").expect("bootstrap spec");
+    let commit = Arc::new(RwLock::new("0123456789abcdef".to_string()));
+    daemon.set_repository_inspector(Arc::new(DeclarationInspector { bootstrap: bootstrap.clone(), commit })).await;
+    let mut rx = daemon.subscribe();
+
+    std::fs::write(
+        tmp.path().join("project.yaml"),
+        "name: flotilla\nmembers:\n  - alias: flotilla\n    url: https://github.com/flotilla-org/flotilla\n    roles: [code, ops, knowledge]\n",
+    )
+    .expect("write declaration");
+    assert_eq!(
+        execute_project_command(&daemon, &mut rx, CommandAction::ProjectRegister { target: tmp.path().to_string_lossy().into_owned() },)
+            .await,
+        CommandValue::ProjectRegistered { name: "flotilla".to_string(), members: 1 }
+    );
+    let flotilla = backend.using::<Project>("flotilla").get("flotilla").await.expect("flotilla project");
+    assert_eq!(flotilla.spec.repositories[0].alias.as_deref(), Some("flotilla"));
+    assert_eq!(
+        flotilla.spec.repositories[0].roles,
+        [ProjectRepositoryRole::Code, ProjectRepositoryRole::Ops, ProjectRepositoryRole::Knowledge,].into_iter().collect()
+    );
+    assert_eq!(flotilla.metadata.annotations.get(BOOTSTRAP_REPOSITORY_ANNOTATION), Some(&bootstrap.key().to_string()));
+    assert_eq!(flotilla.metadata.annotations.get(BOOTSTRAP_COMMIT_ANNOTATION).map(String::as_str), Some("0123456789abcdef"));
+
+    std::fs::write(
+        tmp.path().join("project.yaml"),
+        "name: split\nmembers:\n  - alias: app\n    url: https://github.com/example/app\n    roles: [code]\n  - alias: operations\n    url: https://github.com/example/ops\n    roles: [ops]\n",
+    )
+    .expect("write declaration");
+    assert_eq!(
+        execute_project_command(&daemon, &mut rx, CommandAction::ProjectRegister { target: tmp.path().to_string_lossy().into_owned() },)
+            .await,
+        CommandValue::ProjectRegistered { name: "split".to_string(), members: 2 }
+    );
+    let split = backend.using::<Project>("flotilla").get("split").await.expect("split project");
+    assert_eq!(split.spec.repositories.iter().map(|member| member.alias.as_deref()).collect::<Vec<_>>(), vec![
+        Some("app"),
+        Some("operations")
+    ]);
+    for member in &split.spec.repositories {
+        let repository = backend.using::<Repository>("flotilla").get(&member.repo.to_string()).await.expect("member repository");
+        assert_eq!(repository.metadata.annotations.get(BOOTSTRAP_COMMIT_ANNOTATION).map(String::as_str), Some("0123456789abcdef"));
+    }
+}
+
+#[tokio::test]
+async fn project_refresh_is_one_way_and_keeps_alias_repository_keys_stable_across_rename() {
+    let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
+    let commit = Arc::new(RwLock::new("commit-one".to_string()));
+    daemon
+        .set_repository_inspector(Arc::new(DeclarationInspector {
+            bootstrap: RepositorySpec::remote("https://github.com/example/bootstrap").expect("bootstrap spec"),
+            commit: Arc::clone(&commit),
+        }))
+        .await;
+    let declaration_path = tmp.path().join("project.yaml");
+    std::fs::write(
+        &declaration_path,
+        "name: demo\nmembers:\n  - alias: app\n    url: https://github.com/example/app-old\n    roles: [code]\n  - alias: ops\n    url: https://github.com/example/ops\n    roles: [ops]\n",
+    )
+    .expect("write declaration");
+    let mut rx = daemon.subscribe();
+    execute_project_command(&daemon, &mut rx, CommandAction::ProjectRegister { target: tmp.path().to_string_lossy().into_owned() }).await;
+    let projects = backend.definitions::<Project>("flotilla");
+    let original = projects.get("demo").await.expect("project");
+    let app_key = original.spec.repositories.iter().find(|member| member.alias.as_deref() == Some("app")).expect("app member").repo.clone();
+    let mut drifted = original.spec.clone();
+    drifted.display_name = "hand edited".to_string();
+    projects.apply(&InputMeta::from(&original.metadata), &drifted).await.expect("introduce drift");
+
+    *commit.write().expect("commit lock should not be poisoned") = "commit-two".to_string();
+    std::fs::write(
+        &declaration_path,
+        "name: demo\nmembers:\n  - alias: app\n    url: https://github.com/example/app-renamed\n    roles: [code, knowledge]\n  - alias: ops\n    url: https://github.com/example/ops\n    roles: [ops]\n",
+    )
+    .expect("update declaration");
+    assert_eq!(
+        execute_project_command(&daemon, &mut rx, CommandAction::ProjectRefresh { name: "demo".to_string() }).await,
+        CommandValue::ProjectRefreshed { name: "demo".to_string(), members: 2, converged: true }
+    );
+    let refreshed = projects.get("demo").await.expect("refreshed project");
+    assert_eq!(refreshed.spec.display_name, "demo");
+    let app = refreshed.spec.repositories.iter().find(|member| member.alias.as_deref() == Some("app")).expect("app member");
+    assert_eq!(app.repo, app_key, "alias should preserve the rename-stable RepositoryKey");
+    assert!(app.roles.contains(&ProjectRepositoryRole::Knowledge));
+    assert_eq!(refreshed.metadata.annotations.get(BOOTSTRAP_COMMIT_ANNOTATION).map(String::as_str), Some("commit-two"));
+    assert_eq!(
+        execute_project_command(&daemon, &mut rx, CommandAction::ProjectRefresh { name: "demo".to_string() }).await,
+        CommandValue::ProjectRefreshed { name: "demo".to_string(), members: 2, converged: false }
+    );
+}
+
 #[tokio::test]
 async fn tracking_repo_materializes_whole_repo_project() {
     let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
@@ -198,6 +332,8 @@ async fn tracking_repo_materializes_whole_repo_project() {
     assert_eq!(project.metadata.labels.get(MANAGED_BY_LABEL).map(String::as_str), Some("whole-repository-project"));
     assert_eq!(project.spec.repositories.as_slice(), [flotilla_resources::ProjectRepositorySpec {
         repo: repository_key,
+        alias: None,
+        roles: Default::default(),
         subpath: None,
         default_branch: None,
     }]);
@@ -235,6 +371,8 @@ async fn tracked_repo_reconciles_generator_owned_project_fields_and_preserves_cu
                 .maybe_issue_source(Some(IssueSource { service: "https://linear.app".to_string(), scope: "TRACK".to_string() }))
                 .repositories(vec![flotilla_resources::ProjectRepositorySpec {
                     repo: repository_key,
+                    alias: None,
+                    roles: Default::default(),
                     subpath: None,
                     default_branch: Some("release".to_string()),
                 }])
@@ -263,6 +401,8 @@ async fn tracked_repo_reconciles_generator_owned_project_fields_and_preserves_cu
     assert_eq!(reconciled.spec.default_workflow_ref, "single-agent-trusted");
     assert_eq!(reconciled.spec.repositories.as_slice(), [flotilla_resources::ProjectRepositorySpec {
         repo: RepositorySpec::remote("https://github.com/org/tracked.git").expect("repository spec").key(),
+        alias: None,
+        roles: Default::default(),
         subpath: None,
         default_branch: None,
     }]);
@@ -303,7 +443,13 @@ async fn tracked_repo_labels_matching_unlabelled_project_once() {
             &ProjectSpec::builder()
                 .display_name("tracked".to_string())
                 .default_workflow_ref("single-agent-trusted".to_string())
-                .repositories(vec![flotilla_resources::ProjectRepositorySpec { repo: repository_key, subpath: None, default_branch: None }])
+                .repositories(vec![flotilla_resources::ProjectRepositorySpec {
+                    repo: repository_key,
+                    alias: None,
+                    roles: Default::default(),
+                    subpath: None,
+                    default_branch: None,
+                }])
                 .build(),
         )
         .await
@@ -677,6 +823,8 @@ async fn daemon_start_backfills_project_idempotently_and_preserves_edits_to_gene
     evolved.issue_source = Some(IssueSource { service: "linear".to_string(), scope: "BACK".to_string() });
     evolved.repositories.push(flotilla_resources::ProjectRepositorySpec {
         repo: RepositoryKey("second-repository".to_string()),
+        alias: None,
+        roles: Default::default(),
         subpath: None,
         default_branch: None,
     });
@@ -798,6 +946,8 @@ async fn tracking_repo_widens_project_name_without_overwriting_custom_project() 
         issue_source: None,
         repositories: vec![flotilla_resources::ProjectRepositorySpec {
             repo: RepositoryKey("other-repository".to_string()),
+            alias: None,
+            roles: Default::default(),
             subpath: None,
             default_branch: None,
         }],
@@ -822,6 +972,8 @@ async fn tracking_repo_uses_repository_key_when_slug_candidates_collide() {
                 issue_source: None,
                 repositories: vec![flotilla_resources::ProjectRepositorySpec {
                     repo: RepositoryKey(repo_ref.to_string()),
+                    alias: None,
+                    roles: Default::default(),
                     subpath: None,
                     default_branch: None,
                 }],
@@ -862,6 +1014,8 @@ async fn project_add_untracked_path_ensures_repository_checkout_and_whole_repo_p
     assert_eq!(project.spec.default_workflow_ref, "single-agent-trusted");
     assert_eq!(project.spec.repositories.as_slice(), [flotilla_resources::ProjectRepositorySpec {
         repo: repository_key,
+        alias: None,
+        roles: Default::default(),
         subpath: None,
         default_branch: None,
     }]);
@@ -1134,6 +1288,8 @@ async fn project_apply_preserves_existing_metadata() {
                 .default_workflow_ref("single-agent-trusted".to_string())
                 .repositories(vec![flotilla_resources::ProjectRepositorySpec {
                     repo: RepositoryKey("repository".to_string()),
+                    alias: None,
+                    roles: Default::default(),
                     subpath: None,
                     default_branch: None,
                 }])

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -23,6 +23,7 @@ use flotilla_resources::{
     Checkout, CheckoutSpec, Convoy, InMemoryBackend, InputMeta, IssueSource, ObservedCheckoutSpec, Project, ProjectRepositoryRole,
     ProjectSpec, Repository, RepositoryKey, RepositorySpec, RepositoryStatus, ResourceBackend, MANAGED_BY_LABEL,
 };
+use tracing::instrument::WithSubscriber;
 
 #[derive(Clone)]
 struct LogCaptureWriter(Arc<Mutex<Vec<u8>>>);
@@ -391,8 +392,11 @@ async fn tracked_repo_reconciles_generator_owned_project_fields_and_preserves_cu
             .with_max_level(tracing::Level::WARN)
             .with_writer(move || writer.clone())
             .finish();
-        let _guard = tracing::subscriber::set_default(subscriber);
-        daemon.materialize_tracked_repo_projects().await.expect("tracked Project reconciliation should succeed");
+        daemon
+            .materialize_tracked_repo_projects()
+            .with_subscriber(subscriber)
+            .await
+            .expect("tracked Project reconciliation should succeed");
     }
 
     let reconciled = projects.get("tracked").await.expect("tracked Project should remain");

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -495,6 +495,12 @@ pub enum CommandAction {
         name: String,
         spec_yaml: String,
     },
+    ProjectRegister {
+        target: String,
+    },
+    ProjectRefresh {
+        name: String,
+    },
     TeleportSession {
         session_id: String,
         branch: Option<String>,
@@ -647,6 +653,8 @@ impl Command {
             CommandAction::WorkflowTemplateApply { .. } => "Applying workflow template...",
             CommandAction::ProjectAdd { .. } => "Adding project...",
             CommandAction::ProjectApply { .. } => "Applying project...",
+            CommandAction::ProjectRegister { .. } => "Registering project declaration...",
+            CommandAction::ProjectRefresh { .. } => "Refreshing project declaration...",
             CommandAction::TeleportSession { .. } => "Teleporting session...",
             CommandAction::TrackRepoPath { .. } => "Tracking repository...",
             CommandAction::UntrackRepo { .. } => "Untracking repository...",
@@ -811,6 +819,15 @@ pub enum CommandValue {
     },
     ProjectApplied {
         name: String,
+    },
+    ProjectRegistered {
+        name: String,
+        members: usize,
+    },
+    ProjectRefreshed {
+        name: String,
+        members: usize,
+        converged: bool,
     },
 }
 

--- a/crates/flotilla-resources/src/crds/project.crd.yaml
+++ b/crates/flotilla-resources/src/crds/project.crd.yaml
@@ -44,6 +44,15 @@ spec:
                     properties:
                       repo:
                         type: string
+                      alias:
+                        type: string
+                        minLength: 1
+                      roles:
+                        type: array
+                        uniqueItems: true
+                        items:
+                          type: string
+                          enum: [code, ops, knowledge]
                       subpath:
                         type: string
                       default_branch:

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -104,7 +104,7 @@ pub use principal_attention::{
 };
 pub use project::{
     normalize_project_spec, resolve_project_issue_sources, IssueSource, IssueSourceResolution, IssueSourceUnavailable, Project,
-    ProjectRepositorySpec, ProjectSpec,
+    ProjectRepositoryRole, ProjectRepositorySpec, ProjectSpec,
 };
 pub use provisioning_identity::{canonicalize_repo_url, clone_key, descriptive_repo_slug, repo_key};
 pub use registry::{

--- a/crates/flotilla-resources/src/project.rs
+++ b/crates/flotilla-resources/src/project.rs
@@ -24,9 +24,22 @@ pub struct ProjectSpec {
 pub struct ProjectRepositorySpec {
     pub repo: RepositoryKey,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub alias: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    #[builder(default)]
+    pub roles: BTreeSet<ProjectRepositoryRole>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subpath: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_branch: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectRepositoryRole {
+    Code,
+    Ops,
+    Knowledge,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -85,6 +98,14 @@ pub fn normalize_project_spec(mut spec: ProjectSpec) -> Result<ProjectSpec, Stri
         repository.subpath = repository.subpath.take().map(normalize_subpath).transpose()?;
         repository.default_branch =
             repository.default_branch.take().map(|branch| required_value(branch, "repositories[].default_branch")).transpose()?;
+        repository.alias = repository.alias.take().map(|alias| required_value(alias, "repositories[].alias")).transpose()?;
+        if repository.alias.is_some() && repository.roles.is_empty() {
+            return Err("project repository roles cannot be empty when alias is declared".to_string());
+        }
+    }
+    let aliases = spec.repositories.iter().filter_map(|repository| repository.alias.as_deref()).collect::<BTreeSet<_>>();
+    if aliases.len() != spec.repositories.iter().filter(|repository| repository.alias.is_some()).count() {
+        return Err("project contains a duplicate repository alias".to_string());
     }
     spec.repositories.sort_by(|left, right| (&left.repo, &left.subpath).cmp(&(&right.repo, &right.subpath)));
     if spec.repositories.windows(2).any(|pair| pair[0].repo == pair[1].repo && pair[0].subpath == pair[1].subpath) {

--- a/crates/flotilla-resources/tests/common/contract.rs
+++ b/crates/flotilla-resources/tests/common/contract.rs
@@ -314,6 +314,8 @@ fn project_spec(display_name: &str, workflow: &str) -> ProjectSpec {
         .default_workflow_ref(workflow.to_string())
         .repositories(vec![ProjectRepositorySpec {
             repo: RepositoryKey("github.com/acme/widgets".to_string()),
+            alias: None,
+            roles: Default::default(),
             subpath: None,
             default_branch: None,
         }])

--- a/crates/flotilla-resources/tests/repository_in_memory.rs
+++ b/crates/flotilla-resources/tests/repository_in_memory.rs
@@ -15,6 +15,8 @@ async fn project_issue_source_override_resolves_without_a_checkout_or_repository
         issue_source: Some(override_source.clone()),
         repositories: vec![ProjectRepositorySpec {
             repo: RepositoryKey("repository-not-present-on-this-host".into()),
+            alias: None,
+            roles: Default::default(),
             subpath: None,
             default_branch: None,
         }],
@@ -39,9 +41,15 @@ async fn project_issue_sources_are_the_deduplicated_union_of_repository_forges()
         default_workflow_ref: "single-agent-contained".into(),
         issue_source: None,
         repositories: vec![
-            ProjectRepositorySpec { repo: first.key(), subpath: None, default_branch: None },
-            ProjectRepositorySpec { repo: second.key(), subpath: None, default_branch: None },
-            ProjectRepositorySpec { repo: first.key(), subpath: Some("duplicate-source".into()), default_branch: None },
+            ProjectRepositorySpec { repo: first.key(), alias: None, roles: Default::default(), subpath: None, default_branch: None },
+            ProjectRepositorySpec { repo: second.key(), alias: None, roles: Default::default(), subpath: None, default_branch: None },
+            ProjectRepositorySpec {
+                repo: first.key(),
+                alias: None,
+                roles: Default::default(),
+                subpath: Some("duplicate-source".into()),
+                default_branch: None,
+            },
         ],
     };
 
@@ -63,7 +71,13 @@ async fn project_issue_source_resolution_reports_typed_unavailability() {
         display_name: "Widgets".into(),
         default_workflow_ref: "single-agent-contained".into(),
         issue_source: None,
-        repositories: vec![ProjectRepositorySpec { repo: local.key(), subpath: None, default_branch: None }],
+        repositories: vec![ProjectRepositorySpec {
+            repo: local.key(),
+            alias: None,
+            roles: Default::default(),
+            subpath: None,
+            default_branch: None,
+        }],
     };
     assert_eq!(
         resolve_project_issue_sources(&repositories, &local_only).await,
@@ -72,7 +86,13 @@ async fn project_issue_source_resolution_reports_typed_unavailability() {
 
     let missing = RepositoryKey("missing".into());
     let unresolved = ProjectSpec {
-        repositories: vec![ProjectRepositorySpec { repo: missing.clone(), subpath: None, default_branch: None }],
+        repositories: vec![ProjectRepositorySpec {
+            repo: missing.clone(),
+            alias: None,
+            roles: Default::default(),
+            subpath: None,
+            default_branch: None,
+        }],
         ..local_only
     };
     assert!(matches!(
@@ -209,8 +229,14 @@ fn project_normalization_sorts_entries_omits_whole_repo_subpath_and_rejects_dupl
         default_workflow_ref: " single-agent-contained ".to_string(),
         issue_source: None,
         repositories: vec![
-            ProjectRepositorySpec { repo: repo_b.clone(), subpath: Some("./apps/api".to_string()), default_branch: None },
-            ProjectRepositorySpec { repo: repo_a.clone(), subpath: None, default_branch: None },
+            ProjectRepositorySpec {
+                repo: repo_b.clone(),
+                alias: None,
+                roles: Default::default(),
+                subpath: Some("./apps/api".to_string()),
+                default_branch: None,
+            },
+            ProjectRepositorySpec { repo: repo_a.clone(), alias: None, roles: Default::default(), subpath: None, default_branch: None },
         ],
     })
     .expect("project should normalize");
@@ -225,11 +251,10 @@ fn project_normalization_sorts_entries_omits_whole_repo_subpath_and_rejects_dupl
         display_name: "Example".to_string(),
         default_workflow_ref: "single-agent-contained".to_string(),
         issue_source: None,
-        repositories: vec![ProjectRepositorySpec { repo: repo_b.clone(), subpath: None, default_branch: None }, ProjectRepositorySpec {
-            repo: repo_b,
-            subpath: None,
-            default_branch: None,
-        }],
+        repositories: vec![
+            ProjectRepositorySpec { repo: repo_b.clone(), alias: None, roles: Default::default(), subpath: None, default_branch: None },
+            ProjectRepositorySpec { repo: repo_b, alias: None, roles: Default::default(), subpath: None, default_branch: None },
+        ],
     };
     assert!(normalize_project_spec(duplicate).expect_err("duplicates should fail").contains("duplicate"));
 
@@ -247,6 +272,8 @@ fn project_subpaths_reject_absolute_and_parent_traversal() {
             issue_source: None,
             repositories: vec![ProjectRepositorySpec {
                 repo: RepositoryKey("repo".to_string()),
+                alias: None,
+                roles: Default::default(),
                 subpath: Some(subpath.to_string()),
                 default_branch: None,
             }],

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -302,6 +302,15 @@ pub fn handle_result(result: CommandValue, app: &mut App) {
             info!(%name, "project applied");
             app.set_status_message(Some(format!("Project applied: {name}")));
         }
+        CommandValue::ProjectRegistered { name, members } => {
+            info!(%name, %members, "project registered from declaration");
+            app.set_status_message(Some(format!("Project registered: {name} ({members} members)")));
+        }
+        CommandValue::ProjectRefreshed { name, members, converged } => {
+            info!(%name, %members, %converged, "project declaration refreshed");
+            let outcome = if converged { "drift converged" } else { "already current" };
+            app.set_status_message(Some(format!("Project refreshed: {name} ({members} members, {outcome})")));
+        }
     }
 }
 

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -604,6 +604,11 @@ fn format_command_result(result: &flotilla_protocol::commands::CommandValue) -> 
         CommandValue::WorkflowTemplateApplied { name } => format!("workflow template applied: {name}"),
         CommandValue::ProjectAdded { name } => format!("project added: {name}"),
         CommandValue::ProjectApplied { name } => format!("project applied: {name}"),
+        CommandValue::ProjectRegistered { name, members } => format!("project registered: {name} ({members} members)"),
+        CommandValue::ProjectRefreshed { name, members, converged } => format!(
+            "project refreshed: {name} ({members} members, {})",
+            if *converged { "materialized drift converged" } else { "already current" }
+        ),
     }
 }
 

--- a/docs/adr/0020-project-membership-association-and-hulls.md
+++ b/docs/adr/0020-project-membership-association-and-hulls.md
@@ -194,6 +194,26 @@ rejected UID would have served none.
 Project rename continuity is **deferred with a named dependency**: what would
 need to follow a rename is annotations on the Project or its sub-resources, so
 the decision waits on the annotation-layer design rather than on speculation.
+
+## Project declarations and explicit materialization
+
+A Project may opt into a reviewed `project.yaml` declaration stored in any
+bootstrap repository; that repository need not itself be a member. The schema
+names the Project and lists members by project-scoped alias, canonical URL, and
+a non-empty set of `code`, `ops`, and `knowledge` roles. Multiple roles on one
+repository are first-class.
+
+Registration and operator-requested refresh are the only materialization
+triggers. They project the declaration into the Project and Repository
+resources and stamp the bootstrap RepositoryKey and exact commit as provenance.
+The flow is strictly one-way: edits to materialized state are drift and refresh
+converges them back to the declaration. There is deliberately no continuous
+watch, so merging a declaration change cannot reconfigure the fleet by itself.
+Projects without declarations remain legitimate.
+
+Aliases are the stable join across refreshes. If a member URL changes under the
+same alias, the Project retains its established RepositoryKey and relies on the
+forge redirect semantics above rather than rewriting existing references.
 External forge renames are out of scope; the forge redirects.
 
 ## Consequences

--- a/docs/project-declarations.md
+++ b/docs/project-declarations.md
@@ -1,0 +1,42 @@
+# Project declarations
+
+A bootstrap repository may declare a Project in `project.yaml`:
+
+```yaml
+name: example
+members:
+  - alias: app
+    url: https://github.com/example/app
+    roles: [code]
+  - alias: operations
+    url: https://github.com/example/project-ops
+    roles: [ops, knowledge]
+```
+
+`name` is the Project resource name. Every member has a project-scoped,
+human-writable `alias`, a canonical repository `url`, and a non-empty set of
+roles drawn from `code`, `ops`, and `knowledge`. A repository may have several
+roles. The bootstrap repository contains the declaration but need not itself be
+a member. Code-workspace admission targets members carrying `code`; legacy
+members without declaration roles retain their existing behavior.
+
+Register the declaration from a local checkout, then refresh it explicitly when
+the reviewed declaration changes:
+
+```text
+flotilla project register /path/to/bootstrap # or a tracked repository catalog slug
+flotilla project refresh example
+```
+
+Registration creates or updates the Project and member Repository resources.
+It records the bootstrap RepositoryKey, exact commit, declaration filename, and
+local bootstrap path as provenance annotations. Refresh reads `project.yaml`
+from the bootstrap checkout's committed `HEAD` and converges materialized state
+back to the declaration. It does not watch for changes continuously, and it
+does not use uncommitted working-tree contents.
+
+Aliases preserve each member's RepositoryKey if its URL changes between
+refreshes. This follows the repository identity model: forge renames are served
+through redirects while resource references retain their established key.
+Projects created with `project add` or `project apply` remain valid and cannot
+be refreshed until they opt in by being registered from a declaration.

--- a/docs/project-declarations.md
+++ b/docs/project-declarations.md
@@ -30,10 +30,12 @@ flotilla project refresh example
 
 Registration creates or updates the Project and member Repository resources.
 It records the bootstrap RepositoryKey, exact commit, declaration filename, and
-local bootstrap path as provenance annotations. Refresh reads `project.yaml`
-from the bootstrap checkout's committed `HEAD` and converges materialized state
-back to the declaration. It does not watch for changes continuously, and it
-does not use uncommitted working-tree contents.
+local bootstrap path as provenance annotations on the Project; member
+Repositories receive only the portable repository, commit, and filename
+provenance. Refresh reads `project.yaml` from the bootstrap checkout's committed
+`HEAD` and converges materialized state back to the declaration. It does not
+watch for changes continuously, and it does not use uncommitted working-tree
+contents.
 
 Aliases preserve each member's RepositoryKey if its URL changes between
 refreshes. This follows the repository identity model: forge renames are served

--- a/project.yaml
+++ b/project.yaml
@@ -1,0 +1,5 @@
+name: flotilla
+members:
+  - alias: flotilla
+    url: https://github.com/flotilla-org/flotilla
+    roles: [code, ops, knowledge]


### PR DESCRIPTION
## What changed

- add the reviewed `project.yaml` schema with project-scoped aliases and set-valued `code`, `ops`, and `knowledge` roles
- add `flotilla project register <repo-or-path>` and `flotilla project refresh <name>`
- materialize Project and member Repository resources with bootstrap RepositoryKey and commit provenance
- preserve RepositoryKeys across member URL renames by resolving stable aliases on refresh
- report whether refresh converged materialized drift, while leaving projects without declarations legitimate
- add Flotilla's own declaration, CRD schema, ADR/docs, and in-memory daemon behavior coverage

## Why

Project-authored operational material needs a reviewed repository source of truth and an explicit, one-way projection into control-plane resources. This keeps bad merges from continuously reconfiguring a fleet and makes hand-edited materialized drift visible and correctable.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1375
