### PR TITLE
feat: materialize project ops entries

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -87,7 +87,7 @@ use crate::{
     model::{provider_names_from_registry, repo_name, RepoModel},
     ops_entry::{
         parse_operational_entry, OperationalEntryDefinition, MATERIALIZED_PROJECT_ANNOTATION, SOURCE_COMMIT_ANNOTATION,
-        SOURCE_ENTRY_PATH_ANNOTATION, SOURCE_REPOSITORY_ANNOTATION, VERIFICATION_PROVENANCE_ANNOTATION,
+        SOURCE_ENTRY_PATH_ANNOTATION, SOURCE_REPOSITORY_ANNOTATION, VERIFICATION_PROJECT_ANNOTATION, VERIFICATION_PROVENANCE_ANNOTATION,
     },
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     placement_policy::reconcile_registered_policy,
@@ -5178,12 +5178,12 @@ impl InProcessDaemon {
                 Err(ResourceError::NotFound { .. }) => None,
                 Err(error) => return Err(error.to_string()),
             };
-            if let Some(owner) = current
-                .as_ref()
-                .and_then(|current| current.metadata.annotations.get(MATERIALIZED_PROJECT_ANNOTATION))
-                .filter(|owner| owner.as_str() != project_name)
-            {
-                return Err(format!("WorkflowTemplate `{name}` is materialized by project `{owner}`"));
+            if let Some(current) = &current {
+                match current.metadata.annotations.get(MATERIALIZED_PROJECT_ANNOTATION) {
+                    Some(owner) if owner == project_name => {}
+                    Some(owner) => return Err(format!("WorkflowTemplate `{name}` is materialized by project `{owner}`")),
+                    None => return Err(format!("WorkflowTemplate `{name}` already exists and is not materialized by a project")),
+                }
             }
             if current.as_ref().is_none_or(|current| current.spec != *spec || current.metadata.annotations != meta.annotations) {
                 match current {
@@ -5209,16 +5209,33 @@ impl InProcessDaemon {
         for member in project.spec.repositories.iter().filter(|member| member.roles.contains(&ProjectRepositoryRole::Code)) {
             let current = repositories.get(&member.repo.to_string()).await.map_err(|error| error.to_string())?;
             let desired_commands = commands.remove(&member.repo).unwrap_or_default();
+            let owner = current.metadata.annotations.get(VERIFICATION_PROJECT_ANNOTATION).map(String::as_str);
+            match owner {
+                Some(owner) if owner == project_name => {}
+                Some(owner) if !desired_commands.is_empty() => {
+                    return Err(format!("Repository {} verification commands are materialized by project `{owner}`", member.repo));
+                }
+                None if !desired_commands.is_empty() && !current.spec.verification_commands().is_empty() => {
+                    return Err(format!(
+                        "Repository {} already has verification commands that are not materialized by a project",
+                        member.repo
+                    ));
+                }
+                None if !desired_commands.is_empty() => {}
+                _ => continue,
+            }
             let desired_spec = current.spec.clone().with_verification_commands(desired_commands);
             let mut meta = InputMeta::from(&current.metadata);
             match command_provenance.remove(&member.repo) {
                 Some(provenance) => {
+                    meta.annotations.insert(VERIFICATION_PROJECT_ANNOTATION.to_string(), project_name.to_string());
                     meta.annotations.insert(
                         VERIFICATION_PROVENANCE_ANNOTATION.to_string(),
                         serde_json::to_string(&provenance).expect("JSON provenance values serialize"),
                     );
                 }
                 None => {
+                    meta.annotations.remove(VERIFICATION_PROJECT_ANNOTATION);
                     meta.annotations.remove(VERIFICATION_PROVENANCE_ANNOTATION);
                 }
             }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -5282,11 +5282,22 @@ impl InProcessDaemon {
             let Some(entry) = parse_operational_entry(&file.contents).map_err(|error| format!("{}: {error}", file.path))? else {
                 continue;
             };
+            let is_verification_command = matches!(&entry.definition, OperationalEntryDefinition::VerificationCommand { .. });
             let targets = match entry.repos {
                 Some(repo_aliases) => repo_aliases
                     .into_iter()
                     .map(|alias| {
-                        aliases.get(&alias).cloned().ok_or_else(|| format!("{} names unknown repository alias `{alias}`", file.path))
+                        let target = aliases
+                            .get(&alias)
+                            .cloned()
+                            .ok_or_else(|| format!("{} names unknown repository alias `{alias}`", file.path))?;
+                        if is_verification_command && !all_code.contains(&target) {
+                            return Err(format!(
+                                "{} verification command `{}` targets repository alias `{alias}` without the code role",
+                                file.path, entry.name
+                            ));
+                        }
+                        Ok(target)
                     })
                     .collect::<Result<Vec<_>, _>>()?,
                 None => all_code.to_vec(),

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -5206,6 +5206,13 @@ impl InProcessDaemon {
         }
 
         let repositories = self.resource_backend.clone().using::<Repository>(&namespace);
+        let current_code_members = project
+            .spec
+            .repositories
+            .iter()
+            .filter(|member| member.roles.contains(&ProjectRepositoryRole::Code))
+            .map(|member| member.repo.clone())
+            .collect::<BTreeSet<_>>();
         for member in project.spec.repositories.iter().filter(|member| member.roles.contains(&ProjectRepositoryRole::Code)) {
             let current = repositories.get(&member.repo.to_string()).await.map_err(|error| error.to_string())?;
             let desired_commands = commands.remove(&member.repo).unwrap_or_default();
@@ -5243,6 +5250,17 @@ impl InProcessDaemon {
                 repositories.update(&meta, &current.metadata.resource_version, &desired_spec).await.map_err(|error| error.to_string())?;
                 changes.push(format!("Repository/{} verification commands", member.repo));
             }
+        }
+        for stale in repositories.list().await.map_err(|error| error.to_string())?.items.into_iter().filter(|repository| {
+            repository.metadata.annotations.get(VERIFICATION_PROJECT_ANNOTATION).map(String::as_str) == Some(project_name)
+                && !current_code_members.contains(&RepositoryKey(repository.metadata.name.clone()))
+        }) {
+            let mut meta = InputMeta::from(&stale.metadata);
+            meta.annotations.remove(VERIFICATION_PROJECT_ANNOTATION);
+            meta.annotations.remove(VERIFICATION_PROVENANCE_ANNOTATION);
+            let spec = stale.spec.clone().with_verification_commands(BTreeMap::new());
+            repositories.update(&meta, &stale.metadata.resource_version, &spec).await.map_err(|error| error.to_string())?;
+            changes.push(format!("Repository/{} verification commands", stale.metadata.name));
         }
         changes.sort();
         Ok(changes)

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -85,6 +85,10 @@ use crate::{
     host_registry::HostCounts,
     leaf_engine::LeafSubscriptionTable,
     model::{provider_names_from_registry, repo_name, RepoModel},
+    ops_entry::{
+        parse_operational_entry, OperationalEntryDefinition, MATERIALIZED_PROJECT_ANNOTATION, SOURCE_COMMIT_ANNOTATION,
+        SOURCE_ENTRY_PATH_ANNOTATION, SOURCE_REPOSITORY_ANNOTATION, VERIFICATION_PROVENANCE_ANNOTATION,
+    },
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     placement_policy::reconcile_registered_policy,
     project_declaration::{
@@ -104,7 +108,9 @@ use crate::{
     refresh::RefreshSnapshot,
     regard_lifecycle::{RegardLifecycle, SurfaceGestureOutcome, DEFAULT_REGARD_DECAY_SECONDS, DEFAULT_REGARD_REFRESH_SECONDS},
     repo_state::{RepoRootState, RepoState, SnapshotBuildContext},
-    repository_inspection::{GitRepositoryInspector, ProjectDeclarationInspection, RepositoryInspection, RepositoryInspector},
+    repository_inspection::{
+        GitRepositoryInspector, OperationalEntriesInspection, ProjectDeclarationInspection, RepositoryInspection, RepositoryInspector,
+    },
     step::{
         run_step_plan_with_remote_executor, RemoteStepBatchRequest, RemoteStepExecutor, RemoteStepProgressSink, StepOutcome, StepResolver,
     },
@@ -4952,7 +4958,7 @@ impl InProcessDaemon {
         Ok((name, project.spec.repositories.len()))
     }
 
-    async fn project_refresh(&self, name: &str) -> Result<(usize, bool), String> {
+    async fn project_refresh(&self, name: &str) -> Result<(usize, bool, Vec<String>), String> {
         validate_project_name(name)?;
         let namespace = self.provisioning_namespace().await;
         let project =
@@ -4971,7 +4977,7 @@ impl InProcessDaemon {
                 declaration.name
             ));
         }
-        let converged = self.materialize_project_declaration(declaration, inspection).await?;
+        let changes = self.materialize_project_declaration(declaration, inspection).await?;
         let members = self
             .resource_backend
             .clone()
@@ -4982,14 +4988,14 @@ impl InProcessDaemon {
             .spec
             .repositories
             .len();
-        Ok((members, converged))
+        Ok((members, !changes.is_empty(), changes))
     }
 
     async fn materialize_project_declaration(
         &self,
         declaration: ProjectDeclaration,
         inspection: ProjectDeclarationInspection,
-    ) -> Result<bool, String> {
+    ) -> Result<Vec<String>, String> {
         validate_project_name(&declaration.name)?;
         let namespace = self.provisioning_namespace().await;
         let projects = self.resource_backend.clone().definitions::<Project>(&namespace);
@@ -5007,6 +5013,7 @@ impl InProcessDaemon {
             .collect::<BTreeMap<_, _>>();
         let bootstrap_key = inspection.repository.key();
         let bootstrap_path = inspection.repository.checkout.path.to_string_lossy().into_owned();
+        let bootstrap_inspection = inspection.clone();
         let provenance = BTreeMap::from([
             (BOOTSTRAP_REPOSITORY_ANNOTATION.to_string(), bootstrap_key.to_string()),
             (BOOTSTRAP_COMMIT_ANNOTATION.to_string(), inspection.commit.clone()),
@@ -5066,7 +5073,230 @@ impl InProcessDaemon {
         converged |=
             existing_project.as_ref().is_none_or(|project| project.spec != spec || project.metadata.annotations != meta.annotations);
         projects.apply(&meta, &spec).await.map_err(|error| error.to_string())?;
-        Ok(converged)
+        let mut changes = if converged { vec![format!("Project/{}", declaration.name)] } else { Vec::new() };
+        changes.extend(self.materialize_project_operational_entries(&declaration.name, &bootstrap_inspection).await?);
+        Ok(changes)
+    }
+
+    async fn materialize_project_operational_entries(
+        &self,
+        project_name: &str,
+        bootstrap: &ProjectDeclarationInspection,
+    ) -> Result<Vec<String>, String> {
+        let namespace = self.provisioning_namespace().await;
+        let project =
+            self.resource_backend.clone().definitions::<Project>(&namespace).get(project_name).await.map_err(|e| e.to_string())?;
+        let aliases = project
+            .spec
+            .repositories
+            .iter()
+            .filter_map(|member| member.alias.as_ref().map(|alias| (alias.clone(), member.repo.clone())))
+            .collect::<BTreeMap<_, _>>();
+        let all_code = project
+            .spec
+            .repositories
+            .iter()
+            .filter(|member| member.roles.contains(&ProjectRepositoryRole::Code))
+            .map(|member| member.repo.clone())
+            .collect::<Vec<_>>();
+        let inspector = self.repository_inspector().await?;
+        let mut sources = Vec::new();
+        let mut unavailable_source = false;
+        for member in project.spec.repositories.iter().filter(|member| member.roles.contains(&ProjectRepositoryRole::Ops)) {
+            let path = if member.repo == bootstrap.repository.key() {
+                bootstrap.repository.checkout.path.clone()
+            } else {
+                let mut paths = self
+                    .repository_keys_by_path
+                    .read()
+                    .await
+                    .iter()
+                    .filter(|(_, key)| *key == &member.repo)
+                    .map(|(path, _)| path.clone())
+                    .collect::<Vec<_>>();
+                paths.sort();
+                match paths.as_slice() {
+                    [] => {
+                        unavailable_source = true;
+                        continue;
+                    }
+                    [path] => path.clone(),
+                    _ => {
+                        let mut main_paths = Vec::new();
+                        for path in paths {
+                            if inspector.inspect_path(&path, None).await?.checkout.is_main {
+                                main_paths.push(path);
+                            }
+                        }
+                        match main_paths.as_slice() {
+                            [path] => path.clone(),
+                            _ => {
+                                return Err(format!(
+                                    "ops member {} has multiple local checkouts; its main checkout cannot be selected unambiguously",
+                                    member.alias.as_deref().unwrap_or(&member.repo.0)
+                                ));
+                            }
+                        }
+                    }
+                }
+            };
+            let mut source = inspector.inspect_operational_entries(&path).await?;
+            if member.repo == bootstrap.repository.key() {
+                source.commit.clone_from(&bootstrap.commit);
+                source.repository = bootstrap.repository.clone();
+            }
+            sources.push(source);
+        }
+        // Registration remains possible from a bootstrap repository that does
+        // not host every ops member. Never infer an empty desired set from an
+        // unavailable source: that could erase definitions materialized by a
+        // previous refresh on a host that had the checkout.
+        if unavailable_source {
+            return Ok(Vec::new());
+        }
+
+        let mut workflows = BTreeMap::new();
+        let mut commands = BTreeMap::<RepositoryKey, BTreeMap<String, String>>::new();
+        let mut command_provenance = BTreeMap::<RepositoryKey, Vec<serde_json::Value>>::new();
+        for source in sources {
+            self.collect_operational_entries(
+                project_name,
+                &aliases,
+                &all_code,
+                source,
+                &mut workflows,
+                &mut commands,
+                &mut command_provenance,
+            )?;
+        }
+
+        let templates = self.resource_backend.clone().using::<WorkflowTemplate>(&namespace);
+        let mut changes = Vec::new();
+        for (name, (meta, spec)) in &workflows {
+            let current = match templates.get(name).await {
+                Ok(current) => Some(current),
+                Err(ResourceError::NotFound { .. }) => None,
+                Err(error) => return Err(error.to_string()),
+            };
+            if let Some(owner) = current
+                .as_ref()
+                .and_then(|current| current.metadata.annotations.get(MATERIALIZED_PROJECT_ANNOTATION))
+                .filter(|owner| owner.as_str() != project_name)
+            {
+                return Err(format!("WorkflowTemplate `{name}` is materialized by project `{owner}`"));
+            }
+            if current.as_ref().is_none_or(|current| current.spec != *spec || current.metadata.annotations != meta.annotations) {
+                match current {
+                    Some(current) => {
+                        templates.update(meta, &current.metadata.resource_version, spec).await.map_err(|error| error.to_string())?;
+                    }
+                    None => {
+                        templates.create(meta, spec).await.map_err(|error| error.to_string())?;
+                    }
+                }
+                changes.push(format!("WorkflowTemplate/{name}"));
+            }
+        }
+        for stale in templates.list().await.map_err(|error| error.to_string())?.items.into_iter().filter(|template| {
+            template.metadata.annotations.get(MATERIALIZED_PROJECT_ANNOTATION).map(String::as_str) == Some(project_name)
+                && !workflows.contains_key(&template.metadata.name)
+        }) {
+            templates.delete(&stale.metadata.name).await.map_err(|error| error.to_string())?;
+            changes.push(format!("deleted WorkflowTemplate/{}", stale.metadata.name));
+        }
+
+        let repositories = self.resource_backend.clone().using::<Repository>(&namespace);
+        for member in project.spec.repositories.iter().filter(|member| member.roles.contains(&ProjectRepositoryRole::Code)) {
+            let current = repositories.get(&member.repo.to_string()).await.map_err(|error| error.to_string())?;
+            let desired_commands = commands.remove(&member.repo).unwrap_or_default();
+            let desired_spec = current.spec.clone().with_verification_commands(desired_commands);
+            let mut meta = InputMeta::from(&current.metadata);
+            match command_provenance.remove(&member.repo) {
+                Some(provenance) => {
+                    meta.annotations.insert(
+                        VERIFICATION_PROVENANCE_ANNOTATION.to_string(),
+                        serde_json::to_string(&provenance).expect("JSON provenance values serialize"),
+                    );
+                }
+                None => {
+                    meta.annotations.remove(VERIFICATION_PROVENANCE_ANNOTATION);
+                }
+            }
+            if current.spec != desired_spec || current.metadata.annotations != meta.annotations {
+                repositories.update(&meta, &current.metadata.resource_version, &desired_spec).await.map_err(|error| error.to_string())?;
+                changes.push(format!("Repository/{} verification commands", member.repo));
+            }
+        }
+        changes.sort();
+        Ok(changes)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn collect_operational_entries(
+        &self,
+        project_name: &str,
+        aliases: &BTreeMap<String, RepositoryKey>,
+        all_code: &[RepositoryKey],
+        source: OperationalEntriesInspection,
+        workflows: &mut BTreeMap<String, (InputMeta, WorkflowTemplateSpec)>,
+        commands: &mut BTreeMap<RepositoryKey, BTreeMap<String, String>>,
+        command_provenance: &mut BTreeMap<RepositoryKey, Vec<serde_json::Value>>,
+    ) -> Result<(), String> {
+        let source_repository = source.repository.key();
+        for file in source.files {
+            let Some(entry) = parse_operational_entry(&file.contents).map_err(|error| format!("{}: {error}", file.path))? else {
+                continue;
+            };
+            let targets = match entry.repos {
+                Some(repo_aliases) => repo_aliases
+                    .into_iter()
+                    .map(|alias| {
+                        aliases.get(&alias).cloned().ok_or_else(|| format!("{} names unknown repository alias `{alias}`", file.path))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?,
+                None => all_code.to_vec(),
+            };
+            if targets.is_empty() {
+                return Err(format!("{} has no code-role repositories to target", file.path));
+            }
+            let provenance = serde_json::json!({
+                "sourceRepository": source_repository,
+                "sourceCommit": source.commit,
+                "entryPath": file.path,
+            });
+            match entry.definition {
+                OperationalEntryDefinition::WorkflowTemplate(mut spec) => {
+                    for vessel in &mut spec.vessels {
+                        vessel.repository_refs = Some(targets.clone());
+                    }
+                    flotilla_resources::validate(&spec).map_err(|errors| {
+                        let errors = errors.iter().map(ToString::to_string).collect::<Vec<_>>().join("; ");
+                        format!("{} contains invalid workflow template `{}`: {errors}", file.path, entry.name)
+                    })?;
+                    let meta = InputMeta::builder()
+                        .name(entry.name.clone())
+                        .annotations(BTreeMap::from([
+                            (MATERIALIZED_PROJECT_ANNOTATION.to_string(), project_name.to_string()),
+                            (SOURCE_REPOSITORY_ANNOTATION.to_string(), source_repository.to_string()),
+                            (SOURCE_COMMIT_ANNOTATION.to_string(), source.commit.clone()),
+                            (SOURCE_ENTRY_PATH_ANNOTATION.to_string(), file.path.clone()),
+                        ]))
+                        .build();
+                    if workflows.insert(entry.name.clone(), (meta, spec)).is_some() {
+                        return Err(format!("duplicate materialized WorkflowTemplate `{}`", entry.name));
+                    }
+                }
+                OperationalEntryDefinition::VerificationCommand { command } => {
+                    for target in targets {
+                        if commands.entry(target.clone()).or_default().insert(entry.name.clone(), command.clone()).is_some() {
+                            return Err(format!("duplicate verification command `{}` for repository {target}", entry.name));
+                        }
+                        command_provenance.entry(target).or_default().push(provenance.clone());
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 
     async fn project_add(
@@ -8244,7 +8474,7 @@ impl InProcessDaemon {
                 description: command.description().to_string(),
             });
             let result = match self.project_refresh(name).await {
-                Ok((members, converged)) => CommandValue::ProjectRefreshed { name: name.clone(), members, converged },
+                Ok((members, converged, changes)) => CommandValue::ProjectRefreshed { name: name.clone(), members, converged, changes },
                 Err(message) => CommandValue::Error { message },
             };
             let _ = self.event_tx.send(DaemonEvent::CommandFinished {

--- a/crates/flotilla-core/src/lib.rs
+++ b/crates/flotilla-core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod log_file;
 pub mod merge;
 pub mod model;
 pub(crate) mod observed_resources;
+pub mod ops_entry;
 pub mod path_context;
 pub mod path_policy;
 pub mod placement_policy;

--- a/crates/flotilla-core/src/ops_entry.rs
+++ b/crates/flotilla-core/src/ops_entry.rs
@@ -5,6 +5,7 @@ pub const MATERIALIZED_PROJECT_ANNOTATION: &str = "flotilla.work/materialized-pr
 pub const SOURCE_REPOSITORY_ANNOTATION: &str = "flotilla.work/source-repository";
 pub const SOURCE_COMMIT_ANNOTATION: &str = "flotilla.work/source-commit";
 pub const SOURCE_ENTRY_PATH_ANNOTATION: &str = "flotilla.work/source-entry-path";
+pub const VERIFICATION_PROJECT_ANNOTATION: &str = "flotilla.work/verification-command-project";
 pub const VERIFICATION_PROVENANCE_ANNOTATION: &str = "flotilla.work/verification-command-provenance";
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/flotilla-core/src/ops_entry.rs
+++ b/crates/flotilla-core/src/ops_entry.rs
@@ -1,0 +1,116 @@
+use flotilla_resources::WorkflowTemplateSpec;
+use serde::Deserialize;
+
+pub const MATERIALIZED_PROJECT_ANNOTATION: &str = "flotilla.work/materialized-project";
+pub const SOURCE_REPOSITORY_ANNOTATION: &str = "flotilla.work/source-repository";
+pub const SOURCE_COMMIT_ANNOTATION: &str = "flotilla.work/source-commit";
+pub const SOURCE_ENTRY_PATH_ANNOTATION: &str = "flotilla.work/source-entry-path";
+pub const VERIFICATION_PROVENANCE_ANNOTATION: &str = "flotilla.work/verification-command-provenance";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperationalEntryFile {
+    pub path: String,
+    pub contents: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperationalEntry {
+    pub name: String,
+    pub repos: Option<Vec<String>>,
+    pub definition: OperationalEntryDefinition,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OperationalEntryDefinition {
+    WorkflowTemplate(WorkflowTemplateSpec),
+    VerificationCommand { command: String },
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EntryFrontmatter {
+    kind: EntryKind,
+    name: String,
+    repos: Option<Vec<String>>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum EntryKind {
+    WorkflowTemplate,
+    VerificationCommand,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VerificationCommandBody {
+    command: String,
+}
+
+pub fn parse_operational_entry(contents: &str) -> Result<Option<OperationalEntry>, String> {
+    let Some(rest) = contents.strip_prefix("---\n") else {
+        return Ok(None);
+    };
+    let Some((frontmatter, body)) = rest.split_once("\n---\n") else {
+        return Ok(None);
+    };
+    let frontmatter: EntryFrontmatter = match serde_yml::from_str(frontmatter) {
+        Ok(frontmatter) => frontmatter,
+        Err(_) if !frontmatter.lines().any(|line| line.trim_start().starts_with("kind:")) => return Ok(None),
+        Err(error) => return Err(format!("invalid operational entry frontmatter: {error}")),
+    };
+    let name = required(frontmatter.name, "name")?;
+    let repos = frontmatter
+        .repos
+        .map(|repos| {
+            if repos.is_empty() {
+                return Err("operational entry repos cannot be empty; omit repos to target all code members".to_string());
+            }
+            repos.into_iter().map(|alias| required(alias, "repos[]")).collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?;
+    let definition = match frontmatter.kind {
+        EntryKind::WorkflowTemplate => OperationalEntryDefinition::WorkflowTemplate(
+            serde_yml::from_str(body).map_err(|error| format!("invalid workflow template `{name}`: {error}"))?,
+        ),
+        EntryKind::VerificationCommand => {
+            let body: VerificationCommandBody =
+                serde_yml::from_str(body).map_err(|error| format!("invalid verification command `{name}`: {error}"))?;
+            OperationalEntryDefinition::VerificationCommand { command: required(body.command, "command")? }
+        }
+    };
+    Ok(Some(OperationalEntry { name, repos, definition }))
+}
+
+fn required(value: String, field: &str) -> Result<String, String> {
+    let value = value.trim().to_string();
+    if value.is_empty() {
+        Err(format!("operational entry {field} cannot be empty"))
+    } else {
+        Ok(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_operational_entry, OperationalEntryDefinition};
+
+    #[test]
+    fn parses_entry_kind_and_alias_scope_from_frontmatter() {
+        let entry = parse_operational_entry(
+            "---\nkind: workflow_template\nname: review\nrepos: [app]\n---\nvessels:\n  - name: work\n    crew: []\n",
+        )
+        .expect("parse")
+        .expect("entry");
+        assert_eq!(entry.repos, Some(vec!["app".to_string()]));
+        assert!(matches!(entry.definition, OperationalEntryDefinition::WorkflowTemplate(_)));
+    }
+
+    #[test]
+    fn ignores_ordinary_frontmatter_and_rejects_an_empty_explicit_scope() {
+        assert!(parse_operational_entry("---\ntitle: a note\n---\nknowledge\n").expect("parse").is_none());
+        assert!(parse_operational_entry("---\nkind: verification_command\nname: test\nrepos: []\n---\ncommand: cargo test\n")
+            .expect_err("empty scope")
+            .contains("omit repos"));
+    }
+}

--- a/crates/flotilla-core/src/repository_inspection.rs
+++ b/crates/flotilla-core/src/repository_inspection.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use flotilla_resources::{RepositoryKey, RepositorySpec};
 
 use crate::{
+    ops_entry::OperationalEntryFile,
     path_context::ExecutionEnvironmentPath,
     providers::{
         vcs::{git_worktree::GitCheckoutManager, CheckoutManager},
@@ -34,6 +35,13 @@ pub struct ProjectDeclarationInspection {
     pub repository: RepositoryInspection,
     pub yaml: String,
     pub commit: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperationalEntriesInspection {
+    pub repository: RepositoryInspection,
+    pub commit: String,
+    pub files: Vec<OperationalEntryFile>,
 }
 
 impl RepositoryInspection {
@@ -65,6 +73,32 @@ pub trait RepositoryInspector: Send + Sync {
         let yaml = std::fs::read_to_string(&declaration_path).map_err(|error| format!("read {}: {error}", declaration_path.display()))?;
         Ok(ProjectDeclarationInspection { commit: repository.checkout.git_ref.clone(), repository, yaml })
     }
+
+    async fn inspect_operational_entries(&self, path: &Path) -> Result<OperationalEntriesInspection, String> {
+        let repository = self.inspect_path(path, None).await?;
+        let mut files = Vec::new();
+        collect_operational_entry_files(&repository.checkout.path, &repository.checkout.path, &mut files)?;
+        files.sort_by(|left, right| left.path.cmp(&right.path));
+        Ok(OperationalEntriesInspection { commit: repository.checkout.git_ref.clone(), repository, files })
+    }
+}
+
+fn collect_operational_entry_files(root: &Path, directory: &Path, files: &mut Vec<OperationalEntryFile>) -> Result<(), String> {
+    let entries = std::fs::read_dir(directory).map_err(|error| format!("read {}: {error}", directory.display()))?;
+    for entry in entries {
+        let entry = entry.map_err(|error| format!("read {}: {error}", directory.display()))?;
+        let path = entry.path();
+        if path.file_name().is_some_and(|name| name == ".git") {
+            continue;
+        }
+        if path.is_dir() {
+            collect_operational_entry_files(root, &path, files)?;
+        } else if let Ok(contents) = std::fs::read_to_string(&path) {
+            let relative = path.strip_prefix(root).expect("walked paths remain beneath root").to_string_lossy().replace('\\', "/");
+            files.push(OperationalEntryFile { path: relative, contents });
+        }
+    }
+    Ok(())
 }
 
 pub struct GitRepositoryInspector {
@@ -211,6 +245,21 @@ impl RepositoryInspector for GitRepositoryInspector {
             )
         })?;
         Ok(ProjectDeclarationInspection { repository, yaml, commit })
+    }
+
+    async fn inspect_operational_entries(&self, path: &Path) -> Result<OperationalEntriesInspection, String> {
+        let repository = self.inspect_path(path, None).await?;
+        let commit = self.git(&repository.checkout.path, &["rev-parse", "HEAD"]).await?;
+        let paths = self.git(&repository.checkout.path, &["ls-tree", "-r", "--name-only", &commit]).await?;
+        let mut files = Vec::new();
+        for entry_path in paths.lines().map(str::trim).filter(|path| !path.is_empty()) {
+            let object_ref = format!("{commit}:{entry_path}");
+            let Ok(contents) = self.git(&repository.checkout.path, &["show", &object_ref]).await else {
+                continue;
+            };
+            files.push(OperationalEntryFile { path: entry_path.to_string(), contents });
+        }
+        Ok(OperationalEntriesInspection { repository, commit, files })
     }
 
     async fn resolve_remote(&self, remote: &str) -> Result<RepositorySpec, String> {

--- a/crates/flotilla-core/src/repository_inspection.rs
+++ b/crates/flotilla-core/src/repository_inspection.rs
@@ -254,8 +254,16 @@ impl RepositoryInspector for GitRepositoryInspector {
         // kind and scope remain content-authoritative; this only avoids one
         // `git show` subprocess for every unrelated file in a large ops+code
         // repository.
-        let paths =
-            self.git(&repository.checkout.path, &["grep", "-Il", "-e", "^kind:[[:space:]]", &commit, "--"]).await.unwrap_or_default();
+        let grep = self
+            .runner
+            .run_output("git", &["grep", "-Il", "-e", "^kind:[[:space:]]", &commit, "--"], &repository.checkout.path, &ChannelLabel::Noop)
+            .await
+            .map_err(|error| format!("git grep operational entries in {}: {error}", repository.checkout.path.display()))?;
+        let paths = if grep.success || grep.stderr.trim().is_empty() {
+            grep.stdout
+        } else {
+            return Err(format!("git grep operational entries in {}: {}", repository.checkout.path.display(), grep.stderr.trim()));
+        };
         let prefix = format!("{commit}:");
         let mut files = Vec::new();
         for entry_path in paths.lines().filter_map(|path| path.strip_prefix(&prefix)).filter(|path| !path.is_empty()) {

--- a/crates/flotilla-core/src/repository_inspection.rs
+++ b/crates/flotilla-core/src/repository_inspection.rs
@@ -250,9 +250,15 @@ impl RepositoryInspector for GitRepositoryInspector {
     async fn inspect_operational_entries(&self, path: &Path) -> Result<OperationalEntriesInspection, String> {
         let repository = self.inspect_path(path, None).await?;
         let commit = self.git(&repository.checkout.path, &["rev-parse", "HEAD"]).await?;
-        let paths = self.git(&repository.checkout.path, &["ls-tree", "-r", "--name-only", &commit]).await?;
+        // Use one tree-wide grep to find content candidates. Operational entry
+        // kind and scope remain content-authoritative; this only avoids one
+        // `git show` subprocess for every unrelated file in a large ops+code
+        // repository.
+        let paths =
+            self.git(&repository.checkout.path, &["grep", "-Il", "-e", "^kind:[[:space:]]", &commit, "--"]).await.unwrap_or_default();
+        let prefix = format!("{commit}:");
         let mut files = Vec::new();
-        for entry_path in paths.lines().map(str::trim).filter(|path| !path.is_empty()) {
+        for entry_path in paths.lines().filter_map(|path| path.strip_prefix(&prefix)).filter(|path| !path.is_empty()) {
             let object_ref = format!("{commit}:{entry_path}");
             let Ok(contents) = self.git(&repository.checkout.path, &["show", &object_ref]).await else {
                 continue;

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -13,7 +13,7 @@ use flotilla_core::{
     config::ConfigStore,
     daemon::DaemonHandle,
     in_process::InProcessDaemon,
-    ops_entry::{SOURCE_COMMIT_ANNOTATION, SOURCE_ENTRY_PATH_ANNOTATION, SOURCE_REPOSITORY_ANNOTATION},
+    ops_entry::{MATERIALIZED_PROJECT_ANNOTATION, SOURCE_COMMIT_ANNOTATION, SOURCE_ENTRY_PATH_ANNOTATION, SOURCE_REPOSITORY_ANNOTATION},
     project_declaration::{BOOTSTRAP_COMMIT_ANNOTATION, BOOTSTRAP_PATH_ANNOTATION, BOOTSTRAP_REPOSITORY_ANNOTATION},
     providers::discovery::test_support::fake_discovery,
     repository_inspection::{LocalCheckoutInspection, ProjectDeclarationInspection, RepositoryInspection, RepositoryInspector},
@@ -449,6 +449,55 @@ async fn ops_entries_materialize_by_frontmatter_scope_with_provenance_and_conver
         }
     );
     assert_eq!(workflows.get("scoped").await.expect("converged workflow").spec, scoped.spec);
+
+    std::fs::remove_file(misleading_directory.join("this-is-a-workflow.md")).expect("remove workflow entry");
+    assert_eq!(
+        execute_project_command(&daemon, &mut rx, CommandAction::ProjectRefresh { name: "demo".to_string() }).await,
+        CommandValue::ProjectRefreshed {
+            name: "demo".to_string(),
+            members: 3,
+            converged: true,
+            changes: vec!["deleted WorkflowTemplate/scoped".to_string()],
+        }
+    );
+    assert!(matches!(workflows.get("scoped").await, Err(flotilla_resources::ResourceError::NotFound { .. })));
+}
+
+#[tokio::test]
+async fn ops_entry_rejects_a_hand_applied_workflow_name_collision() {
+    let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
+    let ops_spec = RepositorySpec::remote("https://github.com/example/project-ops").expect("ops spec");
+    daemon
+        .set_repository_inspector(Arc::new(DeclarationInspector {
+            bootstrap: ops_spec,
+            commit: Arc::new(RwLock::new("ops-commit".to_string())),
+        }))
+        .await;
+    std::fs::write(
+        tmp.path().join("project.yaml"),
+        "name: demo\nmembers:\n  - alias: app\n    url: https://github.com/example/project-ops\n    roles: [code, ops]\n",
+    )
+    .expect("write declaration");
+    std::fs::write(
+        tmp.path().join("collision.entry"),
+        "---\nkind: workflow_template\nname: existing\n---\nvessels:\n  - name: work\n    crew:\n      - role: verify\n        command: cargo test\n",
+    )
+    .expect("write workflow entry");
+    let hand_applied = WorkflowTemplateSpec::builder().vessels(Vec::new()).build();
+    let workflows = backend.using::<WorkflowTemplate>("flotilla");
+    workflows.create(&InputMeta::builder().name("existing".to_string()).build(), &hand_applied).await.expect("hand apply workflow");
+
+    let mut rx = daemon.subscribe();
+    let result =
+        execute_project_command(&daemon, &mut rx, CommandAction::ProjectRegister { target: tmp.path().to_string_lossy().into_owned() })
+            .await;
+    assert!(
+        matches!(&result, CommandValue::Error { message } if message.contains("already exists") && message.contains("not materialized")),
+        "unexpected command result: {result:?}"
+    );
+    let preserved = workflows.get("existing").await.expect("hand-applied workflow remains");
+    assert_eq!(preserved.spec, hand_applied);
+    assert!(!preserved.metadata.annotations.contains_key(MATERIALIZED_PROJECT_ANNOTATION));
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -520,6 +520,40 @@ async fn ops_entry_rejects_a_hand_applied_workflow_name_collision() {
 }
 
 #[tokio::test]
+async fn ops_entry_rejects_a_verification_command_targeting_a_non_code_member() {
+    let (daemon, _backend, _config, _runtime, tmp) = start_daemon().await;
+    let ops_spec = RepositorySpec::remote("https://github.com/example/project-ops").expect("ops spec");
+    daemon
+        .set_repository_inspector(Arc::new(DeclarationInspector {
+            bootstrap: ops_spec,
+            commit: Arc::new(RwLock::new("ops-commit".to_string())),
+        }))
+        .await;
+    std::fs::write(
+        tmp.path().join("project.yaml"),
+        "name: demo\nmembers:\n  - alias: app\n    url: https://github.com/example/app\n    roles: [code]\n  - alias: operations\n    url: https://github.com/example/project-ops\n    roles: [ops]\n",
+    )
+    .expect("write declaration");
+    std::fs::write(
+        tmp.path().join("invalid-command.entry"),
+        "---\nkind: verification_command\nname: test\nrepos: [operations]\n---\ncommand: cargo test --workspace\n",
+    )
+    .expect("write verification command");
+
+    let mut rx = daemon.subscribe();
+    let result =
+        execute_project_command(&daemon, &mut rx, CommandAction::ProjectRegister { target: tmp.path().to_string_lossy().into_owned() })
+            .await;
+    assert!(
+        matches!(&result, CommandValue::Error { message }
+            if message.contains("invalid-command.entry")
+                && message.contains("repository alias `operations`")
+                && message.contains("without the code role")),
+        "unexpected command result: {result:?}"
+    );
+}
+
+#[tokio::test]
 async fn tracking_repo_materializes_whole_repo_project() {
     let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
     let repository_key = track_repository(&daemon, &tmp, "tracked", "https://github.com/org/tracked.git").await;

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -13,7 +13,10 @@ use flotilla_core::{
     config::ConfigStore,
     daemon::DaemonHandle,
     in_process::InProcessDaemon,
-    ops_entry::{MATERIALIZED_PROJECT_ANNOTATION, SOURCE_COMMIT_ANNOTATION, SOURCE_ENTRY_PATH_ANNOTATION, SOURCE_REPOSITORY_ANNOTATION},
+    ops_entry::{
+        MATERIALIZED_PROJECT_ANNOTATION, SOURCE_COMMIT_ANNOTATION, SOURCE_ENTRY_PATH_ANNOTATION, SOURCE_REPOSITORY_ANNOTATION,
+        VERIFICATION_PROJECT_ANNOTATION,
+    },
     project_declaration::{BOOTSTRAP_COMMIT_ANNOTATION, BOOTSTRAP_PATH_ANNOTATION, BOOTSTRAP_REPOSITORY_ANNOTATION},
     providers::discovery::test_support::fake_discovery,
     repository_inspection::{LocalCheckoutInspection, ProjectDeclarationInspection, RepositoryInspection, RepositoryInspector},
@@ -461,6 +464,22 @@ async fn ops_entries_materialize_by_frontmatter_scope_with_provenance_and_conver
         }
     );
     assert!(matches!(workflows.get("scoped").await, Err(flotilla_resources::ResourceError::NotFound { .. })));
+
+    std::fs::remove_file(tmp.path().join("test-command.entry")).expect("remove verification entry");
+    std::fs::write(
+        tmp.path().join("project.yaml"),
+        "name: demo\nmembers:\n  - alias: app\n    url: https://github.com/example/app\n    roles: [knowledge]\n  - alias: docs\n    url: https://github.com/example/docs\n    roles: [code]\n  - alias: operations\n    url: https://github.com/example/project-ops\n    roles: [ops]\n",
+    )
+    .expect("remove app code role");
+    let result = execute_project_command(&daemon, &mut rx, CommandAction::ProjectRefresh { name: "demo".to_string() }).await;
+    assert!(
+        matches!(&result, CommandValue::ProjectRefreshed { changes, .. }
+            if changes.iter().any(|change| change == &format!("Repository/{} verification commands", app.repo))),
+        "unexpected command result: {result:?}"
+    );
+    let released = backend.using::<Repository>("flotilla").get(&app.repo.to_string()).await.expect("released repository");
+    assert!(released.spec.verification_commands().is_empty());
+    assert!(!released.metadata.annotations.contains_key(VERIFICATION_PROJECT_ANNOTATION));
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -13,6 +13,7 @@ use flotilla_core::{
     config::ConfigStore,
     daemon::DaemonHandle,
     in_process::InProcessDaemon,
+    ops_entry::{SOURCE_COMMIT_ANNOTATION, SOURCE_ENTRY_PATH_ANNOTATION, SOURCE_REPOSITORY_ANNOTATION},
     project_declaration::{BOOTSTRAP_COMMIT_ANNOTATION, BOOTSTRAP_PATH_ANNOTATION, BOOTSTRAP_REPOSITORY_ANNOTATION},
     providers::discovery::test_support::fake_discovery,
     repository_inspection::{LocalCheckoutInspection, ProjectDeclarationInspection, RepositoryInspection, RepositoryInspector},
@@ -21,7 +22,8 @@ use flotilla_daemon::runtime::{DaemonRuntime, RuntimeOptions};
 use flotilla_protocol::{commands::RepositoryIdentityChange, Command, CommandAction, CommandValue, DaemonEvent, HostName, RepoSelector};
 use flotilla_resources::{
     Checkout, CheckoutSpec, Convoy, InMemoryBackend, InputMeta, IssueSource, ObservedCheckoutSpec, Project, ProjectRepositoryRole,
-    ProjectSpec, Repository, RepositoryKey, RepositorySpec, RepositoryStatus, ResourceBackend, MANAGED_BY_LABEL,
+    ProjectSpec, Repository, RepositoryKey, RepositorySpec, RepositoryStatus, ResourceBackend, WorkflowTemplate, WorkflowTemplateSpec,
+    MANAGED_BY_LABEL,
 };
 use tracing::instrument::WithSubscriber;
 
@@ -361,7 +363,7 @@ async fn project_refresh_is_one_way_and_keeps_alias_repository_keys_stable_acros
     .expect("update declaration");
     assert_eq!(
         execute_project_command(&daemon, &mut rx, CommandAction::ProjectRefresh { name: "demo".to_string() }).await,
-        CommandValue::ProjectRefreshed { name: "demo".to_string(), members: 2, converged: true }
+        CommandValue::ProjectRefreshed { name: "demo".to_string(), members: 2, converged: true, changes: vec!["Project/demo".to_string()] }
     );
     let refreshed = projects.get("demo").await.expect("refreshed project");
     assert_eq!(refreshed.spec.display_name, "demo");
@@ -371,8 +373,82 @@ async fn project_refresh_is_one_way_and_keeps_alias_repository_keys_stable_acros
     assert_eq!(refreshed.metadata.annotations.get(BOOTSTRAP_COMMIT_ANNOTATION).map(String::as_str), Some("commit-two"));
     assert_eq!(
         execute_project_command(&daemon, &mut rx, CommandAction::ProjectRefresh { name: "demo".to_string() }).await,
-        CommandValue::ProjectRefreshed { name: "demo".to_string(), members: 2, converged: false }
+        CommandValue::ProjectRefreshed { name: "demo".to_string(), members: 2, converged: false, changes: Vec::new() }
     );
+}
+
+#[tokio::test]
+async fn ops_entries_materialize_by_frontmatter_scope_with_provenance_and_converge_drift() {
+    let (daemon, backend, _config, _runtime, tmp) = start_daemon().await;
+    let ops_spec = RepositorySpec::remote("https://github.com/example/project-ops").expect("ops spec");
+    let commit = Arc::new(RwLock::new("ops-commit".to_string()));
+    daemon.set_repository_inspector(Arc::new(DeclarationInspector { bootstrap: ops_spec.clone(), commit })).await;
+    std::fs::write(
+        tmp.path().join("project.yaml"),
+        "name: demo\nmembers:\n  - alias: app\n    url: https://github.com/example/app\n    roles: [code]\n  - alias: docs\n    url: https://github.com/example/docs\n    roles: [code]\n  - alias: operations\n    url: https://github.com/example/project-ops\n    roles: [ops]\n",
+    )
+    .expect("write declaration");
+    let misleading_directory = tmp.path().join("verification-commands");
+    std::fs::create_dir(&misleading_directory).expect("create misleading directory");
+    std::fs::write(
+        misleading_directory.join("this-is-a-workflow.md"),
+        "---\nkind: workflow_template\nname: scoped\nrepos: [app]\n---\nvessels:\n  - name: work\n    crew:\n      - role: verify\n        command: cargo test\n",
+    )
+    .expect("write scoped workflow");
+    std::fs::write(
+        tmp.path().join("all-code.entry"),
+        "---\nkind: workflow_template\nname: all-code\n---\nvessels:\n  - name: work\n    crew:\n      - role: verify\n        command: cargo check\n",
+    )
+    .expect("write default-scoped workflow");
+    std::fs::write(
+        tmp.path().join("test-command.entry"),
+        "---\nkind: verification_command\nname: test\nrepos: [app]\n---\ncommand: cargo test --workspace\n",
+    )
+    .expect("write verification command");
+
+    let mut rx = daemon.subscribe();
+    assert_eq!(
+        execute_project_command(&daemon, &mut rx, CommandAction::ProjectRegister { target: tmp.path().to_string_lossy().into_owned() })
+            .await,
+        CommandValue::ProjectRegistered { name: "demo".to_string(), members: 3 }
+    );
+    let project = backend.using::<Project>("flotilla").get("demo").await.expect("project");
+    let app = project.spec.repositories.iter().find(|member| member.alias.as_deref() == Some("app")).expect("app");
+    let docs = project.spec.repositories.iter().find(|member| member.alias.as_deref() == Some("docs")).expect("docs");
+    let workflows = backend.using::<WorkflowTemplate>("flotilla");
+    let scoped = workflows.get("scoped").await.expect("scoped workflow");
+    assert_eq!(scoped.spec.vessels[0].repository_refs.as_deref(), Some(std::slice::from_ref(&app.repo)));
+    assert_eq!(scoped.metadata.annotations.get(SOURCE_REPOSITORY_ANNOTATION), Some(&ops_spec.key().to_string()));
+    assert_eq!(scoped.metadata.annotations.get(SOURCE_COMMIT_ANNOTATION).map(String::as_str), Some("ops-commit"));
+    assert_eq!(
+        scoped.metadata.annotations.get(SOURCE_ENTRY_PATH_ANNOTATION).map(String::as_str),
+        Some("verification-commands/this-is-a-workflow.md")
+    );
+    let all_code = workflows.get("all-code").await.expect("default-scoped workflow");
+    assert_eq!(all_code.spec.vessels[0].repository_refs.as_deref(), Some([app.repo.clone(), docs.repo.clone()].as_slice()));
+    let app_repository = backend.using::<Repository>("flotilla").get(&app.repo.to_string()).await.expect("app repository");
+    let docs_repository = backend.using::<Repository>("flotilla").get(&docs.repo.to_string()).await.expect("docs repository");
+    assert_eq!(app_repository.spec.verification_commands().get("test").map(String::as_str), Some("cargo test --workspace"));
+    assert!(docs_repository.spec.verification_commands().is_empty());
+
+    workflows
+        .update(
+            &InputMeta::from(&scoped.metadata),
+            &scoped.metadata.resource_version,
+            &WorkflowTemplateSpec::builder().vessels(Vec::new()).build(),
+        )
+        .await
+        .expect("drift workflow");
+    assert_eq!(
+        execute_project_command(&daemon, &mut rx, CommandAction::ProjectRefresh { name: "demo".to_string() }).await,
+        CommandValue::ProjectRefreshed {
+            name: "demo".to_string(),
+            members: 3,
+            converged: true,
+            changes: vec!["WorkflowTemplate/scoped".to_string()],
+        }
+    );
+    assert_eq!(workflows.get("scoped").await.expect("converged workflow").spec, scoped.spec);
 }
 
 #[tokio::test]

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -828,6 +828,8 @@ pub enum CommandValue {
         name: String,
         members: usize,
         converged: bool,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        changes: Vec<String>,
     },
 }
 

--- a/crates/flotilla-resources/src/crds/repository.crd.yaml
+++ b/crates/flotilla-resources/src/crds/repository.crd.yaml
@@ -54,6 +54,10 @@ spec:
                       enum: [fork]
                 allow_reviewless_workflows:
                   type: boolean
+                verification_commands:
+                  type: object
+                  additionalProperties:
+                    type: string
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true

--- a/crates/flotilla-resources/src/repository.rs
+++ b/crates/flotilla-resources/src/repository.rs
@@ -38,6 +38,8 @@ pub struct RepositorySpec {
     upstream: Option<RepositoryUpstream>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     allow_reviewless_workflows: bool,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    verification_commands: BTreeMap<String, String>,
 }
 
 impl RepositorySpec {
@@ -53,6 +55,7 @@ impl RepositorySpec {
             forge: Some(forge),
             upstream: None,
             allow_reviewless_workflows: false,
+            verification_commands: BTreeMap::new(),
         })
     }
 
@@ -72,6 +75,7 @@ impl RepositorySpec {
             forge: None,
             upstream: None,
             allow_reviewless_workflows: false,
+            verification_commands: BTreeMap::new(),
         })
     }
 
@@ -104,6 +108,10 @@ impl RepositorySpec {
         self.allow_reviewless_workflows
     }
 
+    pub fn verification_commands(&self) -> &BTreeMap<String, String> {
+        &self.verification_commands
+    }
+
     pub fn with_upstream(mut self, url: impl Into<String>, relation: RepositoryRelation) -> Result<Self, String> {
         let url = crate::canonicalize_repo_url(&url.into())?;
         self.upstream = Some(RepositoryUpstream { url, relation });
@@ -112,6 +120,11 @@ impl RepositorySpec {
 
     pub fn with_allow_reviewless_workflows(mut self, allow: bool) -> Self {
         self.allow_reviewless_workflows = allow;
+        self
+    }
+
+    pub fn with_verification_commands(mut self, commands: BTreeMap<String, String>) -> Self {
+        self.verification_commands = commands;
         self
     }
 
@@ -283,7 +296,7 @@ pub async fn ensure_repository(
         }
         // Identity-only observations are common during provisioning and must not
         // erase provenance supplied by the per-repository config authority.
-        if spec.upstream.is_none() && !spec.allow_reviewless_workflows {
+        if spec.upstream.is_none() && !spec.allow_reviewless_workflows && spec.verification_commands.is_empty() {
             return Ok(repository);
         }
         return repositories.update(&InputMeta::from(&repository.metadata), &repository.metadata.resource_version, spec).await;
@@ -305,6 +318,8 @@ impl<'de> Deserialize<'de> for RepositorySpec {
             upstream: Option<RepositoryUpstream>,
             #[serde(default)]
             allow_reviewless_workflows: bool,
+            #[serde(default)]
+            verification_commands: BTreeMap<String, String>,
         }
 
         let stored = StoredRepositorySpec::deserialize(deserializer)?;
@@ -326,6 +341,7 @@ impl<'de> Deserialize<'de> for RepositorySpec {
             }
         }
         normalized.allow_reviewless_workflows = stored.allow_reviewless_workflows;
+        normalized.verification_commands = stored.verification_commands;
         Ok(normalized)
     }
 }

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -306,9 +306,9 @@ pub fn handle_result(result: CommandValue, app: &mut App) {
             info!(%name, %members, "project registered from declaration");
             app.set_status_message(Some(format!("Project registered: {name} ({members} members)")));
         }
-        CommandValue::ProjectRefreshed { name, members, converged } => {
-            info!(%name, %members, %converged, "project declaration refreshed");
-            let outcome = if converged { "drift converged" } else { "already current" };
+        CommandValue::ProjectRefreshed { name, members, converged, changes } => {
+            info!(%name, %members, %converged, ?changes, "project declaration refreshed");
+            let outcome = if converged { format!("changed: {}", changes.join(", ")) } else { "already current".to_string() };
             app.set_status_message(Some(format!("Project refreshed: {name} ({members} members, {outcome})")));
         }
     }

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -605,10 +605,10 @@ fn format_command_result(result: &flotilla_protocol::commands::CommandValue) -> 
         CommandValue::ProjectAdded { name } => format!("project added: {name}"),
         CommandValue::ProjectApplied { name } => format!("project applied: {name}"),
         CommandValue::ProjectRegistered { name, members } => format!("project registered: {name} ({members} members)"),
-        CommandValue::ProjectRefreshed { name, members, converged } => format!(
-            "project refreshed: {name} ({members} members, {})",
-            if *converged { "materialized drift converged" } else { "already current" }
-        ),
+        CommandValue::ProjectRefreshed { name, members, converged, changes } => {
+            let outcome = if *converged { format!("changed: {}", changes.join(", ")) } else { "already current".to_string() };
+            format!("project refreshed: {name} ({members} members, {outcome})")
+        }
     }
 }
 

--- a/docs/project-declarations.md
+++ b/docs/project-declarations.md
@@ -42,3 +42,47 @@ refreshes. This follows the repository identity model: forge renames are served
 through redirects while resource references retain their established key.
 Projects created with `project add` or `project apply` remain valid and cannot
 be refreshed until they opt in by being registered from a declaration.
+
+## Operational entries
+
+Members with the `ops` role may contain operational entries. Flotilla examines
+the committed files in each locally available ops-member checkout during
+`project register` and `project refresh`; it does not watch the checkout and it
+does not read uncommitted contents. An entry is identified by YAML frontmatter,
+independent of its filename or directory:
+
+```yaml
+---
+kind: workflow_template
+name: implement-review
+repos: [app]
+---
+vessels:
+  - name: work
+    crew:
+      - role: coder
+        selector:
+          capability: code
+```
+
+`repos` names project member aliases and is authoritative. Omitting it targets
+all `code`-role members; an explicit empty list is rejected. Materialization
+resolves aliases to stable `RepositoryKey` values and writes them to each
+workflow vessel's `repository_refs`. The resulting `WorkflowTemplate` follows
+the same admission and snapshot-pinning path as a hand-applied template.
+
+Verification commands use the same frontmatter and materialize into the
+targeted Repository definitions:
+
+```yaml
+---
+kind: verification_command
+name: test
+---
+command: cargo test --workspace --locked
+```
+
+Materialized workflow metadata records the source ops repository, exact commit,
+and entry path. Repository metadata records equivalent provenance for its
+materialized verification-command set. Refresh restores drift, removes stale
+materialized workflows, and reports the definitions it changed.


### PR DESCRIPTION
Closes #1376

## Summary

- scan committed ops-member contents for frontmatter-declared workflow and verification-command entries during project registration/refresh
- resolve `repos` aliases to stable repository keys, default omitted scopes to all code members, and stamp source repository/commit/path provenance
- converge workflow and repository drift, remove stale materialized workflows, and report changed definitions from refresh
- document the entry format and cover misleading directory placement, scoped/default targeting, provenance, verification commands, and drift convergence

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`