### PR TITLE
feat: explain convoy settlement evidence

### DIFF
--- a/crates/flotilla-commands/src/commands/convoy.rs
+++ b/crates/flotilla-commands/src/commands/convoy.rs
@@ -21,6 +21,8 @@ pub struct ConvoyNoun {
 
 #[derive(Debug, Clone, PartialEq, Eq, Subcommand)]
 pub enum ConvoyVerb {
+    /// Explain why this convoy is holding in its current phase
+    Explain,
     /// Manage the work aboard a convoy's vessels
     Work(ConvoyWorkNoun),
     /// Delete a convoy and tear down its managed resources
@@ -169,6 +171,19 @@ pub enum ConvoyWorkVerb {
 impl ConvoyNoun {
     pub fn resolve(self) -> Result<Resolved, String> {
         match self.verb {
+            ConvoyVerb::Explain => Ok(Resolved::NeedsContext {
+                command: Command {
+                    node_id: None,
+                    provisioning_target: None,
+                    context_repo: None,
+                    action: CommandAction::QueryExplainConvoy {
+                        namespace: None,
+                        name: self.subject.ok_or_else(|| "convoy name is required before `explain`".to_string())?,
+                    },
+                },
+                repo: RepoContext::None,
+                host: HostResolution::Local,
+            }),
             ConvoyVerb::Work(work) => match work.verb {
                 ConvoyWorkVerb::Complete { message: _, force: false } => Err("human work completion requires --force".to_string()),
                 ConvoyWorkVerb::Complete { message, force: true } => Ok(Resolved::NeedsContext {
@@ -357,6 +372,7 @@ impl std::fmt::Display for ConvoyNoun {
             write!(f, " {subject}")?;
         }
         match &self.verb {
+            ConvoyVerb::Explain => write!(f, " explain")?,
             ConvoyVerb::Work(work) => {
                 write!(f, " work {}", work.subject)?;
                 match &work.verb {
@@ -482,6 +498,18 @@ mod tests {
 
     fn parse(args: &[&str]) -> ConvoyNoun {
         ConvoyNoun::try_parse_from(args).expect("should parse")
+    }
+
+    #[test]
+    fn convoy_explain_resolves_as_a_query() {
+        let resolved = parse(&["convoy", "held-work", "explain"]).resolve().expect("resolve");
+        assert!(matches!(resolved, Resolved::NeedsContext { command, .. }
+            if command.action == CommandAction::QueryExplainConvoy { namespace: None, name: "held-work".to_string() }));
+    }
+
+    #[test]
+    fn round_trip_explain() {
+        assert_round_trip::<ConvoyNoun>(&["convoy", "held-work", "explain"]);
     }
 
     #[test]

--- a/crates/flotilla-core/src/daemon.rs
+++ b/crates/flotilla-core/src/daemon.rs
@@ -2,8 +2,10 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use flotilla_protocol::{
-    arg::Arg, commands::CommandValue, AttachExcursionId, Command, DaemonEvent, QueryCursor, RepoInfo, RepoSelector, RepoSnapshot,
-    StatusResponse, StreamKey, TopologyResponse,
+    arg::Arg,
+    commands::{CommandValue, ConvoyExplanation},
+    AttachExcursionId, Command, DaemonEvent, QueryCursor, RepoInfo, RepoSelector, RepoSnapshot, StatusResponse, StreamKey,
+    TopologyResponse,
 };
 use tokio::sync::broadcast;
 use uuid::Uuid;
@@ -117,6 +119,11 @@ pub trait DaemonHandle: Send + Sync {
     /// without broadcasting. Only valid for commands where `action.is_query()`.
     /// The `session_id` ties cursor ownership to the calling client session.
     async fn execute_query(&self, command: Command, session_id: Uuid) -> Result<CommandValue, String>;
+
+    #[doc(hidden)]
+    async fn explain_convoy_internal(&self, _namespace: Option<&str>, _name: &str) -> Result<ConvoyExplanation, String> {
+        Err("convoy explanation is unsupported by this daemon".to_string())
+    }
 
     /// High-level status: repos, health, counts.
     async fn get_status(&self) -> Result<StatusResponse, String>;

--- a/crates/flotilla-core/src/daemon.rs
+++ b/crates/flotilla-core/src/daemon.rs
@@ -2,10 +2,8 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use flotilla_protocol::{
-    arg::Arg,
-    commands::{CommandValue, ConvoyExplanation},
-    AttachExcursionId, Command, DaemonEvent, QueryCursor, RepoInfo, RepoSelector, RepoSnapshot, StatusResponse, StreamKey,
-    TopologyResponse,
+    arg::Arg, commands::CommandValue, AttachExcursionId, Command, DaemonEvent, QueryCursor, RepoInfo, RepoSelector, RepoSnapshot,
+    StatusResponse, StreamKey, TopologyResponse,
 };
 use tokio::sync::broadcast;
 use uuid::Uuid;
@@ -119,11 +117,6 @@ pub trait DaemonHandle: Send + Sync {
     /// without broadcasting. Only valid for commands where `action.is_query()`.
     /// The `session_id` ties cursor ownership to the calling client session.
     async fn execute_query(&self, command: Command, session_id: Uuid) -> Result<CommandValue, String>;
-
-    #[doc(hidden)]
-    async fn explain_convoy_internal(&self, _namespace: Option<&str>, _name: &str) -> Result<ConvoyExplanation, String> {
-        Err("convoy explanation is unsupported by this daemon".to_string())
-    }
 
     /// High-level status: repos, health, counts.
     async fn get_status(&self) -> Result<StatusResponse, String>;

--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -170,6 +170,7 @@ pub async fn build_plan(
     match action {
         CommandAction::QueryResourceList { .. }
         | CommandAction::QueryResourceGet { .. }
+        | CommandAction::QueryExplainConvoy { .. }
         | CommandAction::ResourceApply { .. }
         | CommandAction::ResourceDelete { .. }
         | CommandAction::ResourceWatch { .. } => {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -36,23 +36,23 @@ use flotilla_protocol::{
 };
 use flotilla_resources::{
     api_version, apply_resource_document, apply_status_patch as apply_resource_status_patch,
-    apply_status_patch_checked as apply_resource_status_patch_checked, ensure_repository, evaluate_landing_settlement,
-    expected_change_request_leaves, expected_checkout_refs, external_patches as convoy_external_patches, list_resource_kind,
-    list_resource_kind_including_replicas, normalize_project_spec, repository_display_labels, resolve_project_issue_sources,
-    terminal_session_attach_target, watch_resource_kind, watch_resource_kind_from, watch_resource_kind_including_replicas,
-    watch_resource_kind_replica_sources, BoundChangeRequest, Checkout as ResourceCheckout, CheckoutIntegrationStatus,
-    CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus, Clock,
-    ConditionValue, Convoy as ResourceConvoy, ConvoyIssue, ConvoyRepositorySpec, ConvoySpec, ConvoyStatusPatch, CredentialGrant,
-    CredentialSpec, CrewCompletionPending, CrewSource, Environment as ResourceEnvironment, Host as ResourceHost,
-    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus, InMemoryBackend, InputMeta,
-    InputValue, IntegrationCondition, IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable, LifecycleAuthority,
-    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project, ProjectRepositoryRole,
-    ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError,
-    ResourceObject, ResourceProvenance, SettlementMode, SystemClock, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
-    TerminalSession as ResourceTerminalSession, TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase,
-    TerminalSessionSource, TerminalSessionStatusPatch, UnmetSettlementExpectation, Vessel, WatchEvent, WatchStart, WorkCompletionAuthority,
-    WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec, ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL,
-    HEARTBEAT_READY_TTL_SECS, MANAGED_BY_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
+    apply_status_patch_checked as apply_resource_status_patch_checked, bound_change_request_record_name, ensure_repository,
+    evaluate_landing_settlement, expected_change_request_leaves, expected_checkout_refs, external_patches as convoy_external_patches,
+    list_resource_kind, list_resource_kind_including_replicas, normalize_project_spec, repository_display_labels,
+    resolve_project_issue_sources, terminal_session_attach_target, watch_resource_kind, watch_resource_kind_from,
+    watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, BoundChangeRequest, Checkout as ResourceCheckout,
+    CheckoutIntegrationStatus, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
+    CheckoutStatus as ResourceCheckoutStatus, Clock, ConditionValue, Convoy as ResourceConvoy, ConvoyIssue, ConvoyRepositorySpec,
+    ConvoySpec, ConvoyStatusPatch, CredentialGrant, CredentialSpec, CrewCompletionPending, CrewSource, Environment as ResourceEnvironment,
+    Host as ResourceHost, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus,
+    InMemoryBackend, InputMeta, InputValue, IntegrationCondition, IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable,
+    LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project,
+    ProjectRepositoryRole, ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend,
+    ResourceError, ResourceObject, ResourceProvenance, SettlementMode, SystemClock, TerminalBrief, TerminalCrewContext,
+    TerminalCrewMessage, TerminalSession as ResourceTerminalSession, TerminalSessionIdentity,
+    TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch, UnmetSettlementExpectation,
+    Vessel, WatchEvent, WatchStart, WorkCompletionAuthority, WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec,
+    ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL, HEARTBEAT_READY_TTL_SECS, MANAGED_BY_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
 use futures::{FutureExt, StreamExt};
 use sha2::{Digest, Sha256};
@@ -8641,72 +8641,7 @@ async fn execute_local_remote_step_batch(
     Ok(outcomes)
 }
 
-#[async_trait]
-impl DaemonHandle for InProcessDaemon {
-    fn subscribe(&self) -> broadcast::Receiver<DaemonEvent> {
-        self.event_tx.subscribe()
-    }
-
-    fn query_subscription(&self, subscriber_id: uuid::Uuid) -> QuerySubscription {
-        let state = self.aggregator_projection_state.clone();
-        let namespace = self.provisioning_namespace.read().expect("provisioning namespace lock poisoned").clone();
-        self.connect_surface(subscriber_id, SurfaceDeclaration::focal_for_namespace(namespace));
-        let daemon = self.self_weak.clone();
-        QuerySubscription::new(move || {
-            state.remove_subscriber(subscriber_id);
-            if let Some(daemon) = daemon.upgrade() {
-                tokio::spawn(async move {
-                    if let Err(error) = daemon.disconnect_surface(subscriber_id).await {
-                        warn!(%error, "failed to disconnect in-process surface");
-                    }
-                });
-            }
-        })
-    }
-
-    async fn get_state(&self, repo: &flotilla_protocol::RepoSelector) -> Result<RepoSnapshot, String> {
-        let repo_path = self.resolve_repo_selector(repo).await?;
-        let identity =
-            self.tracked_repo_identity_for_path(&repo_path).await.ok_or_else(|| format!("repo not tracked: {}", repo_path.display()))?;
-        let peer_overlay = self.peer_providers.read().await.get(&identity).cloned();
-        let repos = self.repos.read().await;
-        let state = repos.get(&identity).ok_or_else(|| format!("repo not tracked: {}", repo_path.display()))?;
-        Ok(match state.cached_snapshot() {
-            Some(s) => (**s).clone(),
-            None => build_repo_snapshot_with_peers(
-                state.snapshot_context(&self.node_id, &self.host_name, &self.environment_manager),
-                state.seq(),
-                peer_overlay.as_deref(),
-            ),
-        })
-    }
-
-    async fn list_repos(&self) -> Result<Vec<RepoInfo>, String> {
-        let repository_keys = self.repository_keys_by_path.read().await;
-        let repos = self.repos.read().await;
-        let order = self.repo_order.read().await;
-        let mut result = Vec::new();
-        for identity in order.iter() {
-            if let Some(state) = repos.get(identity) {
-                result.push(RepoInfo {
-                    identity: state.identity().clone(),
-                    repository_key: repository_keys.get(state.preferred_path()).cloned(),
-                    path: Some(state.preferred_path().to_path_buf()),
-                    name: repo_name(state.preferred_path()),
-                    labels: state.labels().clone(),
-                    provider_names: state.provider_names(),
-                    provider_health: crate::convert::health_to_proto(state.provider_health()),
-                    loading: state.loading(),
-                });
-            }
-        }
-        Ok(result)
-    }
-
-    async fn execute(&self, command: Command) -> Result<u64, String> {
-        self.execute_impl(command, Arc::new(crate::step::UnsupportedRemoteStepExecutor), false, None).await
-    }
-
+impl InProcessDaemon {
     async fn explain_convoy_internal(&self, requested_namespace: Option<&str>, name: &str) -> Result<ConvoyExplanation, String> {
         let namespace = requested_namespace.map(ToOwned::to_owned).unwrap_or(self.provisioning_namespace().await);
         let convoy_sources =
@@ -8781,13 +8716,7 @@ impl DaemonHandle for InProcessDaemon {
                 _ => None,
             })
             .collect::<BTreeSet<_>>();
-        let bound_name = convoy.spec.change_request.as_ref().and_then(|bound| {
-            let repository = convoy.spec.repositories.iter().find(|repository| repository.repo_ref == bound.repository_ref)?;
-            let leaf = flotilla_resources::expected_change_request_leaves(&convoy, &selected_checkouts).ok()?.into_iter().next()?;
-            let flotilla_protocol::LeafAddress::ChangeRequest { service, scope, number } = leaf.address else { return None };
-            let _ = repository;
-            Some(flotilla_resources::change_request_record_name(&service, &scope, number))
-        });
+        let bound_name = bound_change_request_record_name(&convoy).map_err(|error| format!("derive bound change request: {error}"))?;
         let change_requests = expected_change_requests
             .iter()
             .map(|record_name| {
@@ -8877,6 +8806,73 @@ impl DaemonHandle for InProcessDaemon {
             crew_deliveries,
             settlement,
         })
+    }
+}
+
+#[async_trait]
+impl DaemonHandle for InProcessDaemon {
+    fn subscribe(&self) -> broadcast::Receiver<DaemonEvent> {
+        self.event_tx.subscribe()
+    }
+
+    fn query_subscription(&self, subscriber_id: uuid::Uuid) -> QuerySubscription {
+        let state = self.aggregator_projection_state.clone();
+        let namespace = self.provisioning_namespace.read().expect("provisioning namespace lock poisoned").clone();
+        self.connect_surface(subscriber_id, SurfaceDeclaration::focal_for_namespace(namespace));
+        let daemon = self.self_weak.clone();
+        QuerySubscription::new(move || {
+            state.remove_subscriber(subscriber_id);
+            if let Some(daemon) = daemon.upgrade() {
+                tokio::spawn(async move {
+                    if let Err(error) = daemon.disconnect_surface(subscriber_id).await {
+                        warn!(%error, "failed to disconnect in-process surface");
+                    }
+                });
+            }
+        })
+    }
+
+    async fn get_state(&self, repo: &flotilla_protocol::RepoSelector) -> Result<RepoSnapshot, String> {
+        let repo_path = self.resolve_repo_selector(repo).await?;
+        let identity =
+            self.tracked_repo_identity_for_path(&repo_path).await.ok_or_else(|| format!("repo not tracked: {}", repo_path.display()))?;
+        let peer_overlay = self.peer_providers.read().await.get(&identity).cloned();
+        let repos = self.repos.read().await;
+        let state = repos.get(&identity).ok_or_else(|| format!("repo not tracked: {}", repo_path.display()))?;
+        Ok(match state.cached_snapshot() {
+            Some(s) => (**s).clone(),
+            None => build_repo_snapshot_with_peers(
+                state.snapshot_context(&self.node_id, &self.host_name, &self.environment_manager),
+                state.seq(),
+                peer_overlay.as_deref(),
+            ),
+        })
+    }
+
+    async fn list_repos(&self) -> Result<Vec<RepoInfo>, String> {
+        let repository_keys = self.repository_keys_by_path.read().await;
+        let repos = self.repos.read().await;
+        let order = self.repo_order.read().await;
+        let mut result = Vec::new();
+        for identity in order.iter() {
+            if let Some(state) = repos.get(identity) {
+                result.push(RepoInfo {
+                    identity: state.identity().clone(),
+                    repository_key: repository_keys.get(state.preferred_path()).cloned(),
+                    path: Some(state.preferred_path().to_path_buf()),
+                    name: repo_name(state.preferred_path()),
+                    labels: state.labels().clone(),
+                    provider_names: state.provider_names(),
+                    provider_health: crate::convert::health_to_proto(state.provider_health()),
+                    loading: state.loading(),
+                });
+            }
+        }
+        Ok(result)
+    }
+
+    async fn execute(&self, command: Command) -> Result<u64, String> {
+        self.execute_impl(command, Arc::new(crate::step::UnsupportedRemoteStepExecutor), false, None).await
     }
 
     async fn execute_query(&self, command: Command, session_id: uuid::Uuid) -> Result<flotilla_protocol::CommandValue, String> {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -22,33 +22,34 @@ use flotilla_protocol::{
     commands::{AttachMode, RepositoryIdentityChange},
     qualified_path::{HostId, QualifiedPath},
     result_set::{CheckoutRow, ConvoyChangeRequest, ConvoyRow, ResultSet, Rows},
-    AttachBinding, Command, CommandAction, CommandValue, ConvoyDispatchRegard, CorrelationKey, CrewCommandContext, CrewListMember,
-    CrewListResponse, DaemonEvent, DeltaEntry, EnvironmentId, FleetHealthResponse, FleetHostRow, FleetHostStaleness, FleetListResponse,
-    FleetListRow, FleetObservationAgreement, FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListResponse, HostName,
-    HostProviderStatus, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId, NodeInfo, PeerConnectionState, PlacementDecision,
-    PlacementRefusal, PlacementTargetHost, PlacementViableCandidate, PrincipalRef, ProjectListEntry, ProjectListRepository,
-    ProjectListResponse, ProviderData, ProviderInfo, QueryCursor, RepoDelta, RepoDetailResponse, RepoIdentity, RepoInfo,
-    RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedAttachAction, ResolvedAttachPlan, ResourceCursor,
-    ResourceJsonResponse, ResourceReadEnvelope, ResourceReadRecord, ResourceRecordProvenance, ResourceRecordType, ResourceRef,
-    StatusResponse, StepStatus, StreamKey, SurfaceDeclaration, SystemInfo, ToolInventory, TopologyResponse, TopologyRoute, ViewAddress,
-    AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
+    AttachBinding, Command, CommandAction, CommandValue, ConvoyDispatchRegard, ConvoyExplanation, CorrelationKey, CrewCommandContext,
+    CrewListMember, CrewListResponse, DaemonEvent, DeltaEntry, EnvironmentId, EvidenceFreshness, ExplainedChangeRequest, ExplainedCheckout,
+    ExplainedCondition, ExplainedCrewDelivery, ExplainedLeafFiring, ExplainedSettlement, ExplainedSubscription, ExplainedUnmetExpectation,
+    FleetHealthResponse, FleetHostRow, FleetHostStaleness, FleetListResponse, FleetListRow, FleetObservationAgreement,
+    FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListResponse, HostName, HostProviderStatus, HostProvidersResponse,
+    HostStatusResponse, HostSummary, NodeId, NodeInfo, PeerConnectionState, PlacementDecision, PlacementRefusal, PlacementTargetHost,
+    PlacementViableCandidate, PrincipalRef, ProjectListEntry, ProjectListRepository, ProjectListResponse, ProviderData, ProviderInfo,
+    QueryCursor, RepoDelta, RepoDetailResponse, RepoIdentity, RepoInfo, RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse,
+    ResolvedAttachAction, ResolvedAttachPlan, ResourceCursor, ResourceJsonResponse, ResourceReadEnvelope, ResourceReadRecord,
+    ResourceRecordProvenance, ResourceRecordType, ResourceRef, StatusResponse, StepStatus, StreamKey, SurfaceDeclaration, SystemInfo,
+    ToolInventory, TopologyResponse, TopologyRoute, ViewAddress, AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
     api_version, apply_resource_document, apply_status_patch as apply_resource_status_patch,
-    apply_status_patch_checked as apply_resource_status_patch_checked, external_patches as convoy_external_patches, get_resource_kind,
-    list_resource_kind, list_resource_kind_including_replicas, normalize_project_spec, repository_display_labels,
-    resolve_project_issue_sources, terminal_session_attach_target, watch_resource_kind, watch_resource_kind_from,
-    watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, BoundChangeRequest, Checkout as ResourceCheckout,
-    CheckoutIntegrationStatus, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
+    apply_status_patch_checked as apply_resource_status_patch_checked, evaluate_landing_settlement, expected_change_request_leaves,
+    expected_checkout_refs, external_patches as convoy_external_patches, list_resource_kind, list_resource_kind_including_replicas,
+    normalize_project_spec, repository_display_labels, resolve_project_issue_sources, terminal_session_attach_target, watch_resource_kind,
+    watch_resource_kind_from, watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, BoundChangeRequest,
+    Checkout as ResourceCheckout, CheckoutIntegrationStatus, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
     CheckoutStatus as ResourceCheckoutStatus, Clock, ConditionValue, Convoy as ResourceConvoy, ConvoyIssue, ConvoyRepositorySpec,
     ConvoySpec, ConvoyStatusPatch, CredentialGrant, CredentialSpec, CrewCompletionPending, CrewSource, Environment as ResourceEnvironment,
     Host as ResourceHost, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus,
     InMemoryBackend, InputMeta, InputValue, IntegrationCondition, IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable,
     LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project,
     ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError,
-    ResourceObject, ResourceProvenance, SystemClock, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
+    ResourceObject, ResourceProvenance, SettlementMode, SystemClock, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
     TerminalSession as ResourceTerminalSession, TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase,
-    TerminalSessionSource, TerminalSessionStatusPatch, Vessel, WatchEvent, WatchStart, WorkCompletionAuthority,
+    TerminalSessionSource, TerminalSessionStatusPatch, UnmetSettlementExpectation, Vessel, WatchEvent, WatchStart, WorkCompletionAuthority,
     WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec, ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL,
     HEARTBEAT_READY_TTL_SECS, MANAGED_BY_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
@@ -83,7 +84,7 @@ use crate::{
         resolve_or_create_remote_environment_id, resolve_or_create_remote_host_id,
     },
     host_registry::HostCounts,
-    leaf_engine::LeafSubscriptionTable,
+    leaf_engine::{LeafSubscriptionTable, LeafWatcher},
     model::{provider_names_from_registry, repo_name, RepoModel},
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     placement_policy::reconcile_registered_policy,
@@ -315,6 +316,89 @@ fn resource_record(record_type: ResourceRecordType, object: serde_json::Value, l
         _ => ResourceRecordProvenance::Local { node_id: local_node_id.clone() },
     };
     ResourceReadRecord { record_type, provenance, object: Some(object) }
+}
+
+fn explained_provenance(provenance: &ResourceProvenance, local_node_id: &NodeId) -> ResourceRecordProvenance {
+    match provenance {
+        ResourceProvenance::Local => ResourceRecordProvenance::Local { node_id: local_node_id.clone() },
+        ResourceProvenance::Replica { origin_root, last_synced_at } => {
+            ResourceRecordProvenance::Replica { origin_root: origin_root.clone(), last_synced_at: last_synced_at.to_rfc3339() }
+        }
+    }
+}
+
+fn observed_freshness(observed_at: Option<DateTime<Utc>>, now: DateTime<Utc>, ttl: Duration) -> EvidenceFreshness {
+    match observed_at.and_then(|observed_at| now.signed_duration_since(observed_at).to_std().ok()) {
+        Some(age) if age < ttl => EvidenceFreshness::Fresh,
+        Some(_) => EvidenceFreshness::Stale,
+        None => EvidenceFreshness::Missing,
+    }
+}
+
+fn explain_condition(condition: &IntegrationCondition, now: DateTime<Utc>, ttl: Duration) -> ExplainedCondition {
+    let observed_at = condition.observed_at.as_deref().and_then(|value| DateTime::parse_from_rfc3339(value).ok()).map(|at| at.to_utc());
+    ExplainedCondition {
+        value: match condition.value {
+            ConditionValue::True => "true",
+            ConditionValue::False => "false",
+            ConditionValue::Unknown => "unknown",
+        }
+        .to_string(),
+        observed_at: condition.observed_at.clone(),
+        freshness: observed_freshness(observed_at, now, ttl),
+        details: condition.details.clone(),
+    }
+}
+
+fn explain_unmet_expectation(expectation: UnmetSettlementExpectation) -> ExplainedUnmetExpectation {
+    match expectation {
+        UnmetSettlementExpectation::InvalidExpectedCheckouts { message } => {
+            ExplainedUnmetExpectation { reason: "invalid_expected_checkouts".to_string(), subject: "convoy".to_string(), detail: message }
+        }
+        UnmetSettlementExpectation::MissingCheckout { checkout } => ExplainedUnmetExpectation {
+            reason: "missing_record".to_string(),
+            subject: format!("checkout/{checkout}"),
+            detail: "expected checkout has no federated record".to_string(),
+        },
+        UnmetSettlementExpectation::MissingCheckoutStatus { checkout } => ExplainedUnmetExpectation {
+            reason: "missing_status".to_string(),
+            subject: format!("checkout/{checkout}"),
+            detail: "observed checkout has no status".to_string(),
+        },
+        UnmetSettlementExpectation::CheckoutConditionFalse { checkout, condition } => ExplainedUnmetExpectation {
+            reason: "false_condition".to_string(),
+            subject: format!("checkout/{checkout}.{condition}"),
+            detail: format!("{condition} is false"),
+        },
+        UnmetSettlementExpectation::CheckoutConditionUnknown { checkout, condition } => ExplainedUnmetExpectation {
+            reason: "unknown_condition".to_string(),
+            subject: format!("checkout/{checkout}.{condition}"),
+            detail: format!("{condition} is unknown"),
+        },
+        UnmetSettlementExpectation::StaleCheckoutEvidence { checkout, condition, observed_at } => ExplainedUnmetExpectation {
+            reason: "stale_evidence".to_string(),
+            subject: format!("checkout/{checkout}.{condition}"),
+            detail: observed_at.map_or_else(|| "evidence has no observation time".to_string(), |at| format!("observed at {at}")),
+        },
+        UnmetSettlementExpectation::MissingChangeRequest { record } => ExplainedUnmetExpectation {
+            reason: "missing_record".to_string(),
+            subject: format!("change_request/{record}"),
+            detail: "expected change request has no federated observation".to_string(),
+        },
+        UnmetSettlementExpectation::StaleChangeRequest { record, observed_at } => ExplainedUnmetExpectation {
+            reason: "stale_evidence".to_string(),
+            subject: format!("change_request/{record}.state"),
+            detail: observed_at.map_or_else(|| "state has no observation time".to_string(), |at| format!("observed at {at}")),
+        },
+        UnmetSettlementExpectation::ChangeRequestConditionFalse { record, value } => ExplainedUnmetExpectation {
+            reason: "false_condition".to_string(),
+            subject: format!("change_request/{record}.state"),
+            detail: value.map_or_else(|| "state is unknown".to_string(), |value| format!("state is {value}")),
+        },
+        UnmetSettlementExpectation::InvalidCondition { subject, message } => {
+            ExplainedUnmetExpectation { reason: "invalid_condition".to_string(), subject, detail: message }
+        }
+    }
 }
 
 fn resource_watch_record(event: serde_json::Value, local_node_id: &NodeId) -> Result<Option<ResourceReadRecord>, String> {
@@ -2676,7 +2760,8 @@ impl InProcessDaemon {
         let (namespace, name) = match action {
             flotilla_protocol::CommandAction::ConvoyDelete { namespace, name, .. }
             | flotilla_protocol::CommandAction::ConvoyAbandon { namespace, name, .. }
-            | flotilla_protocol::CommandAction::ConvoyResume { namespace, name, .. } => {
+            | flotilla_protocol::CommandAction::ConvoyResume { namespace, name, .. }
+            | flotilla_protocol::CommandAction::QueryExplainConvoy { namespace, name } => {
                 (namespace.clone().unwrap_or(self.provisioning_namespace().await), name.as_str())
             }
             flotilla_protocol::CommandAction::ConvoyWorkForceComplete { convoy, .. } => {
@@ -8360,6 +8445,178 @@ impl DaemonHandle for InProcessDaemon {
         self.execute_impl(command, Arc::new(crate::step::UnsupportedRemoteStepExecutor), false, None).await
     }
 
+    async fn explain_convoy_internal(&self, requested_namespace: Option<&str>, name: &str) -> Result<ConvoyExplanation, String> {
+        let namespace = requested_namespace.map(ToOwned::to_owned).unwrap_or(self.provisioning_namespace().await);
+        let convoy_sources =
+            self.resource_backend.including_replicas::<ResourceConvoy>(&namespace).list().await.map_err(|error| error.to_string())?;
+        let convoy_source = convoy_sources
+            .items
+            .into_iter()
+            .filter(|source| source.object.metadata.name == name)
+            .max_by_key(|source| matches!(source.provenance, ResourceProvenance::Local))
+            .ok_or_else(|| format!("convoy {namespace}/{name} not found in local or replicated resources"))?;
+        let convoy = convoy_source.object;
+        let now = self.clock.now();
+        let change_request_stale_after = self.change_request_stale_after();
+
+        let checkout_sources =
+            self.resource_backend.including_replicas::<ResourceCheckout>(&namespace).list().await.map_err(|error| error.to_string())?.items;
+        let selected_checkouts = flotilla_resources::select_convoy_children(&convoy, &checkout_sources);
+        let expected = expected_checkout_refs(&convoy).map_err(|error| format!("derive expected checkouts: {error}"))?;
+        let checkouts = expected
+            .iter()
+            .map(|checkout_name| {
+                let selected = selected_checkouts.get(checkout_name);
+                let provenance = selected.and_then(|object| {
+                    checkout_sources
+                        .iter()
+                        .find(|source| {
+                            source.object.metadata.name == object.metadata.name
+                                && source.object.metadata.resource_version == object.metadata.resource_version
+                        })
+                        .map(|source| explained_provenance(&source.provenance, &self.node_id))
+                });
+                let integration = selected.and_then(|checkout| checkout.status.as_ref()).map(|status| &status.integration);
+                ExplainedCheckout {
+                    name: checkout_name.clone(),
+                    observed: selected.is_some(),
+                    provenance,
+                    clean: integration.map(|status| explain_condition(&status.clean, now, LANDING_EVIDENCE_TTL)),
+                    pushed: integration.map(|status| explain_condition(&status.pushed, now, LANDING_EVIDENCE_TTL)),
+                    landed: integration.map(|status| explain_condition(&status.landed, now, LANDING_EVIDENCE_TTL)),
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let change_request_sources = self
+            .resource_backend
+            .including_replicas::<flotilla_resources::ChangeRequest>(&namespace)
+            .list()
+            .await
+            .map_err(|error| error.to_string())?
+            .items;
+        let mut selected_change_requests = BTreeMap::new();
+        for source in &change_request_sources {
+            let name = source.object.metadata.name.clone();
+            let replace = selected_change_requests.get(&name).is_none_or(
+                |existing: &&flotilla_resources::ReadResourceObject<flotilla_resources::ChangeRequest>| {
+                    !matches!(existing.provenance, ResourceProvenance::Local) && matches!(source.provenance, ResourceProvenance::Local)
+                },
+            );
+            if replace {
+                selected_change_requests.insert(name, source);
+            }
+        }
+        let change_request_objects =
+            selected_change_requests.iter().map(|(name, source)| (name.clone(), source.object.clone())).collect::<BTreeMap<_, _>>();
+        let expected_change_requests = expected_change_request_leaves(&convoy, &selected_checkouts)
+            .map_err(|error| format!("derive expected change requests: {error}"))?
+            .into_iter()
+            .filter_map(|leaf| match leaf.address {
+                flotilla_protocol::LeafAddress::ChangeRequest { service, scope, number } => {
+                    Some(flotilla_resources::change_request_record_name(&service, &scope, number))
+                }
+                _ => None,
+            })
+            .collect::<BTreeSet<_>>();
+        let bound_name = convoy.spec.change_request.as_ref().and_then(|bound| {
+            let repository = convoy.spec.repositories.iter().find(|repository| repository.repo_ref == bound.repository_ref)?;
+            let leaf = flotilla_resources::expected_change_request_leaves(&convoy, &selected_checkouts).ok()?.into_iter().next()?;
+            let flotilla_protocol::LeafAddress::ChangeRequest { service, scope, number } = leaf.address else { return None };
+            let _ = repository;
+            Some(flotilla_resources::change_request_record_name(&service, &scope, number))
+        });
+        let change_requests = expected_change_requests
+            .iter()
+            .map(|record_name| {
+                let selected = selected_change_requests.get(record_name).copied();
+                let observed_at = selected.and_then(|source| source.object.status.as_ref()).map(|status| status.state.observed_at);
+                ExplainedChangeRequest {
+                    name: record_name.clone(),
+                    bound: bound_name.as_ref() == Some(record_name),
+                    observed: selected.is_some(),
+                    provenance: selected.map(|source| explained_provenance(&source.provenance, &self.node_id)),
+                    fields: selected.and_then(|source| serde_json::to_value(&source.object).ok()),
+                    observed_at: observed_at.map(|at| at.to_rfc3339()),
+                    freshness: observed_freshness(observed_at, now, change_request_stale_after),
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let evaluation = evaluate_landing_settlement(
+            &convoy,
+            &selected_checkouts,
+            &change_request_objects,
+            change_request_stale_after,
+            LANDING_EVIDENCE_TTL,
+            now,
+        );
+        let settlement = ExplainedSettlement {
+            mode: match evaluation.mode {
+                SettlementMode::ClaimExit => "claim_exit",
+                SettlementMode::WorldTerminal => "world_terminal",
+            }
+            .to_string(),
+            satisfied: evaluation.satisfied,
+            unmet: evaluation.unmet.into_iter().map(explain_unmet_expectation).collect(),
+        };
+
+        let subscriptions = self
+            .leaf_subscriptions
+            .diagnostics()
+            .await
+            .into_iter()
+            .filter(|(row, _)| matches!(&row.watcher, LeafWatcher::ReconcilerWake { convoy } if convoy == name))
+            .map(|(row, firings)| ExplainedSubscription {
+                id: row.id,
+                watcher: match row.watcher {
+                    LeafWatcher::WaitCaller { .. } => "wait_caller",
+                    LeafWatcher::ReconcilerWake { .. } => "reconciler_wake",
+                }
+                .to_string(),
+                leaves: row.leaves,
+                last_leaf_firings: firings
+                    .into_iter()
+                    .map(|firing| ExplainedLeafFiring { leaf: firing.leaf, value: firing.value, fired_at: firing.fired_at.to_rfc3339() })
+                    .collect(),
+            })
+            .collect();
+
+        let mut crew_deliveries = self
+            .resource_backend
+            .including_replicas::<ResourceTerminalSession>(&namespace)
+            .list()
+            .await
+            .map_err(|error| error.to_string())?
+            .items
+            .into_iter()
+            .filter(|source| source.object.metadata.labels.get(CONVOY_LABEL).is_some_and(|convoy| convoy == name))
+            .map(|source| ExplainedCrewDelivery {
+                session: source.object.metadata.name,
+                role: source.object.spec.role,
+                // ADR 0028's delivery ladder has not landed yet. Keep the
+                // field explicit so recorded rungs appear without inventing
+                // one from session liveness or message delivery.
+                last_delivery_rung: None,
+                delivered_message_id: source.object.status.and_then(|status| status.delivered_message_id),
+            })
+            .collect::<Vec<_>>();
+        crew_deliveries.sort_by(|left, right| left.session.cmp(&right.session));
+
+        Ok(ConvoyExplanation {
+            namespace,
+            convoy: name.to_string(),
+            phase: convoy.status.as_ref().map_or_else(|| "Unknown".to_string(), |status| format!("{:?}", status.phase)),
+            evidence_ttl_seconds: LANDING_EVIDENCE_TTL.as_secs(),
+            change_request_stale_after_seconds: change_request_stale_after.as_secs(),
+            checkouts,
+            change_requests,
+            subscriptions,
+            crew_deliveries,
+            settlement,
+        })
+    }
+
     async fn execute_query(&self, command: Command, session_id: uuid::Uuid) -> Result<flotilla_protocol::CommandValue, String> {
         use flotilla_protocol::CommandAction;
         match &command.action {
@@ -8421,6 +8678,10 @@ impl DaemonHandle for InProcessDaemon {
                     Err(message) => Ok(flotilla_protocol::CommandValue::Error { message }),
                 }
             }
+            CommandAction::QueryExplainConvoy { namespace, name } => match self.explain_convoy_internal(namespace.as_deref(), name).await {
+                Ok(explanation) => Ok(CommandValue::ConvoyExplanation(Box::new(explanation))),
+                Err(message) => Ok(CommandValue::Error { message }),
+            },
             CommandAction::QueryResourceList { namespace, kind, include_replicas } => {
                 let listed = if *include_replicas {
                     list_resource_kind_including_replicas(&self.resource_backend, namespace, kind).await
@@ -8453,25 +8714,33 @@ impl DaemonHandle for InProcessDaemon {
                 // Take the collection cursor before reading the object. A
                 // concurrent mutation can then be replayed (at worst as a
                 // duplicate) instead of being hidden behind a newer cursor.
-                let listed = match list_resource_kind(&self.resource_backend, namespace, kind).await {
+                let cursor_list = match list_resource_kind(&self.resource_backend, namespace, kind).await {
                     Ok(listed) => listed,
                     Err(error) => return Ok(CommandValue::Error { message: error.to_string() }),
                 };
-                match get_resource_kind(&self.resource_backend, namespace, kind, name).await {
-                    Ok(v) => {
-                        let resource_version = listed.value["metadata"]["resourceVersion"].as_str().unwrap_or_default().to_string();
-                        let generation = listed.value["metadata"]["generation"].as_str().map(ToOwned::to_owned);
-                        let record = resource_record(ResourceRecordType::Current, v.value, &self.node_id);
-                        Ok(CommandValue::ResourceRead(Box::new(resource_read_envelope(
-                            v.kind,
-                            v.plural,
-                            v.namespace,
-                            ResourceCursor::from_position(resource_version, generation),
-                            vec![record],
-                        ))))
-                    }
-                    Err(error) => Ok(flotilla_protocol::CommandValue::Error { message: error.to_string() }),
-                }
+                let visible = match list_resource_kind_including_replicas(&self.resource_backend, namespace, kind).await {
+                    Ok(listed) => listed,
+                    Err(error) => return Ok(CommandValue::Error { message: error.to_string() }),
+                };
+                let object = visible.value["items"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .find(|object| object["metadata"]["name"].as_str() == Some(name.as_str()))
+                    .cloned();
+                let Some(object) = object else {
+                    return Ok(CommandValue::Error { message: format!("resource {kind}/{namespace}/{name} not found") });
+                };
+                let resource_version = cursor_list.value["metadata"]["resourceVersion"].as_str().unwrap_or_default().to_string();
+                let generation = cursor_list.value["metadata"]["generation"].as_str().map(ToOwned::to_owned);
+                let record = resource_record(ResourceRecordType::Current, object, &self.node_id);
+                Ok(CommandValue::ResourceRead(Box::new(resource_read_envelope(
+                    visible.kind,
+                    visible.plural,
+                    visible.namespace,
+                    ResourceCursor::from_position(resource_version, generation),
+                    vec![record],
+                ))))
             }
             CommandAction::Attach { reference, host, mode } => {
                 match self.resolve_attach_with_mode_internal(reference, host.as_ref(), false, *mode).await {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1101,6 +1101,60 @@ async fn create_explanation_convoy(
     }
 }
 
+async fn create_bound_explanation_convoy(
+    backend: &ResourceBackend,
+    name: &str,
+    observation: Option<(flotilla_resources::ObservedChangeRequestState, DateTime<Utc>)>,
+) {
+    let repo_ref = flotilla_resources::RepositoryKey("repo-a".to_string());
+    let mut spec = ConvoySpec::builder().workflow_ref("workflow".to_string()).build();
+    spec.repositories = vec![ConvoyRepositorySpec::builder()
+        .url(format!("https://example.com/org/{name}"))
+        .repo_ref(repo_ref.clone())
+        .source_ref("main".to_string())
+        .target_ref("main".to_string())
+        .workspace_slug("repo".to_string())
+        .subpaths(Vec::new())
+        .build()];
+    spec.change_request = Some(flotilla_resources::BoundChangeRequest {
+        id: "42".to_string(),
+        repository_ref: repo_ref,
+        title: "Bound change request".to_string(),
+    });
+    let convoys = backend.using::<Convoy>("flotilla");
+    let convoy = convoys.create(&empty_input_meta(name), &spec).await.expect("create bound convoy");
+    convoys
+        .update_status(name, &convoy.metadata.resource_version, &ConvoyStatus { phase: ConvoyPhase::Landing, ..Default::default() })
+        .await
+        .expect("update bound convoy status");
+
+    let Some((state, observed_at)) = observation else { return };
+    let scope = format!("org/{name}");
+    let record_name = flotilla_resources::change_request_record_name("example.com", &scope, 42);
+    let change_requests = backend.using::<flotilla_resources::ChangeRequest>("flotilla");
+    let change_request = change_requests
+        .create(&empty_input_meta(&record_name), &flotilla_resources::ChangeRequestSpec {
+            service: "example.com".to_string(),
+            scope,
+            number: 42,
+            observing_authority: "test".to_string(),
+        })
+        .await
+        .expect("create change request");
+    change_requests
+        .update_status(&record_name, &change_request.metadata.resource_version, &flotilla_resources::ChangeRequestStatus {
+            state: flotilla_resources::Observation::known(state, observed_at),
+            head_sha: flotilla_resources::Observation::known("abc123".to_string(), observed_at),
+            checks: flotilla_resources::Observation::known(flotilla_resources::ObservedChecks::Pass, observed_at),
+            review: flotilla_resources::ChangeRequestReviewObservation {
+                actionable_at_head: flotilla_resources::Observation::known(false, observed_at),
+            },
+            mergeable: flotilla_resources::Observation::known(flotilla_resources::ObservedMergeability::Mergeable, observed_at),
+        })
+        .await
+        .expect("update change request status");
+}
+
 async fn explain(daemon: &InProcessDaemon, name: &str) -> flotilla_protocol::ConvoyExplanation {
     let result = daemon
         .execute_query(
@@ -1145,6 +1199,39 @@ async fn convoy_explanation_names_each_held_landing_expectation_and_claim_exit()
     let claim_exit = explain(&daemon, "claim-exit").await;
     assert!(claim_exit.settlement.satisfied);
     assert_eq!(claim_exit.settlement.mode, "claim_exit");
+}
+
+#[tokio::test]
+async fn convoy_explanation_names_missing_stale_and_open_bound_change_requests() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let (daemon, _temp) = explanation_daemon(backend.clone()).await;
+    create_bound_explanation_convoy(&backend, "bound-missing", None).await;
+    create_bound_explanation_convoy(
+        &backend,
+        "bound-stale",
+        Some((flotilla_resources::ObservedChangeRequestState::Open, Utc::now() - ChronoDuration::hours(1))),
+    )
+    .await;
+    create_bound_explanation_convoy(&backend, "bound-open", Some((flotilla_resources::ObservedChangeRequestState::Open, Utc::now()))).await;
+
+    let missing = explain(&daemon, "bound-missing").await;
+    assert_eq!(missing.settlement.unmet[0].reason, "missing_record");
+    assert_eq!(
+        missing.settlement.unmet[0].subject,
+        format!("change_request/{}", flotilla_resources::change_request_record_name("example.com", "org/bound-missing", 42))
+    );
+    assert!(missing.change_requests[0].bound);
+    assert!(!missing.change_requests[0].observed);
+
+    let stale = explain(&daemon, "bound-stale").await;
+    assert_eq!(stale.settlement.unmet[0].reason, "stale_evidence");
+    assert!(stale.change_requests[0].bound);
+    assert_eq!(stale.change_requests[0].freshness, flotilla_protocol::EvidenceFreshness::Stale);
+
+    let open = explain(&daemon, "bound-open").await;
+    assert_eq!(open.settlement.unmet[0].reason, "false_condition");
+    assert!(open.change_requests[0].bound);
+    assert_eq!(open.change_requests[0].freshness, flotilla_protocol::EvidenceFreshness::Fresh);
 }
 
 #[tokio::test]

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1021,6 +1021,174 @@ fn input_meta_with_labels(name: &str, labels: BTreeMap<String, String>) -> Input
     InputMeta { labels, ..empty_input_meta(name) }
 }
 
+async fn explanation_daemon(backend: ResourceBackend) -> (Arc<InProcessDaemon>, tempfile::TempDir) {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"explanation-test\"\n").expect("write daemon config");
+    let daemon = InProcessDaemon::new_with_resource_backend(
+        vec![],
+        Arc::new(ConfigStore::with_base(config_base)),
+        fake_discovery(false),
+        HostName::new("local"),
+        backend,
+    )
+    .await;
+    (daemon, temp)
+}
+
+async fn create_explanation_convoy(
+    backend: &ResourceBackend,
+    name: &str,
+    checkout_name: Option<&str>,
+    landed: Option<(ConditionValue, DateTime<Utc>)>,
+) {
+    let repo_ref = flotilla_resources::RepositoryKey("repo-a".to_string());
+    let convoys = backend.using::<Convoy>("flotilla");
+    let mut spec = ConvoySpec::builder().workflow_ref("workflow".to_string()).build();
+    spec.repositories = vec![ConvoyRepositorySpec::builder()
+        .url("https://example.com/org/repo".to_string())
+        .repo_ref(repo_ref.clone())
+        .source_ref("main".to_string())
+        .target_ref("main".to_string())
+        .workspace_slug("repo".to_string())
+        .subpaths(Vec::new())
+        .build()];
+    let created = convoys.create(&empty_input_meta(name), &spec).await.expect("create convoy");
+    let mut status = ConvoyStatus { phase: ConvoyPhase::Landing, ..Default::default() };
+    if let Some(checkout_name) = checkout_name {
+        status.work.insert(
+            "work".to_string(),
+            WorkState::builder()
+                .phase(WorkPhase::Complete)
+                .placement(PlacementStatus {
+                    fields: BTreeMap::from([(
+                        "checkout_refs".to_string(),
+                        serde_json::json!(BTreeMap::from([(repo_ref.clone(), checkout_name.to_string())])),
+                    )]),
+                })
+                .build(),
+        );
+    }
+    convoys.update_status(name, &created.metadata.resource_version, &status).await.expect("update convoy status");
+
+    if let (Some(checkout_name), Some((value, observed_at))) = (checkout_name, landed) {
+        let checkouts = backend.using::<ResourceCheckout>("flotilla");
+        let checkout = checkouts
+            .create(
+                &input_meta_with_labels(checkout_name, BTreeMap::from([(CONVOY_LABEL.to_string(), name.to_string())])),
+                &ResourceCheckoutSpec::Observed(ResourceObservedCheckoutSpec {
+                    r#ref: "feature/explain".to_string(),
+                    path: format!("/tmp/{checkout_name}"),
+                    repo_ref,
+                    host_ref: "host-a".to_string(),
+                    is_main: false,
+                }),
+            )
+            .await
+            .expect("create checkout");
+        checkouts
+            .update_status(checkout_name, &checkout.metadata.resource_version, &ResourceCheckoutStatus {
+                phase: ResourceCheckoutPhase::Ready,
+                integration: CheckoutIntegrationStatus {
+                    landed: IntegrationCondition::builder().value(value).observed_at(observed_at.to_rfc3339()).build(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .await
+            .expect("update checkout status");
+    }
+}
+
+async fn explain(daemon: &InProcessDaemon, name: &str) -> flotilla_protocol::ConvoyExplanation {
+    let result = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::QueryExplainConvoy { namespace: Some("flotilla".to_string()), name: name.to_string() },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("explain query");
+    let CommandValue::ConvoyExplanation(explanation) = result else { panic!("expected convoy explanation, got {result:?}") };
+    *explanation
+}
+
+#[tokio::test]
+async fn convoy_explanation_names_each_held_landing_expectation_and_claim_exit() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let (daemon, _temp) = explanation_daemon(backend.clone()).await;
+    create_explanation_convoy(&backend, "missing", Some("checkout-missing"), None).await;
+    create_explanation_convoy(
+        &backend,
+        "stale",
+        Some("checkout-stale"),
+        Some((ConditionValue::True, Utc::now() - ChronoDuration::seconds(60))),
+    )
+    .await;
+    create_explanation_convoy(&backend, "false", Some("checkout-false"), Some((ConditionValue::False, Utc::now()))).await;
+    create_explanation_convoy(&backend, "claim-exit", None, None).await;
+
+    let missing = explain(&daemon, "missing").await;
+    assert_eq!(missing.settlement.unmet[0].reason, "missing_record");
+    assert_eq!(missing.settlement.unmet[0].subject, "checkout/checkout-missing");
+    let stale = explain(&daemon, "stale").await;
+    assert_eq!(stale.settlement.unmet[0].reason, "stale_evidence");
+    assert_eq!(stale.settlement.unmet[0].subject, "checkout/checkout-stale.landed");
+    let false_condition = explain(&daemon, "false").await;
+    assert_eq!(false_condition.settlement.unmet[0].reason, "false_condition");
+    assert_eq!(false_condition.settlement.unmet[0].subject, "checkout/checkout-false.landed");
+    let claim_exit = explain(&daemon, "claim-exit").await;
+    assert!(claim_exit.settlement.satisfied);
+    assert_eq!(claim_exit.settlement.mode, "claim_exit");
+}
+
+#[tokio::test]
+async fn convoy_explanation_and_resource_get_read_remote_replicas() {
+    let authority = ResourceBackend::InMemory(InMemoryBackend::default());
+    create_explanation_convoy(&authority, "remote-held", Some("remote-checkout"), Some((ConditionValue::False, Utc::now()))).await;
+    let local = ResourceBackend::InMemory(InMemoryBackend::default());
+    let remote_node = NodeId::new("remote-authority");
+    local
+        .replica_writer::<Convoy>(remote_node.clone(), "flotilla")
+        .replace(&authority.using::<Convoy>("flotilla").list().await.expect("list authority convoys"), Utc::now())
+        .await
+        .expect("replicate convoy");
+    local
+        .replica_writer::<ResourceCheckout>(remote_node, "flotilla")
+        .replace(&authority.using::<ResourceCheckout>("flotilla").list().await.expect("list authority checkouts"), Utc::now())
+        .await
+        .expect("replicate checkout");
+    let (daemon, _temp) = explanation_daemon(local).await;
+
+    let explanation = explain(&daemon, "remote-held").await;
+    assert_eq!(explanation.settlement.unmet[0].subject, "checkout/remote-checkout.landed");
+    assert!(matches!(explanation.checkouts[0].provenance, Some(flotilla_protocol::ResourceRecordProvenance::Replica { .. })));
+
+    let fetched = daemon
+        .execute_query(
+            Command {
+                node_id: None,
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::QueryResourceGet {
+                    namespace: "flotilla".to_string(),
+                    kind: "convoys".to_string(),
+                    name: "remote-held".to_string(),
+                },
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .await
+        .expect("resource get");
+    let CommandValue::ResourceRead(fetched) = fetched else { panic!("expected replicated resource read") };
+    assert!(matches!(fetched.records[0].provenance, flotilla_protocol::ResourceRecordProvenance::Replica { .. }));
+}
+
 async fn wait_for_command_result(events: &mut tokio::sync::broadcast::Receiver<DaemonEvent>, command_id: u64) -> CommandValue {
     tokio::time::timeout(std::time::Duration::from_secs(2), async {
         loop {

--- a/crates/flotilla-core/src/leaf_engine.rs
+++ b/crates/flotilla-core/src/leaf_engine.rs
@@ -40,6 +40,13 @@ pub struct LeafSubscriptionRow {
     pub episode_key: EpisodeKeyFields,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeafFiringRecord {
+    pub leaf: Leaf,
+    pub value: String,
+    pub fired_at: DateTime<Utc>,
+}
+
 #[derive(Clone)]
 pub struct LeafSubscriptionTable {
     inner: Arc<LeafSubscriptionTableInner>,
@@ -49,6 +56,7 @@ struct LeafSubscriptionTableInner {
     backend: ResourceBackend,
     event_tx: broadcast::Sender<DaemonEvent>,
     rows: Mutex<HashMap<uuid::Uuid, LeafSubscriptionRow>>,
+    last_firings: Mutex<HashMap<(uuid::Uuid, Leaf), LeafFiringRecord>>,
     tasks: Mutex<HashMap<uuid::Uuid, JoinHandle<()>>>,
     change_requests: ChangeRequestRefresher,
     reconciler_tx: broadcast::Sender<String>,
@@ -62,6 +70,7 @@ impl LeafSubscriptionTable {
                 backend,
                 event_tx,
                 rows: Mutex::new(HashMap::new()),
+                last_firings: Mutex::new(HashMap::new()),
                 tasks: Mutex::new(HashMap::new()),
                 change_requests,
                 reconciler_tx,
@@ -94,6 +103,7 @@ impl LeafSubscriptionTable {
         for subject in row.leaves.iter().filter_map(|leaf| ChangeRequestRef::from_address(&row.namespace, &leaf.address)) {
             if let Err(error) = self.inner.change_requests.demand(id, subject, row.freshness_demand).await {
                 self.inner.rows.lock().await.remove(&id);
+                self.forget_firings(id).await;
                 self.inner.change_requests.release(id).await;
                 return Err(error);
             }
@@ -123,6 +133,7 @@ impl LeafSubscriptionTable {
             .collect::<Vec<_>>();
         for id in ids {
             self.inner.rows.lock().await.remove(&id);
+            self.forget_firings(id).await;
             if let Some(task) = self.inner.tasks.lock().await.remove(&id) {
                 task.abort();
             }
@@ -138,15 +149,33 @@ impl LeafSubscriptionTable {
         self.inner.change_requests.stale_after()
     }
 
-    #[cfg(test)]
     pub async fn rows(&self) -> Vec<LeafSubscriptionRow> {
         self.inner.rows.lock().await.values().cloned().collect()
     }
 
+    pub async fn diagnostics(&self) -> Vec<(LeafSubscriptionRow, Vec<LeafFiringRecord>)> {
+        let mut rows = self.rows().await;
+        rows.sort_by_key(|row| row.created_at);
+        let firings = self.inner.last_firings.lock().await;
+        rows.into_iter()
+            .map(|row| {
+                let mut row_firings =
+                    firings.iter().filter(|((id, _), _)| *id == row.id).map(|(_, firing)| firing.clone()).collect::<Vec<_>>();
+                row_firings.sort_by_key(|firing| firing.fired_at);
+                (row, row_firings)
+            })
+            .collect()
+    }
+
     async fn finish(&self, id: uuid::Uuid) {
         self.inner.rows.lock().await.remove(&id);
+        self.forget_firings(id).await;
         self.inner.tasks.lock().await.remove(&id);
         self.inner.change_requests.release(id).await;
+    }
+
+    async fn forget_firings(&self, id: uuid::Uuid) {
+        self.inner.last_firings.lock().await.retain(|(subscription_id, _), _| *subscription_id != id);
     }
 
     async fn watch_row(&self, row: LeafSubscriptionRow) -> Result<(), String> {
@@ -208,6 +237,11 @@ impl LeafSubscriptionTable {
 
     async fn fire(&self, subscription_id: uuid::Uuid, mut fire: LeafFire) {
         fire.subscription_id = subscription_id;
+        self.inner.last_firings.lock().await.insert((subscription_id, fire.leaf.clone()), LeafFiringRecord {
+            leaf: fire.leaf.clone(),
+            value: fire.value.clone(),
+            fired_at: Utc::now(),
+        });
         let watcher = self.inner.rows.lock().await.get(&subscription_id).map(|row| row.watcher.clone());
         match watcher {
             Some(LeafWatcher::WaitCaller { connection_id }) => {
@@ -338,6 +372,7 @@ impl ReconcilerWake {
                 continue;
             }
             self.subscriptions.inner.rows.lock().await.remove(id);
+            self.subscriptions.forget_firings(*id).await;
             if let Some(task) = self.subscriptions.inner.tasks.lock().await.remove(id) {
                 task.abort();
             }
@@ -362,6 +397,7 @@ impl ReconcilerWake {
             for subject in row.leaves.iter().filter_map(|leaf| ChangeRequestRef::from_address(namespace, &leaf.address)) {
                 if let Err(error) = self.subscriptions.inner.change_requests.demand(id, subject, None).await {
                     self.subscriptions.inner.rows.lock().await.remove(&id);
+                    self.subscriptions.forget_firings(id).await;
                     self.subscriptions.inner.change_requests.release(id).await;
                     tracing::warn!(%convoy, %error, "arm reconciler leaf subscription failed");
                     continue 'desired_rows;
@@ -726,6 +762,44 @@ mod tests {
         .await
         .expect("leaf fire must enqueue reconcile without waiting for hourly resync");
         controller.abort();
+    }
+
+    #[tokio::test]
+    async fn diagnostics_retain_the_last_firing_for_an_armed_reconciler_row() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let (event_tx, _) = broadcast::channel(4);
+        let refresher = ChangeRequestRefresher::new(
+            backend.clone(),
+            "authority".to_string(),
+            Arc::new(ControlledChangeRequests { merged: AtomicBool::new(false) }),
+            crate::change_request_observer::ChangeRequestRefreshCadence::default(),
+        );
+        let table = LeafSubscriptionTable::new(backend, event_tx, refresher);
+        let id = uuid::Uuid::new_v4();
+        let fired_leaf = leaf(LeafAddress::Convoy { name: "held".to_string() }, ".status.phase", "Landed");
+        table.inner.rows.lock().await.insert(id, LeafSubscriptionRow {
+            id,
+            namespace: "flotilla".to_string(),
+            leaves: vec![fired_leaf.clone()],
+            watcher: LeafWatcher::ReconcilerWake { convoy: "held".to_string() },
+            freshness_demand: None,
+            created_at: Utc::now(),
+            episode_key: EpisodeKeyFields::default(),
+        });
+
+        table
+            .fire(id, LeafFire {
+                subscription_id: uuid::Uuid::nil(),
+                watcher_id: uuid::Uuid::nil(),
+                leaf: fired_leaf,
+                value: "Landed".into(),
+            })
+            .await;
+
+        let diagnostics = table.diagnostics().await;
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].1.len(), 1);
+        assert_eq!(diagnostics[0].1[0].value, "Landed");
     }
 
     #[tokio::test]

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -151,6 +151,108 @@ pub struct ResourceReadEnvelope {
     pub records: Vec<ResourceReadRecord>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceFreshness {
+    Fresh,
+    Stale,
+    Missing,
+    NotApplicable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExplainedCondition {
+    pub value: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_at: Option<String>,
+    pub freshness: EvidenceFreshness,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub details: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExplainedCheckout {
+    pub name: String,
+    pub observed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<ResourceRecordProvenance>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub clean: Option<ExplainedCondition>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pushed: Option<ExplainedCondition>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub landed: Option<ExplainedCondition>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExplainedChangeRequest {
+    pub name: String,
+    pub bound: bool,
+    pub observed: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<ResourceRecordProvenance>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fields: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_at: Option<String>,
+    pub freshness: EvidenceFreshness,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExplainedLeafFiring {
+    pub leaf: crate::Leaf,
+    pub value: String,
+    pub fired_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExplainedSubscription {
+    pub id: uuid::Uuid,
+    pub watcher: String,
+    pub leaves: Vec<crate::Leaf>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub last_leaf_firings: Vec<ExplainedLeafFiring>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExplainedCrewDelivery {
+    pub session: String,
+    pub role: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_delivery_rung: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delivered_message_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExplainedUnmetExpectation {
+    pub reason: String,
+    pub subject: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExplainedSettlement {
+    pub mode: String,
+    pub satisfied: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unmet: Vec<ExplainedUnmetExpectation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConvoyExplanation {
+    pub namespace: String,
+    pub convoy: String,
+    pub phase: String,
+    pub evidence_ttl_seconds: u64,
+    pub change_request_stale_after_seconds: u64,
+    pub checkouts: Vec<ExplainedCheckout>,
+    pub change_requests: Vec<ExplainedChangeRequest>,
+    pub subscriptions: Vec<ExplainedSubscription>,
+    pub crew_deliveries: Vec<ExplainedCrewDelivery>,
+    pub settlement: ExplainedSettlement,
+}
+
 /// Filters for reading a daemon's host-local structured log.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct DaemonLogQuery {
@@ -550,6 +652,11 @@ pub enum CommandAction {
     QueryDaemonLogs {
         query: DaemonLogQuery,
     },
+    QueryExplainConvoy {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        namespace: Option<String>,
+        name: String,
+    },
     QueryResourceList {
         namespace: String,
         kind: String,
@@ -601,6 +708,7 @@ impl CommandAction {
                 | CommandAction::QueryCrewList { .. }
                 | CommandAction::QueryFleetReplicaSnapshot {}
                 | CommandAction::QueryDaemonLogs { .. }
+                | CommandAction::QueryExplainConvoy { .. }
                 | CommandAction::QueryResourceList { .. }
                 | CommandAction::QueryResourceGet { .. }
                 | CommandAction::Attach { .. }
@@ -666,6 +774,7 @@ impl Command {
             CommandAction::QueryCrewList { .. } => "query crew list",
             CommandAction::QueryFleetReplicaSnapshot {} => "query fleet replica snapshot",
             CommandAction::QueryDaemonLogs { .. } => "query daemon logs",
+            CommandAction::QueryExplainConvoy { .. } => "explain convoy",
             CommandAction::QueryResourceList { .. } => "query resource list",
             CommandAction::QueryResourceGet { .. } => "query resource get",
             CommandAction::ResourceApply { .. } => "apply resource",
@@ -782,6 +891,7 @@ pub enum CommandValue {
         /// Complete JSON-lines records, oldest first.
         lines: Vec<String>,
     },
+    ConvoyExplanation(Box<ConvoyExplanation>),
     ResourceRead(Box<ResourceReadEnvelope>),
     ResourceObject(Box<ResourceJsonResponse>),
     ResourceDeleted(Box<ResourceJsonResponse>),
@@ -1148,6 +1258,12 @@ mod tests {
                         target: Some("flotilla_daemon::peer".into()),
                     },
                 },
+            },
+            Command {
+                node_id: Some(NodeId::new("feta")),
+                provisioning_target: None,
+                context_repo: None,
+                action: CommandAction::QueryExplainConvoy { namespace: Some("flotilla".into()), name: "held-work".into() },
             },
             Command {
                 node_id: Some(NodeId::new("feta")),

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -157,7 +157,6 @@ pub enum EvidenceFreshness {
     Fresh,
     Stale,
     Missing,
-    NotApplicable,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -114,9 +114,10 @@ pub(crate) mod test_helpers {
 
 pub use commands::{
     AttachBinding, CheckoutSelector, CheckoutStatus, CheckoutTarget, Command, CommandAction, CommandValue, ConvoyAutoAttach,
-    ConvoyDispatchRegard, ConvoyStartIntent, IssueSelector, PreparedConvoyStart, PreparedTerminalCommand, PreparedWorkspace, RepoSelector,
-    ResolvedPaneCommand, ResourceCursor, ResourceJsonResponse, ResourceReadEnvelope, ResourceReadRecord, ResourceRecordProvenance,
-    ResourceRecordType, StepStatus,
+    ConvoyDispatchRegard, ConvoyExplanation, ConvoyStartIntent, EvidenceFreshness, ExplainedChangeRequest, ExplainedCheckout,
+    ExplainedCondition, ExplainedCrewDelivery, ExplainedLeafFiring, ExplainedSettlement, ExplainedSubscription, ExplainedUnmetExpectation,
+    IssueSelector, PreparedConvoyStart, PreparedTerminalCommand, PreparedWorkspace, RepoSelector, ResolvedPaneCommand, ResourceCursor,
+    ResourceJsonResponse, ResourceReadEnvelope, ResourceReadRecord, ResourceRecordProvenance, ResourceRecordType, StepStatus,
 };
 pub use delta::{Branch, BranchStatus, Change, DeltaEntry, EntryOp};
 pub use provider_data::{

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -90,6 +90,21 @@ pub fn expected_checkout_refs(convoy: &crate::ResourceObject<Convoy>) -> Result<
     Ok(expected)
 }
 
+/// Canonical resource name for a convoy's explicitly bound change request.
+pub fn bound_change_request_record_name(convoy: &crate::ResourceObject<Convoy>) -> Result<Option<String>, String> {
+    let Some(bound) = &convoy.spec.change_request else { return Ok(None) };
+    let repository = convoy
+        .spec
+        .repositories
+        .iter()
+        .find(|repository| repository.repo_ref == bound.repository_ref)
+        .ok_or_else(|| format!("bound change request repository {} is absent from convoy", bound.repository_ref))?;
+    let LeafAddress::ChangeRequest { service, scope, number } = change_request_address(&repository.url, &bound.id)? else {
+        unreachable!("change_request_address always returns a change-request address")
+    };
+    Ok(Some(crate::change_request_record_name(&service, &scope, number)))
+}
+
 /// Select the authoritative child observation for each object name.
 ///
 /// The actuator host wins when placement identifies one, followed by a local

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -11,7 +11,10 @@ use crate::{
 
 mod reconcile;
 
-pub use reconcile::{reconcile, ConvoyEvent, ConvoyReconciler, ConvoyTeardownRuntime, ReconcileOutcome};
+pub use reconcile::{
+    evaluate_landing_settlement, reconcile, ConvoyEvent, ConvoyReconciler, ConvoyTeardownRuntime, ReconcileOutcome, SettlementEvaluation,
+    SettlementMode, UnmetSettlementExpectation,
+};
 
 define_resource!(Convoy, "convoys", ConvoySpec, ConvoyStatus, ConvoyStatusPatch, replication = ReplicationClass::HomeBoundRuntime);
 

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -6,6 +6,7 @@ use std::{
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use super::{
@@ -203,58 +204,155 @@ async fn federated_children<T: Resource + Clone>(
     Ok(select_convoy_children(convoy, &resolver.list().await?.items))
 }
 
-fn landing_condition_satisfied(
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SettlementMode {
+    ClaimExit,
+    WorldTerminal,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "reason", rename_all = "snake_case")]
+pub enum UnmetSettlementExpectation {
+    InvalidExpectedCheckouts { message: String },
+    MissingCheckout { checkout: String },
+    MissingCheckoutStatus { checkout: String },
+    CheckoutConditionFalse { checkout: String, condition: String },
+    CheckoutConditionUnknown { checkout: String, condition: String },
+    StaleCheckoutEvidence { checkout: String, condition: String, observed_at: Option<String> },
+    MissingChangeRequest { record: String },
+    StaleChangeRequest { record: String, observed_at: Option<DateTime<Utc>> },
+    ChangeRequestConditionFalse { record: String, value: Option<String> },
+    InvalidCondition { subject: String, message: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SettlementEvaluation {
+    pub mode: SettlementMode,
+    pub satisfied: bool,
+    pub unmet: Vec<UnmetSettlementExpectation>,
+}
+
+/// Evaluate the exact Landing settlement condition and retain the evidence for
+/// every branch that held it false. Reconciliation and diagnostics share this
+/// function so an explanation cannot drift from the condition writer.
+pub fn evaluate_landing_settlement(
     convoy: &ResourceObject<Convoy>,
     checkouts: &BTreeMap<String, ResourceObject<Checkout>>,
     change_requests: &BTreeMap<String, ResourceObject<ChangeRequest>>,
     change_request_stale_after: std::time::Duration,
     landing_evidence_stale_after: std::time::Duration,
     now: DateTime<Utc>,
-) -> bool {
-    let Ok(leaves) = expected_change_request_leaves(convoy, checkouts) else {
-        return false;
+) -> SettlementEvaluation {
+    let expected = match expected_checkout_refs(convoy) {
+        Ok(expected) => expected,
+        Err(message) => {
+            return SettlementEvaluation {
+                mode: SettlementMode::WorldTerminal,
+                satisfied: false,
+                unmet: vec![UnmetSettlementExpectation::InvalidExpectedCheckouts { message }],
+            };
+        }
     };
-    let all_change_requests_terminal = leaves.chunks_exact(2).all(|terminal_leaves| {
-        terminal_leaves.iter().any(|leaf| {
+    if expected.is_empty() && convoy.spec.change_request.is_none() {
+        return SettlementEvaluation { mode: SettlementMode::ClaimExit, satisfied: true, unmet: Vec::new() };
+    }
+
+    let mut unmet = Vec::new();
+    let leaves = match expected_change_request_leaves(convoy, checkouts) {
+        Ok(leaves) => leaves,
+        Err(message) => {
+            return SettlementEvaluation {
+                mode: SettlementMode::WorldTerminal,
+                satisfied: false,
+                unmet: vec![UnmetSettlementExpectation::InvalidCondition { subject: convoy.metadata.name.clone(), message }],
+            };
+        }
+    };
+    for terminal_leaves in leaves.chunks_exact(2) {
+        let mut record_name = None;
+        let mut observed_at = None;
+        let mut value = None;
+        let mut terminal = false;
+        for leaf in terminal_leaves {
             let flotilla_protocol::LeafAddress::ChangeRequest { service, scope, number } = &leaf.address else {
-                return false;
+                continue;
             };
             let name = crate::change_request_record_name(service, scope, *number);
+            record_name = Some(name.clone());
             let subject = change_requests.get(&name).map(|change_request| ChangeRequestLeafSubject {
                 change_request,
                 now,
                 stale_after: change_request_stale_after,
             });
-            crate::evaluate_leaf(leaf, subject.as_ref().map(|subject| subject as &dyn crate::LeafSubject), None)
-                .is_ok_and(|evaluation| evaluation.result == ThreeValue::True)
-        })
-    });
-    if !all_change_requests_terminal {
-        return false;
+            observed_at = change_requests.get(&name).and_then(|record| record.status.as_ref()).map(|status| status.state.observed_at);
+            match crate::evaluate_leaf(leaf, subject.as_ref().map(|subject| subject as &dyn crate::LeafSubject), None) {
+                Ok(evaluation) => {
+                    value = evaluation.value.map(|value| value.to_string()).or(value);
+                    terminal |= evaluation.result == ThreeValue::True;
+                }
+                Err(message) => unmet.push(UnmetSettlementExpectation::InvalidCondition { subject: name, message }),
+            }
+        }
+        if terminal {
+            continue;
+        }
+        let record = record_name.expect("change request terminal leaf pair has an address");
+        match change_requests.get(&record) {
+            None => unmet.push(UnmetSettlementExpectation::MissingChangeRequest { record }),
+            Some(_)
+                if observed_at
+                    .and_then(|at| now.signed_duration_since(at).to_std().ok())
+                    .is_none_or(|age| age > change_request_stale_after) =>
+            {
+                unmet.push(UnmetSettlementExpectation::StaleChangeRequest { record, observed_at });
+            }
+            Some(_) => unmet.push(UnmetSettlementExpectation::ChangeRequestConditionFalse { record, value }),
+        }
     }
 
     let bound_repository = convoy.spec.change_request.as_ref().map(|bound| &bound.repository_ref);
-    expected_checkout_refs(convoy).is_ok_and(|expected| {
-        expected.iter().all(|name| {
-            checkouts.get(name).is_some_and(|checkout| {
-                let has_expected_change_request =
-                    checkout.status.as_ref().and_then(|status| status.integration.change_request.as_ref()).is_some()
-                        || bound_repository == Some(checkout.spec.repo_ref());
-                has_expected_change_request
-                    || checkout.status.as_ref().is_some_and(|status| {
-                        status.integration.landed.value == crate::ConditionValue::True
-                            && status
-                                .integration
-                                .landed
-                                .observed_at
-                                .as_deref()
-                                .and_then(|observed_at| DateTime::parse_from_rfc3339(observed_at).ok())
-                                .and_then(|observed_at| now.signed_duration_since(observed_at).to_std().ok())
-                                .is_some_and(|age| age < landing_evidence_stale_after)
-                    })
-            })
-        })
-    })
+    for name in expected {
+        let Some(checkout) = checkouts.get(&name) else {
+            unmet.push(UnmetSettlementExpectation::MissingCheckout { checkout: name });
+            continue;
+        };
+        let has_expected_change_request = checkout.status.as_ref().and_then(|status| status.integration.change_request.as_ref()).is_some()
+            || bound_repository == Some(checkout.spec.repo_ref());
+        if has_expected_change_request {
+            continue;
+        }
+        let Some(status) = checkout.status.as_ref() else {
+            unmet.push(UnmetSettlementExpectation::MissingCheckoutStatus { checkout: name });
+            continue;
+        };
+        let condition = &status.integration.landed;
+        match condition.value {
+            crate::ConditionValue::False => {
+                unmet.push(UnmetSettlementExpectation::CheckoutConditionFalse { checkout: name, condition: "landed".to_string() })
+            }
+            crate::ConditionValue::Unknown => {
+                unmet.push(UnmetSettlementExpectation::CheckoutConditionUnknown { checkout: name, condition: "landed".to_string() })
+            }
+            crate::ConditionValue::True => {
+                let fresh = condition
+                    .observed_at
+                    .as_deref()
+                    .and_then(|observed_at| DateTime::parse_from_rfc3339(observed_at).ok())
+                    .and_then(|observed_at| now.signed_duration_since(observed_at).to_std().ok())
+                    .is_some_and(|age| age < landing_evidence_stale_after);
+                if !fresh {
+                    unmet.push(UnmetSettlementExpectation::StaleCheckoutEvidence {
+                        checkout: name,
+                        condition: "landed".to_string(),
+                        observed_at: condition.observed_at.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    SettlementEvaluation { mode: SettlementMode::WorldTerminal, satisfied: unmet.is_empty(), unmet }
 }
 
 impl Reconciler for ConvoyReconciler {
@@ -315,7 +413,7 @@ impl Reconciler for ConvoyReconciler {
             _ => BTreeMap::new(),
         };
         let no_change_request_outstanding = if is_landing {
-            landing_condition_satisfied(
+            evaluate_landing_settlement(
                 obj,
                 &checkouts,
                 &change_requests,
@@ -323,6 +421,7 @@ impl Reconciler for ConvoyReconciler {
                 self.landing_evidence_stale_after,
                 self.clock.now(),
             )
+            .satisfied
         } else {
             false
         };

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -52,12 +52,13 @@ pub use clock::VirtualClock;
 pub use clock::{Clock, SystemClock};
 pub use clone::{Clone, ClonePhase, CloneSpec, CloneStatus, CloneStatusPatch};
 pub use convoy::{
-    controller_patches, evaluate_landing_settlement, expected_change_request_leaves, expected_checkout_refs, external_patches,
-    pinned_placement_ref, pinned_workflow_ref, prepared_snapshot_pending, provisioning_patches, reconcile, select_convoy_children,
-    BoundChangeRequest, Convoy, ConvoyEvent, ConvoyIssue, ConvoyPhase, ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus,
-    ConvoyStatusPatch, ConvoyTeardownRuntime, CrewWorkPhase, CrewWorkState, InputValue, IssueSnapshot, PlacementStatus, ReconcileOutcome,
-    SettlementEvaluation, SettlementMode, TargetMismatch, UnmetSettlementExpectation, WorkCompletionAuthority, WorkPhase, WorkState,
-    WorkflowSnapshot, PLACEMENT_SNAPSHOT_ANNOTATION, PREPARED_SNAPSHOT_PENDING_ANNOTATION, WORKFLOW_SNAPSHOT_ANNOTATION,
+    bound_change_request_record_name, controller_patches, evaluate_landing_settlement, expected_change_request_leaves,
+    expected_checkout_refs, external_patches, pinned_placement_ref, pinned_workflow_ref, prepared_snapshot_pending, provisioning_patches,
+    reconcile, select_convoy_children, BoundChangeRequest, Convoy, ConvoyEvent, ConvoyIssue, ConvoyPhase, ConvoyReconciler,
+    ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, ConvoyStatusPatch, ConvoyTeardownRuntime, CrewWorkPhase, CrewWorkState, InputValue,
+    IssueSnapshot, PlacementStatus, ReconcileOutcome, SettlementEvaluation, SettlementMode, TargetMismatch, UnmetSettlementExpectation,
+    WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot, PLACEMENT_SNAPSHOT_ANNOTATION, PREPARED_SNAPSHOT_PENDING_ANNOTATION,
+    WORKFLOW_SNAPSHOT_ANNOTATION,
 };
 pub use credential::{
     CredentialConsumer, CredentialGrant, CredentialGrantSelector, CredentialGrantSpec, CredentialLifecycle,

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -52,12 +52,12 @@ pub use clock::VirtualClock;
 pub use clock::{Clock, SystemClock};
 pub use clone::{Clone, ClonePhase, CloneSpec, CloneStatus, CloneStatusPatch};
 pub use convoy::{
-    controller_patches, expected_change_request_leaves, expected_checkout_refs, external_patches, pinned_placement_ref,
-    pinned_workflow_ref, prepared_snapshot_pending, provisioning_patches, reconcile, select_convoy_children, BoundChangeRequest, Convoy,
-    ConvoyEvent, ConvoyIssue, ConvoyPhase, ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, ConvoyStatusPatch,
-    ConvoyTeardownRuntime, CrewWorkPhase, CrewWorkState, InputValue, IssueSnapshot, PlacementStatus, ReconcileOutcome, TargetMismatch,
-    WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot, PLACEMENT_SNAPSHOT_ANNOTATION, PREPARED_SNAPSHOT_PENDING_ANNOTATION,
-    WORKFLOW_SNAPSHOT_ANNOTATION,
+    controller_patches, evaluate_landing_settlement, expected_change_request_leaves, expected_checkout_refs, external_patches,
+    pinned_placement_ref, pinned_workflow_ref, prepared_snapshot_pending, provisioning_patches, reconcile, select_convoy_children,
+    BoundChangeRequest, Convoy, ConvoyEvent, ConvoyIssue, ConvoyPhase, ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus,
+    ConvoyStatusPatch, ConvoyTeardownRuntime, CrewWorkPhase, CrewWorkState, InputValue, IssueSnapshot, PlacementStatus, ReconcileOutcome,
+    SettlementEvaluation, SettlementMode, TargetMismatch, UnmetSettlementExpectation, WorkCompletionAuthority, WorkPhase, WorkState,
+    WorkflowSnapshot, PLACEMENT_SNAPSHOT_ANNOTATION, PREPARED_SNAPSHOT_PENDING_ANNOTATION, WORKFLOW_SNAPSHOT_ANNOTATION,
 };
 pub use credential::{
     CredentialConsumer, CredentialGrant, CredentialGrantSelector, CredentialGrantSpec, CredentialLifecycle,

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -269,6 +269,7 @@ pub fn handle_result(result: CommandValue, app: &mut App) {
         | CommandValue::CrewList(_)
         | CommandValue::FleetReplicaSnapshot(_)
         | CommandValue::DaemonLogs { .. }
+        | CommandValue::ConvoyExplanation(_)
         | CommandValue::ResourceRead(_)
         | CommandValue::ResourceObject(_)
         | CommandValue::ResourceDeleted(_)

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::Path};
+use std::{collections::HashMap, fmt::Write as _, path::Path};
 
 use chrono::{DateTime, Utc};
 use comfy_table::{presets::UTF8_FULL_CONDENSED, Cell, Table};
@@ -509,6 +509,113 @@ fn format_crew_list_human(response: &CrewListResponse) -> String {
     format!("Convoy: {}  Vessel: {} ({})\n{}\n", response.convoy, response.vessel, response.vessel_ref, table)
 }
 
+fn explained_condition_label(condition: Option<&flotilla_protocol::ExplainedCondition>) -> String {
+    condition.map_or_else(
+        || "missing".to_string(),
+        |condition| {
+            format!("{} @ {} ({:?})", condition.value, condition.observed_at.as_deref().unwrap_or("unknown"), condition.freshness)
+                .to_lowercase()
+        },
+    )
+}
+
+fn explanation_provenance_label(provenance: Option<&flotilla_protocol::ResourceRecordProvenance>) -> String {
+    match provenance {
+        Some(flotilla_protocol::ResourceRecordProvenance::Local { node_id }) => format!("local:{node_id}"),
+        Some(flotilla_protocol::ResourceRecordProvenance::Replica { origin_root, .. }) => format!("replica:{origin_root}"),
+        None => "-".to_string(),
+    }
+}
+
+pub(crate) fn format_convoy_explanation_human(explanation: &flotilla_protocol::ConvoyExplanation) -> String {
+    let mut output = format!("Convoy: {}/{}\nPhase: {}\n", explanation.namespace, explanation.convoy, explanation.phase);
+    let verdict = if explanation.settlement.satisfied { "SATISFIED" } else { "HOLDING" };
+    let _ = writeln!(output, "Settlement: {verdict} ({})", explanation.settlement.mode);
+    let _ = writeln!(
+        output,
+        "Freshness: checkout evidence < {}s; change requests <= {}s",
+        explanation.evidence_ttl_seconds, explanation.change_request_stale_after_seconds
+    );
+    if !explanation.settlement.unmet.is_empty() {
+        output.push_str("\nUnmet expectations:\n");
+        for unmet in &explanation.settlement.unmet {
+            let _ = writeln!(output, "  - {}: {} — {}", unmet.reason, unmet.subject, unmet.detail);
+        }
+    }
+
+    output.push_str("\nExpected checkouts:\n");
+    if explanation.checkouts.is_empty() {
+        output.push_str("  (none; artifact-less claim exit)\n");
+    } else {
+        let mut table = Table::new();
+        table.load_preset(UTF8_FULL_CONDENSED);
+        table.set_header(vec!["Checkout", "Observed", "Source", "Landed", "Clean", "Pushed"]);
+        for checkout in &explanation.checkouts {
+            table.add_row(vec![
+                Cell::new(&checkout.name),
+                Cell::new(if checkout.observed { "yes" } else { "NO" }),
+                Cell::new(explanation_provenance_label(checkout.provenance.as_ref())),
+                Cell::new(explained_condition_label(checkout.landed.as_ref())),
+                Cell::new(explained_condition_label(checkout.clean.as_ref())),
+                Cell::new(explained_condition_label(checkout.pushed.as_ref())),
+            ]);
+        }
+        let _ = writeln!(output, "{table}");
+    }
+
+    output.push_str("\nChange requests:\n");
+    if explanation.change_requests.is_empty() {
+        output.push_str("  (none)\n");
+    } else {
+        for request in &explanation.change_requests {
+            let fields = request.fields.as_ref().map_or_else(|| "missing".to_string(), serde_json::Value::to_string);
+            let _ = writeln!(
+                output,
+                "  - {} bound={} observed={} source={} observed_at={} freshness={:?}\n    fields={}",
+                request.name,
+                request.bound,
+                request.observed,
+                explanation_provenance_label(request.provenance.as_ref()),
+                request.observed_at.as_deref().unwrap_or("-"),
+                request.freshness,
+                fields
+            );
+        }
+    }
+
+    output.push_str("\nArmed subscriptions:\n");
+    if explanation.subscriptions.is_empty() {
+        output.push_str("  (none recorded on this host)\n");
+    } else {
+        for subscription in &explanation.subscriptions {
+            let _ = writeln!(output, "  - {} watcher={}", subscription.id, subscription.watcher);
+            for leaf in &subscription.leaves {
+                let _ = writeln!(output, "    leaf: {leaf}");
+            }
+            for firing in &subscription.last_leaf_firings {
+                let _ = writeln!(output, "    last firing: {} => {} at {}", firing.leaf, firing.value, firing.fired_at);
+            }
+        }
+    }
+
+    output.push_str("\nCrew delivery:\n");
+    if explanation.crew_deliveries.is_empty() {
+        output.push_str("  (none)\n");
+    } else {
+        for delivery in &explanation.crew_deliveries {
+            let _ = writeln!(
+                output,
+                "  - {} role={} last_rung={} delivered_message={}",
+                delivery.session,
+                delivery.role,
+                delivery.last_delivery_rung.as_deref().unwrap_or("not recorded"),
+                delivery.delivered_message_id.as_deref().unwrap_or("-")
+            );
+        }
+    }
+    output
+}
+
 /// Extract a short display name from a repo path (last path component).
 /// Falls back to the full path display for root or non-UTF-8 paths,
 /// matching `flotilla_core::model::repo_name`.
@@ -586,6 +693,7 @@ fn format_command_result(result: &flotilla_protocol::commands::CommandValue) -> 
         CommandValue::CrewList(crew) => format_crew_list_human(crew),
         CommandValue::FleetReplicaSnapshot(_) => "fleet replica snapshot".to_string(),
         CommandValue::DaemonLogs { lines } => lines.join("\n"),
+        CommandValue::ConvoyExplanation(explanation) => format_convoy_explanation_human(explanation),
         CommandValue::ResourceRead(response) => flotilla_protocol::output::json_pretty(response),
         CommandValue::ResourceObject(response) => flotilla_protocol::output::json_pretty(&response.value),
         CommandValue::ResourceDeleted(response) => {

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -38,6 +38,46 @@ fn make_work_item(kind: WorkItemKind, branch: Option<&str>, description: &str) -
     }
 }
 
+#[test]
+fn convoy_explanation_human_names_the_holding_expectation() {
+    let explanation = flotilla_protocol::ConvoyExplanation {
+        namespace: "flotilla".to_string(),
+        convoy: "held-work".to_string(),
+        phase: "Landing".to_string(),
+        evidence_ttl_seconds: 30,
+        change_request_stale_after_seconds: 180,
+        checkouts: vec![flotilla_protocol::ExplainedCheckout {
+            name: "checkout-held".to_string(),
+            observed: false,
+            provenance: None,
+            clean: None,
+            pushed: None,
+            landed: None,
+        }],
+        change_requests: Vec::new(),
+        subscriptions: Vec::new(),
+        crew_deliveries: Vec::new(),
+        settlement: flotilla_protocol::ExplainedSettlement {
+            mode: "world_terminal".to_string(),
+            satisfied: false,
+            unmet: vec![flotilla_protocol::ExplainedUnmetExpectation {
+                reason: "missing_record".to_string(),
+                subject: "checkout/checkout-held".to_string(),
+                detail: "expected checkout has no federated record".to_string(),
+            }],
+        },
+    };
+
+    let output = crate::cli::format_convoy_explanation_human(&explanation);
+    assert!(output.contains("Settlement: HOLDING (world_terminal)"));
+    assert!(output.contains("missing_record: checkout/checkout-held"));
+    assert!(output.contains("checkout-held"));
+
+    let json = flotilla_protocol::output::json_pretty(&flotilla_protocol::CommandValue::ConvoyExplanation(Box::new(explanation)));
+    assert!(json.contains("\"convoy\": \"held-work\""));
+    assert!(json.contains("\"reason\": \"missing_record\""));
+}
+
 mod status_human {
     use flotilla_protocol::{
         qualified_path::HostId, EnvironmentId, EnvironmentInfo, EnvironmentStatus, HostEnvironment, HostListEntry, HostListResponse,


### PR DESCRIPTION
## Summary

- add `flotilla convoy <name> explain` with human-readable and JSON output
- explain the exact settlement evaluation shared with reconciliation, including missing, stale, false, and unknown evidence
- surface federated checkout/change-request provenance, armed subscriptions and last leaf firings, and recorded crew delivery state
- make resource gets and convoy explanations resolve replicated resources on non-authority hosts

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #1386
