### PR TITLE
feat: compose Codex home material fragments

### DIFF
--- a/crates/flotilla-daemon/src/agent_material.rs
+++ b/crates/flotilla-daemon/src/agent_material.rs
@@ -34,7 +34,6 @@ pub(crate) struct AgentMaterialPreflight {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AgentMaterialDelivery {
     pub(crate) mount: ProvisionedMount,
-    pub(crate) fragment: Box<Fragment>,
     pub(crate) preflight: AgentMaterialPreflight,
 }
 
@@ -49,6 +48,7 @@ pub(crate) enum AgentMaterialOutcome {
 trait AgentMaterialAdapter: Send + Sync {
     fn id(&self) -> &'static str;
     fn pool_ref(&self) -> &'static str;
+    fn fragment(&self, environment: &BTreeMap<String, String>) -> Option<Fragment>;
 
     async fn prepare(&self, holder_ref: &ResourceRef, environment: &BTreeMap<String, String>) -> Result<AgentMaterialOutcome, String>;
 }
@@ -94,6 +94,14 @@ impl AgentMaterialRegistry {
             }
         }
         Ok(deliveries)
+    }
+
+    pub(crate) fn fragments(&self, required_adapters: &BTreeSet<String>, environment: &BTreeMap<String, String>) -> Vec<Fragment> {
+        required_adapters
+            .iter()
+            .filter_map(|adapter_id| self.adapters.get(adapter_id.as_str()))
+            .filter_map(|adapter| adapter.fragment(environment))
+            .collect()
     }
 
     pub(crate) async fn release(&self, environment_ref: &str) -> Result<(), String> {
@@ -177,6 +185,11 @@ impl AgentMaterialAdapter for CodexMaterialAdapter {
         CODEX_POOL_REF
     }
 
+    fn fragment(&self, environment: &BTreeMap<String, String>) -> Option<Fragment> {
+        (!environment.contains_key("CODEX_HOME"))
+            .then(|| agent_environment_fragment("CODEX_HOME", CONTAINER_CODEX_HOME, format!("agent-material/codex {CODEX_POOL_REF}")))
+    }
+
     async fn prepare(&self, holder_ref: &ResourceRef, environment: &BTreeMap<String, String>) -> Result<AgentMaterialOutcome, String> {
         if environment.contains_key("CODEX_HOME") {
             return Ok(AgentMaterialOutcome::NotRequired);
@@ -190,11 +203,6 @@ impl AgentMaterialAdapter for CodexMaterialAdapter {
         match self.pools.acquire(CODEX_POOL_REF, holder_ref).await? {
             MaterialLeaseOutcome::Leased { unit, .. } => Ok(AgentMaterialOutcome::Ready(AgentMaterialDelivery {
                 mount: ProvisionedMount::new(PathBuf::from(&unit.directory), CONTAINER_CODEX_HOME, ProvisionedMountMode::Rw),
-                fragment: Box::new(agent_environment_fragment(
-                    "CODEX_HOME",
-                    CONTAINER_CODEX_HOME,
-                    format!("agent-material/codex {CODEX_POOL_REF}"),
-                )),
                 preflight: AgentMaterialPreflight {
                     command: "codex".to_string(),
                     args: vec!["login".to_string(), "status".to_string()],
@@ -264,9 +272,11 @@ mod tests {
 
         assert_eq!(deliveries.len(), 1);
         assert_eq!(deliveries[0].mount, ProvisionedMount::new(slot, CONTAINER_CODEX_HOME, ProvisionedMountMode::Rw));
-        let composed =
-            crate::vessel_config::compose(crate::vessel_config::TargetId::AgentEnvironment, [deliveries[0].fragment.as_ref().clone()])
-                .expect("compose Codex home");
+        let composed = crate::vessel_config::compose(
+            crate::vessel_config::TargetId::AgentEnvironment,
+            registry.fragments(&BTreeSet::from([CODEX_ADAPTER_ID.to_string()]), &BTreeMap::new()),
+        )
+        .expect("compose Codex home");
         assert_eq!(composed.environment, vec![("CODEX_HOME".to_string(), CONTAINER_CODEX_HOME.to_string())]);
         assert!(composed.contents.contains("# fragment: agent-material/codex codex-login"));
     }

--- a/crates/flotilla-daemon/src/agent_material.rs
+++ b/crates/flotilla-daemon/src/agent_material.rs
@@ -15,7 +15,10 @@ use flotilla_resources::{api_version, Environment, MaterialPoolSpec, MaterialPoo
 use tokio::fs;
 use tracing::warn;
 
-use crate::material_pool::{MaterialLeaseOutcome, MaterialPoolManager};
+use crate::{
+    material_pool::{MaterialLeaseOutcome, MaterialPoolManager},
+    vessel_config::{agent_environment_fragment, Fragment},
+};
 
 const CODEX_ADAPTER_ID: &str = "codex";
 const CODEX_POOL_REF: &str = "codex-login";
@@ -31,7 +34,7 @@ pub(crate) struct AgentMaterialPreflight {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AgentMaterialDelivery {
     pub(crate) mount: ProvisionedMount,
-    pub(crate) environment: Vec<(String, String)>,
+    pub(crate) fragment: Box<Fragment>,
     pub(crate) preflight: AgentMaterialPreflight,
 }
 
@@ -47,12 +50,7 @@ trait AgentMaterialAdapter: Send + Sync {
     fn id(&self) -> &'static str;
     fn pool_ref(&self) -> &'static str;
 
-    async fn prepare(
-        &self,
-        holder_ref: &ResourceRef,
-        environment: &BTreeMap<String, String>,
-        credential_adapters: &BTreeSet<String>,
-    ) -> Result<AgentMaterialOutcome, String>;
+    async fn prepare(&self, holder_ref: &ResourceRef, environment: &BTreeMap<String, String>) -> Result<AgentMaterialOutcome, String>;
 }
 
 pub(crate) struct AgentMaterialRegistry {
@@ -79,7 +77,6 @@ impl AgentMaterialRegistry {
         environment_ref: &str,
         required_adapters: &BTreeSet<String>,
         environment: &BTreeMap<String, String>,
-        credential_adapters: &BTreeSet<String>,
     ) -> Result<Vec<AgentMaterialDelivery>, AgentMaterialPrepareError> {
         let holder_ref = self.holder_ref(environment_ref);
         let mut deliveries = Vec::new();
@@ -87,7 +84,7 @@ impl AgentMaterialRegistry {
             let Some(adapter) = self.adapters.get(adapter_id.as_str()) else {
                 continue;
             };
-            match adapter.prepare(&holder_ref, environment, credential_adapters).await {
+            match adapter.prepare(&holder_ref, environment).await {
                 Ok(AgentMaterialOutcome::NotRequired) => {}
                 Ok(AgentMaterialOutcome::Ready(delivery)) => deliveries.push(delivery),
                 Ok(AgentMaterialOutcome::Waiting { pool_ref, message }) => {
@@ -180,13 +177,8 @@ impl AgentMaterialAdapter for CodexMaterialAdapter {
         CODEX_POOL_REF
     }
 
-    async fn prepare(
-        &self,
-        holder_ref: &ResourceRef,
-        environment: &BTreeMap<String, String>,
-        credential_adapters: &BTreeSet<String>,
-    ) -> Result<AgentMaterialOutcome, String> {
-        if credential_adapters.contains(CODEX_ADAPTER_ID) || environment.contains_key("CODEX_HOME") {
+    async fn prepare(&self, holder_ref: &ResourceRef, environment: &BTreeMap<String, String>) -> Result<AgentMaterialOutcome, String> {
+        if environment.contains_key("CODEX_HOME") {
             return Ok(AgentMaterialOutcome::NotRequired);
         }
         if !self.supported {
@@ -198,7 +190,11 @@ impl AgentMaterialAdapter for CodexMaterialAdapter {
         match self.pools.acquire(CODEX_POOL_REF, holder_ref).await? {
             MaterialLeaseOutcome::Leased { unit, .. } => Ok(AgentMaterialOutcome::Ready(AgentMaterialDelivery {
                 mount: ProvisionedMount::new(PathBuf::from(&unit.directory), CONTAINER_CODEX_HOME, ProvisionedMountMode::Rw),
-                environment: vec![("CODEX_HOME".to_string(), CONTAINER_CODEX_HOME.to_string())],
+                fragment: Box::new(agent_environment_fragment(
+                    "CODEX_HOME",
+                    CONTAINER_CODEX_HOME,
+                    format!("agent-material/codex {CODEX_POOL_REF}"),
+                )),
                 preflight: AgentMaterialPreflight {
                     command: "codex".to_string(),
                     args: vec!["login".to_string(), "status".to_string()],
@@ -263,14 +259,16 @@ mod tests {
         let slot = write_slot(&temp.path().join(".config/flotilla/credentials/codex-pool"), 0);
         let registry = registry(temp.path());
 
-        let deliveries = registry
-            .prepare("env-a", &BTreeSet::from([CODEX_ADAPTER_ID.to_string()]), &BTreeMap::new(), &BTreeSet::new())
-            .await
-            .expect("prepare");
+        let deliveries =
+            registry.prepare("env-a", &BTreeSet::from([CODEX_ADAPTER_ID.to_string()]), &BTreeMap::new()).await.expect("prepare");
 
         assert_eq!(deliveries.len(), 1);
         assert_eq!(deliveries[0].mount, ProvisionedMount::new(slot, CONTAINER_CODEX_HOME, ProvisionedMountMode::Rw));
-        assert_eq!(deliveries[0].environment, vec![("CODEX_HOME".to_string(), CONTAINER_CODEX_HOME.to_string())]);
+        let composed =
+            crate::vessel_config::compose(crate::vessel_config::TargetId::AgentEnvironment, [deliveries[0].fragment.as_ref().clone()])
+                .expect("compose Codex home");
+        assert_eq!(composed.environment, vec![("CODEX_HOME".to_string(), CONTAINER_CODEX_HOME.to_string())]);
+        assert!(composed.contents.contains("# fragment: agent-material/codex codex-login"));
     }
 
     #[tokio::test]
@@ -312,14 +310,14 @@ mod tests {
         let registry = registry(temp.path());
         let required = BTreeSet::from([CODEX_ADAPTER_ID.to_string()]);
 
-        registry.prepare("env-a", &required, &BTreeMap::new(), &BTreeSet::new()).await.expect("first lease");
+        registry.prepare("env-a", &required, &BTreeMap::new()).await.expect("first lease");
         assert!(matches!(
-            registry.prepare("env-b", &required, &BTreeMap::new(), &BTreeSet::new()).await,
+            registry.prepare("env-b", &required, &BTreeMap::new()).await,
             Err(AgentMaterialPrepareError::Waiting { pool_ref, .. }) if pool_ref == CODEX_POOL_REF
         ));
 
         let second = write_slot(&pool, 1);
-        let delivery = registry.prepare("env-b", &required, &BTreeMap::new(), &BTreeSet::new()).await.expect("lease new unit");
+        let delivery = registry.prepare("env-b", &required, &BTreeMap::new()).await.expect("lease new unit");
         assert_eq!(delivery[0].mount, ProvisionedMount::new(second, CONTAINER_CODEX_HOME, ProvisionedMountMode::Rw));
     }
 
@@ -332,24 +330,19 @@ mod tests {
         let registry = registry(temp.path());
 
         assert!(matches!(
-            registry.prepare("env-a", &BTreeSet::from([CODEX_ADAPTER_ID.to_string()]), &BTreeMap::new(), &BTreeSet::new(),).await,
+            registry.prepare("env-a", &BTreeSet::from([CODEX_ADAPTER_ID.to_string()]), &BTreeMap::new()).await,
             Err(AgentMaterialPrepareError::Waiting { .. })
         ));
     }
 
     #[tokio::test]
-    async fn codex_adapter_defers_to_explicit_credentials_or_an_existing_codex_home() {
+    async fn codex_adapter_defers_to_an_existing_codex_home() {
         let temp = tempfile::tempdir().expect("tempdir");
         let registry = registry(temp.path());
         let required = BTreeSet::from([CODEX_ADAPTER_ID.to_string()]);
 
         assert!(registry
-            .prepare("env-credential", &required, &BTreeMap::new(), &BTreeSet::from([CODEX_ADAPTER_ID.to_string()]),)
-            .await
-            .expect("explicit credential")
-            .is_empty());
-        assert!(registry
-            .prepare("env-home", &required, &BTreeMap::from([("CODEX_HOME".to_string(), "/image/codex".to_string())]), &BTreeSet::new(),)
+            .prepare("env-home", &required, &BTreeMap::from([("CODEX_HOME".to_string(), "/image/codex".to_string())]))
             .await
             .expect("existing home")
             .is_empty());

--- a/crates/flotilla-daemon/src/credential.rs
+++ b/crates/flotilla-daemon/src/credential.rs
@@ -157,7 +157,14 @@ impl CredentialStore {
         }
     }
 
-    pub(crate) async fn vessel_config_fragments(&self, credential_refs: &BTreeSet<String>) -> Result<Vec<Fragment>, String> {
+    pub(crate) async fn vessel_config_fragments(
+        &self,
+        credential_refs: &BTreeSet<String>,
+        environment: &BTreeMap<String, String>,
+    ) -> Result<Vec<Fragment>, String> {
+        if environment.contains_key("CODEX_HOME") {
+            return Ok(Vec::new());
+        }
         let mut fragments = Vec::new();
         for name in credential_refs {
             let spec = self.spec(name).await?;
@@ -1016,9 +1023,16 @@ interactions:
         let runner = Arc::new(RecordingRunner::default());
         let bag = EnvironmentBag::new().with(EnvironmentAssertion::binary("codex", "/usr/bin/codex"));
         let store = CredentialStore::new(backend, "flotilla", env, bag, runner.clone(), PathBuf::from("/tmp/flotilla-test-state"));
+        let credential_refs = BTreeSet::from(["model-api".to_string()]);
 
-        let delivered =
-            store.prepare("env-a", &BTreeSet::from(["model-api".to_string()]), runner.clone()).await.expect("prepare codex credential");
+        assert_eq!(store.vessel_config_fragments(&credential_refs, &BTreeMap::new()).await.expect("Codex fragment").len(), 1);
+        assert!(store
+            .vessel_config_fragments(&credential_refs, &BTreeMap::from([("CODEX_HOME".to_string(), "/image/codex".to_string())]),)
+            .await
+            .expect("explicit Codex home")
+            .is_empty());
+
+        let delivered = store.prepare("env-a", &credential_refs, runner.clone()).await.expect("prepare codex credential");
 
         assert_eq!(delivered.len(), 1);
         assert_eq!(delivered[0].0, "CODEX_HOME");

--- a/crates/flotilla-daemon/src/credential.rs
+++ b/crates/flotilla-daemon/src/credential.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use url::Url;
 
-use crate::vessel_config::{compose, Fragment, GitConfigKey, Merge, Provenance, TargetId, TargetKey};
+use crate::vessel_config::{agent_environment_fragment, compose, Fragment, GitConfigKey, Merge, Provenance, TargetId, TargetKey};
 
 const GIT_CONFIG_PATH: &str = "/run/flotilla/credentials/gitconfig";
 
@@ -157,12 +157,15 @@ impl CredentialStore {
         }
     }
 
-    pub(crate) async fn consumer_adapters(&self, credential_refs: &BTreeSet<String>) -> Result<BTreeSet<String>, String> {
-        let mut adapters = BTreeSet::new();
+    pub(crate) async fn vessel_config_fragments(&self, credential_refs: &BTreeSet<String>) -> Result<Vec<Fragment>, String> {
+        let mut fragments = Vec::new();
         for name in credential_refs {
-            adapters.insert(self.spec(name).await?.consumer.adapter_name().to_string());
+            let spec = self.spec(name).await?;
+            if matches!(spec.consumer, CredentialConsumer::Codex) {
+                fragments.push(codex_home_fragment(name));
+            }
         }
-        Ok(adapters)
+        Ok(fragments)
     }
 
     pub(crate) async fn held_credentials(&self) -> Result<BTreeSet<String>, String> {
@@ -666,7 +669,8 @@ impl CredentialStore {
                 env.insert("ANTHROPIC_API_KEY".to_string(), material.to_string());
             }
             CredentialConsumer::Codex => {
-                let codex_home = format!("/run/flotilla/credentials/{}/codex", safe_component(name));
+                let codex_home_fragment = codex_home_fragment(name);
+                let codex_home = codex_home_fragment.value;
                 if !already_prepared {
                     runner
                         .run("mkdir", &["-p", &codex_home], Path::new("/"), &ChannelLabel::Noop)
@@ -713,6 +717,14 @@ fn git_credential_fragment(credential_name: &str, adapter: &str, credential_url:
         .merge(Merge::Append)
         .provenance(Provenance::new(format!("credential/{adapter} {credential_name}")))
         .build()
+}
+
+fn codex_home_fragment(credential_name: &str) -> Fragment {
+    agent_environment_fragment(
+        "CODEX_HOME",
+        format!("/run/flotilla/credentials/{}/codex", safe_component(credential_name)),
+        format!("credential/codex {credential_name}"),
+    )
 }
 
 async fn api_key_preflight(runner: &dyn CommandRunner, url: &str, headers: &[(&str, &str)]) -> Result<(), String> {

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -1755,7 +1755,7 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
             .map(|(name, value)| (name.clone(), value.clone()))
             .collect::<Vec<_>>();
         let credential_config_fragments = match &self.state.credential_store {
-            Some(store) => match store.vessel_config_fragments(&credential_refs).await {
+            Some(store) => match store.vessel_config_fragments(&credential_refs, &spec.env).await {
                 Ok(fragments) => fragments,
                 Err(error) => {
                     return Err(discard_uncreated_environment(

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -59,6 +59,7 @@ use crate::{
     resource_manifest::ResourceManifestReconciler,
     sleep_inhibitor,
     supervisor::{supervise, ControllerSupervision, RestartBudgetExhausted},
+    vessel_config::{compose, ComposedFile, Fragment, TargetId, AGENT_ENVIRONMENT_PATH},
     Aggregator, AggregatorResolvers,
 };
 
@@ -70,6 +71,14 @@ const MANIFEST_RECONCILE_INTERVAL: Duration = Duration::from_secs(5);
 const DEFAULT_DOCKER_IMAGE: &str = "ubuntu:24.04";
 const DEFAULT_REPO_DIR_SUFFIX: &str = "dev/flotilla-repos";
 const BUILTIN_MANAGED_BY_VALUE: &str = "builtin";
+
+fn compose_agent_environment(fragments: impl IntoIterator<Item = Fragment>) -> Result<Option<ComposedFile>, String> {
+    let fragments = fragments.into_iter().collect::<Vec<_>>();
+    if fragments.is_empty() {
+        return Ok(None);
+    }
+    compose(TargetId::AgentEnvironment, fragments).map(Some).map_err(|error| format!("compose shared agent environment: {error}"))
+}
 
 struct DaemonConvoyTeardownRuntime {
     daemon: Arc<InProcessDaemon>,
@@ -1745,9 +1754,9 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
             .filter(|(name, _)| !matches!(name.as_str(), CREDENTIAL_REFS_ENV | CREDENTIAL_SCOPES_ENV))
             .map(|(name, value)| (name.clone(), value.clone()))
             .collect::<Vec<_>>();
-        let credential_adapters = match &self.state.credential_store {
-            Some(store) => match store.consumer_adapters(&credential_refs).await {
-                Ok(adapters) => adapters,
+        let credential_config_fragments = match &self.state.credential_store {
+            Some(store) => match store.vessel_config_fragments(&credential_refs).await {
+                Ok(fragments) => fragments,
                 Err(error) => {
                     return Err(discard_uncreated_environment(
                         self.state.credential_store.as_deref(),
@@ -1759,11 +1768,11 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
                     .into())
                 }
             },
-            None if credential_refs.is_empty() => BTreeSet::new(),
+            None if credential_refs.is_empty() => Vec::new(),
             None => return Err("host-local credential store unavailable".to_string().into()),
         };
         let material_deliveries = match &self.state.agent_material {
-            Some(registry) => match registry.prepare(name, &spec.required_agent_adapters, &spec.env, &credential_adapters).await {
+            Some(registry) => match registry.prepare(name, &spec.required_agent_adapters, &spec.env).await {
                 Ok(deliveries) => deliveries,
                 Err(AgentMaterialPrepareError::Waiting { pool_ref, message }) => {
                     let message = discard_uncreated_environment(
@@ -1791,6 +1800,28 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
             },
             None => Vec::new(),
         };
+        let agent_environment = match compose_agent_environment(
+            credential_config_fragments.into_iter().chain(material_deliveries.iter().map(|delivery| delivery.fragment.as_ref().clone())),
+        ) {
+            Ok(composed) => composed,
+            Err(error) => {
+                return Err(discard_uncreated_environment(
+                    self.state.credential_store.as_deref(),
+                    self.state.agent_material.as_deref(),
+                    name,
+                    error,
+                )
+                .await
+                .into())
+            }
+        };
+        if let Some(composed) = &agent_environment {
+            for (name, value) in &composed.environment {
+                if !environment_variables.iter().any(|(existing, _)| existing == name) {
+                    environment_variables.push((name.clone(), value.clone()));
+                }
+            }
+        }
         let docker_config_dir = match &self.state.credential_store {
             Some(store) => match store.prepare_registry_pull(name, &credential_refs, &spec.image).await {
                 Ok(config) => config.map(DaemonHostPath::new),
@@ -1812,7 +1843,6 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
         provisioned_mounts.extend(spec.mounts.iter().map(flotilla_controllers::actuators::provisioned_mount));
         for delivery in &material_deliveries {
             provisioned_mounts.push(delivery.mount.clone());
-            environment_variables.extend(delivery.environment.clone());
         }
         let handle = match provider
             .create(env_id.clone(), &image, CreateOpts {
@@ -1836,6 +1866,19 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
             }
         };
         let image_ref = handle.image().as_str().to_string();
+        if let Some(composed) = &agent_environment {
+            if let Err(error) = handle.runner().write_file(Path::new(AGENT_ENVIRONMENT_PATH), &composed.contents).await {
+                return Err(discard_failed_environment(
+                    &handle,
+                    self.state.credential_store.as_deref(),
+                    self.state.agent_material.as_deref(),
+                    name,
+                    format!("stage composed agent environment: {error}"),
+                )
+                .await
+                .into());
+            }
+        }
         let image_digest = match handle.image_digest() {
             Some(digest) => digest.to_string(),
             None => {
@@ -3645,6 +3688,93 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn codex_credential_and_agent_material_conflict_before_container_creation() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().expect("tempdir");
+        let config_base = temp.path().join("config");
+        fs::create_dir_all(&config_base).expect("config directory");
+        fs::write(config_base.join("daemon.toml"), "machine_id = \"codex-material-conflict-test\"\n").expect("daemon config");
+        let home = temp.path().join("home");
+        let slot = home.join(".config/flotilla/credentials/codex-pool/slot-0");
+        fs::create_dir_all(&slot).expect("slot directory");
+        let auth = slot.join("auth.json");
+        fs::write(&auth, "{\"tokens\":\"test\"}").expect("slot auth");
+        fs::set_permissions(&auth, fs::Permissions::from_mode(0o600)).expect("protect slot auth");
+        let config = Arc::new(ConfigStore::with_base(config_base));
+        let discovery = fake_discovery_with_provider_set(FakeDiscoveryProviders::new());
+        let daemon = InProcessDaemon::new(Vec::new(), Arc::clone(&config), discovery, flotilla_protocol::HostName::new("dinghy")).await;
+        daemon
+            .resource_backend()
+            .definitions::<CredentialSpec>(NAMESPACE)
+            .create(&InputMeta::builder().name("openai".to_string()).build(), &CredentialSpecSpec {
+                consumer: CredentialConsumer::Codex,
+                source: CredentialSource::Env { name: "TEST_CODEX_TOKEN".to_string() },
+                lifecycle: CredentialLifecycle::Static,
+                placement: CredentialPlacementRequirements::default(),
+            })
+            .await
+            .expect("create Codex credential");
+        let provider = Arc::new(CapturingFailingEnvironmentProvider { create_opts: Mutex::new(None) });
+        let mut local_registry = ProviderRegistry::new();
+        local_registry.environment_providers.insert(
+            "docker",
+            flotilla_core::providers::discovery::ProviderDescriptor::named(
+                flotilla_core::providers::discovery::ProviderCategory::EnvironmentProvider,
+                "docker",
+            ),
+            Arc::clone(&provider) as Arc<dyn EnvironmentProvider>,
+        );
+        let env = Arc::new(TestEnvVars::new([("HOME", home.display().to_string()), ("TEST_CODEX_TOKEN", "secret".to_string())]));
+        let credential_store = Arc::new(CredentialStore::new(
+            daemon.resource_backend(),
+            NAMESPACE,
+            env.clone(),
+            EnvironmentBag::new(),
+            Arc::new(ProcessCommandRunner),
+            config.state_dir().as_path().to_path_buf(),
+        ));
+        let agent_material = Arc::new(AgentMaterialRegistry::new(daemon.resource_backend(), NAMESPACE, env));
+        let state = Arc::new(
+            ControllerRuntimeState::new(
+                daemon,
+                Arc::clone(&config),
+                Arc::new(local_registry),
+                Some(DaemonHostPath::new("/tmp/flotilla.sock")),
+                "host-test".to_string(),
+                None,
+                "host-direct-host-test".to_string(),
+            )
+            .with_environment_tools(fixed_environment_tools(config.state_dir().join("contained-cleat").as_path().to_path_buf()))
+            .with_credential_store(credential_store)
+            .with_agent_material(agent_material),
+        );
+        let spec = flotilla_resources::DockerEnvironmentSpec {
+            host_ref: "host-test".to_string(),
+            image: "contained-image".to_string(),
+            declared_agent_adapters: BTreeSet::from(["codex".to_string()]),
+            required_agent_adapters: BTreeSet::from(["codex".to_string()]),
+            pull_policy: Default::default(),
+            mounts: Vec::new(),
+            env: BTreeMap::from([(
+                CREDENTIAL_REFS_ENV.to_string(),
+                serde_json::to_string(&BTreeSet::from(["openai".to_string()])).expect("encode credential refs"),
+            )]),
+        };
+
+        let error = DockerControllerRuntime { state }
+            .provision("contained-work", &spec)
+            .await
+            .expect_err("two Codex-home contributors must conflict")
+            .to_string();
+
+        assert!(error.contains("CODEX_HOME"), "error must name the target key: {error}");
+        assert!(error.contains("agent-material/codex codex-login"), "error must name agent material: {error}");
+        assert!(error.contains("credential/codex openai"), "error must name the credential: {error}");
+        assert!(provider.create_opts.lock().await.is_none(), "conflicting config must fail before creating a container");
+    }
+
+    #[tokio::test]
     async fn material_pool_wait_skips_registry_preflight_and_leaves_no_credential_cache() {
         use std::os::unix::fs::PermissionsExt;
 
@@ -3697,7 +3827,7 @@ mod tests {
             Arc::new(TestEnvVars::new([("HOME", home.display().to_string())])),
         ));
         agent_material
-            .prepare("slot-holder", &BTreeSet::from(["codex".to_string()]), &BTreeMap::new(), &BTreeSet::new())
+            .prepare("slot-holder", &BTreeSet::from(["codex".to_string()]), &BTreeMap::new())
             .await
             .expect("occupy only material unit");
         let state = Arc::new(

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -1771,6 +1771,32 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
             None if credential_refs.is_empty() => Vec::new(),
             None => return Err("host-local credential store unavailable".to_string().into()),
         };
+        let agent_material_fragments = self
+            .state
+            .agent_material
+            .as_deref()
+            .map(|registry| registry.fragments(&spec.required_agent_adapters, &spec.env))
+            .unwrap_or_default();
+        let agent_environment = match compose_agent_environment(credential_config_fragments.into_iter().chain(agent_material_fragments)) {
+            Ok(composed) => composed,
+            Err(error) => {
+                return Err(discard_uncreated_environment(
+                    self.state.credential_store.as_deref(),
+                    self.state.agent_material.as_deref(),
+                    name,
+                    error,
+                )
+                .await
+                .into())
+            }
+        };
+        if let Some(composed) = &agent_environment {
+            for (name, value) in &composed.environment {
+                if !environment_variables.iter().any(|(existing, _)| existing == name) {
+                    environment_variables.push((name.clone(), value.clone()));
+                }
+            }
+        }
         let material_deliveries = match &self.state.agent_material {
             Some(registry) => match registry.prepare(name, &spec.required_agent_adapters, &spec.env).await {
                 Ok(deliveries) => deliveries,
@@ -1800,28 +1826,6 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
             },
             None => Vec::new(),
         };
-        let agent_environment = match compose_agent_environment(
-            credential_config_fragments.into_iter().chain(material_deliveries.iter().map(|delivery| delivery.fragment.as_ref().clone())),
-        ) {
-            Ok(composed) => composed,
-            Err(error) => {
-                return Err(discard_uncreated_environment(
-                    self.state.credential_store.as_deref(),
-                    self.state.agent_material.as_deref(),
-                    name,
-                    error,
-                )
-                .await
-                .into())
-            }
-        };
-        if let Some(composed) = &agent_environment {
-            for (name, value) in &composed.environment {
-                if !environment_variables.iter().any(|(existing, _)| existing == name) {
-                    environment_variables.push((name.clone(), value.clone()));
-                }
-            }
-        }
         let docker_config_dir = match &self.state.credential_store {
             Some(store) => match store.prepare_registry_pull(name, &credential_refs, &spec.image).await {
                 Ok(config) => config.map(DaemonHostPath::new),

--- a/crates/flotilla-daemon/src/vessel_config.rs
+++ b/crates/flotilla-daemon/src/vessel_config.rs
@@ -1,5 +1,7 @@
 use std::{collections::BTreeMap, fmt};
 
+pub const AGENT_ENVIRONMENT_PATH: &str = "/run/flotilla/agent-environment";
+
 pub mod order {
     pub const FIRST: u16 = 0;
     pub const EARLY: u16 = 500;
@@ -16,12 +18,14 @@ pub mod priority {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TargetId {
     GitConfig,
+    AgentEnvironment,
 }
 
 impl fmt::Display for TargetId {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::GitConfig => formatter.write_str("gitconfig"),
+            Self::AgentEnvironment => formatter.write_str("agent-environment"),
         }
     }
 }
@@ -29,13 +33,36 @@ impl fmt::Display for TargetId {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TargetKey {
     GitConfig(GitConfigKey),
+    AgentEnvironment(AgentEnvironmentKey),
 }
 
 impl fmt::Display for TargetKey {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::GitConfig(key) => key.fmt(formatter),
+            Self::AgentEnvironment(key) => key.fmt(formatter),
         }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AgentEnvironmentKey(String);
+
+impl AgentEnvironmentKey {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+
+    fn is_valid(&self) -> bool {
+        let mut characters = self.0.chars();
+        characters.next().is_some_and(|character| character == '_' || character.is_ascii_alphabetic())
+            && characters.all(|character| character == '_' || character.is_ascii_alphanumeric())
+    }
+}
+
+impl fmt::Display for AgentEnvironmentKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
     }
 }
 
@@ -112,10 +139,20 @@ pub struct Fragment {
     pub provenance: Provenance,
 }
 
+pub fn agent_environment_fragment(name: impl Into<String>, value: impl Into<String>, provenance: impl Into<String>) -> Fragment {
+    Fragment::builder()
+        .target(TargetId::AgentEnvironment)
+        .key(TargetKey::AgentEnvironment(AgentEnvironmentKey::new(name)))
+        .value(value)
+        .provenance(Provenance::new(provenance))
+        .build()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ComposedFile {
     pub target: TargetId,
     pub contents: String,
+    pub environment: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -127,6 +164,7 @@ pub enum ComposeError {
     SetConflict { key: TargetKey, first: Provenance, second: Provenance },
     MergePolicyConflict { key: TargetKey, first: Provenance, second: Provenance },
     Duplicate { key: TargetKey, first: Provenance, second: Provenance },
+    UnsupportedAppend { key: TargetKey, provenance: Provenance },
 }
 
 impl fmt::Display for ComposeError {
@@ -153,6 +191,9 @@ impl fmt::Display for ComposeError {
             Self::Duplicate { key, first, second } => {
                 write!(formatter, "duplicate fragments from `{first}` and `{second}` are forbidden for key `{key}`")
             }
+            Self::UnsupportedAppend { key, provenance } => {
+                write!(formatter, "fragment from `{provenance}` cannot append single-valued agent environment key `{key}`")
+            }
         }
     }
 }
@@ -168,6 +209,7 @@ pub fn compose(target: TargetId, fragments: impl IntoIterator<Item = Fragment>) 
 
     match target {
         TargetId::GitConfig => compose_gitconfig(fragments),
+        TargetId::AgentEnvironment => compose_agent_environment(fragments),
     }
 }
 
@@ -179,12 +221,66 @@ fn compose_gitconfig(fragments: Vec<Fragment>) -> Result<ComposedFile, ComposeEr
                     return Err(ComposeError::InvalidKey { provenance: fragment.provenance.clone() });
                 }
             }
+            TargetKey::AgentEnvironment(_) => {
+                return Err(ComposeError::TargetKeyMismatch {
+                    target: TargetId::GitConfig,
+                    key: fragment.key.clone(),
+                    provenance: fragment.provenance.clone(),
+                });
+            }
         }
         if fragment.value.contains(['\r', '\n']) {
             return Err(ComposeError::InvalidValue { key: fragment.key.clone(), provenance: fragment.provenance.clone() });
         }
     }
 
+    let rendered = resolve_fragments(&fragments, true)?;
+
+    let contents = rendered.into_iter().map(render_gitconfig_entry).collect::<Vec<_>>().join("\n");
+    Ok(ComposedFile { target: TargetId::GitConfig, contents, environment: Vec::new() })
+}
+
+fn compose_agent_environment(fragments: Vec<Fragment>) -> Result<ComposedFile, ComposeError> {
+    for fragment in &fragments {
+        match &fragment.key {
+            TargetKey::AgentEnvironment(key) if key.is_valid() => {}
+            TargetKey::AgentEnvironment(_) => {
+                return Err(ComposeError::InvalidKey { provenance: fragment.provenance.clone() });
+            }
+            TargetKey::GitConfig(_) => {
+                return Err(ComposeError::TargetKeyMismatch {
+                    target: TargetId::AgentEnvironment,
+                    key: fragment.key.clone(),
+                    provenance: fragment.provenance.clone(),
+                });
+            }
+        }
+        if fragment.value.contains(['\0', '\r', '\n']) {
+            return Err(ComposeError::InvalidValue { key: fragment.key.clone(), provenance: fragment.provenance.clone() });
+        }
+    }
+
+    let rendered = resolve_fragments(&fragments, false)?;
+    let contents = rendered
+        .iter()
+        .map(|entry| {
+            let TargetKey::AgentEnvironment(key) = &entry.fragment.key else { unreachable!("target key validated above") };
+            let comments = entry.provenances.iter().map(|provenance| format!("# fragment: {provenance}\n")).collect::<String>();
+            format!("{comments}{key}={}\n", shell_quote(&entry.fragment.value))
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let environment = rendered
+        .into_iter()
+        .map(|entry| {
+            let TargetKey::AgentEnvironment(key) = &entry.fragment.key else { unreachable!("target key validated above") };
+            (key.0.clone(), entry.fragment.value.clone())
+        })
+        .collect();
+    Ok(ComposedFile { target: TargetId::AgentEnvironment, contents, environment })
+}
+
+fn resolve_fragments(fragments: &[Fragment], append_supported: bool) -> Result<Vec<RenderedEntry<'_>>, ComposeError> {
     let minimum_priorities = fragments.iter().fold(BTreeMap::<TargetKey, u16>::new(), |mut priorities, fragment| {
         priorities
             .entry(fragment.key.clone())
@@ -193,7 +289,7 @@ fn compose_gitconfig(fragments: Vec<Fragment>) -> Result<ComposedFile, ComposeEr
         priorities
     });
     let mut winners = BTreeMap::<TargetKey, Vec<&Fragment>>::new();
-    for fragment in &fragments {
+    for fragment in fragments {
         if minimum_priorities.get(&fragment.key) == Some(&fragment.priority) {
             winners.entry(fragment.key.clone()).or_default().push(fragment);
         }
@@ -218,14 +314,18 @@ fn compose_gitconfig(fragments: Vec<Fragment>) -> Result<ComposedFile, ComposeEr
                         second: other.provenance.clone(),
                     });
                 }
-                rendered.push(RenderedGitConfigEntry {
+                rendered.push(RenderedEntry {
                     fragment: first,
                     provenances: fragments_for_key.iter().map(|fragment| &fragment.provenance).collect(),
                 });
             }
-            Merge::Append => rendered.extend(
-                fragments_for_key.iter().map(|fragment| RenderedGitConfigEntry { fragment, provenances: vec![&fragment.provenance] }),
-            ),
+            Merge::Append if append_supported => {
+                rendered
+                    .extend(fragments_for_key.iter().map(|fragment| RenderedEntry { fragment, provenances: vec![&fragment.provenance] }));
+            }
+            Merge::Append => {
+                return Err(ComposeError::UnsupportedAppend { key: first.key.clone(), provenance: first.provenance.clone() });
+            }
             Merge::ErrorOnDuplicate => {
                 if let Some(other) = fragments_for_key.get(1) {
                     return Err(ComposeError::Duplicate {
@@ -234,24 +334,26 @@ fn compose_gitconfig(fragments: Vec<Fragment>) -> Result<ComposedFile, ComposeEr
                         second: other.provenance.clone(),
                     });
                 }
-                rendered.push(RenderedGitConfigEntry { fragment: first, provenances: vec![&first.provenance] });
+                rendered.push(RenderedEntry { fragment: first, provenances: vec![&first.provenance] });
             }
         }
     }
     rendered
         .sort_by(|left, right| (left.fragment.order, &left.fragment.provenance).cmp(&(right.fragment.order, &right.fragment.provenance)));
-
-    let contents = rendered.into_iter().map(render_gitconfig_entry).collect::<Vec<_>>().join("\n");
-    Ok(ComposedFile { target: TargetId::GitConfig, contents })
+    Ok(rendered)
 }
 
-struct RenderedGitConfigEntry<'a> {
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+struct RenderedEntry<'a> {
     fragment: &'a Fragment,
     provenances: Vec<&'a Provenance>,
 }
 
-fn render_gitconfig_entry(entry: RenderedGitConfigEntry<'_>) -> String {
-    let TargetKey::GitConfig(key) = &entry.fragment.key;
+fn render_gitconfig_entry(entry: RenderedEntry<'_>) -> String {
+    let TargetKey::GitConfig(key) = &entry.fragment.key else { unreachable!("target key validated before rendering") };
     let comments = entry.provenances.into_iter().map(|provenance| format!("# fragment: {provenance}\n")).collect::<String>();
     let section = match &key.subsection {
         Some(subsection) => format!("[{} \"{}\"]", key.section, escape_gitconfig_subsection(subsection)),
@@ -296,6 +398,33 @@ mod tests {
         assert!(error.contains("user.email"), "error must name the key: {error}");
         assert!(error.contains("credential/first"), "error must name the first contributor: {error}");
         assert!(error.contains("credential/second"), "error must name the second contributor: {error}");
+    }
+
+    #[test]
+    fn agent_environment_renders_provenance_and_single_valued_delivery() {
+        let composed = compose(TargetId::AgentEnvironment, [agent_environment_fragment(
+            "CODEX_HOME",
+            "/run/flotilla/codex",
+            "agent-material/codex codex-login",
+        )])
+        .expect("agent environment should compose");
+
+        assert_eq!(composed.contents, "# fragment: agent-material/codex codex-login\nCODEX_HOME='/run/flotilla/codex'\n");
+        assert_eq!(composed.environment, [("CODEX_HOME".to_string(), "/run/flotilla/codex".to_string())]);
+    }
+
+    #[test]
+    fn credential_and_agent_material_conflict_names_both_contributors() {
+        let error = compose(TargetId::AgentEnvironment, [
+            agent_environment_fragment("CODEX_HOME", "/run/flotilla/codex", "agent-material/codex codex-login"),
+            agent_environment_fragment("CODEX_HOME", "/run/flotilla/credentials/openai/codex", "credential/codex openai"),
+        ])
+        .expect_err("two Codex homes must conflict")
+        .to_string();
+
+        assert!(error.contains("CODEX_HOME"), "error must name the key: {error}");
+        assert!(error.contains("agent-material/codex codex-login"), "error must name agent material: {error}");
+        assert!(error.contains("credential/codex openai"), "error must name the credential: {error}");
     }
 
     #[test]

--- a/crates/flotilla-daemon/src/vessel_config.rs
+++ b/crates/flotilla-daemon/src/vessel_config.rs
@@ -266,7 +266,7 @@ fn compose_agent_environment(fragments: Vec<Fragment>) -> Result<ComposedFile, C
         .map(|entry| {
             let TargetKey::AgentEnvironment(key) = &entry.fragment.key else { unreachable!("target key validated above") };
             let comments = entry.provenances.iter().map(|provenance| format!("# fragment: {provenance}\n")).collect::<String>();
-            format!("{comments}{key}={}\n", shell_quote(&entry.fragment.value))
+            format!("{comments}export {key}={}\n", shell_quote(&entry.fragment.value))
         })
         .collect::<Vec<_>>()
         .join("\n");
@@ -409,7 +409,7 @@ mod tests {
         )])
         .expect("agent environment should compose");
 
-        assert_eq!(composed.contents, "# fragment: agent-material/codex codex-login\nCODEX_HOME='/run/flotilla/codex'\n");
+        assert_eq!(composed.contents, "# fragment: agent-material/codex codex-login\nexport CODEX_HOME='/run/flotilla/codex'\n");
         assert_eq!(composed.environment, [("CODEX_HOME".to_string(), "/run/flotilla/codex".to_string())]);
     }
 
@@ -425,6 +425,38 @@ mod tests {
         assert!(error.contains("CODEX_HOME"), "error must name the key: {error}");
         assert!(error.contains("agent-material/codex codex-login"), "error must name agent material: {error}");
         assert!(error.contains("credential/codex openai"), "error must name the credential: {error}");
+    }
+
+    #[test]
+    fn agent_environment_rejects_invalid_names_and_values() {
+        let invalid_name =
+            compose(TargetId::AgentEnvironment, [agent_environment_fragment("CODEX-HOME", "/run/flotilla/codex", "agent-material/codex")])
+                .expect_err("environment names must be shell identifiers")
+                .to_string();
+        assert!(invalid_name.contains("agent-material/codex"));
+
+        let invalid_value = compose(TargetId::AgentEnvironment, [agent_environment_fragment(
+            "CODEX_HOME",
+            "/run/flotilla/codex\0injected",
+            "agent-material/codex",
+        )])
+        .expect_err("environment values must not contain NUL")
+        .to_string();
+        assert!(invalid_value.contains("CODEX_HOME"));
+        assert!(invalid_value.contains("agent-material/codex"));
+    }
+
+    #[test]
+    fn agent_environment_rejects_append_for_single_valued_keys() {
+        let mut fragment = agent_environment_fragment("CODEX_HOME", "/run/flotilla/codex", "agent-material/codex");
+        fragment.merge = Merge::Append;
+
+        let error =
+            compose(TargetId::AgentEnvironment, [fragment]).expect_err("agent environment values must stay single-valued").to_string();
+
+        assert!(error.contains("cannot append"));
+        assert!(error.contains("CODEX_HOME"));
+        assert!(error.contains("agent-material/codex"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #1378

## Summary

- add an agent-environment target to `vessel_config`, with typed environment keys, provenance rendering, single-valued delivery, and the shared priority/merge resolver
- migrate Codex login-pool material to emit a `CODEX_HOME` fragment while preserving its writable mount and login-status preflight
- make Codex credential adapters emit the same target so credential and leased material conflicts fail before container creation and name both contributors
- stage the composed, provenance-commented agent environment inside the vessel while passing its resolved values through the existing environment delivery path

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`