### PR TITLE
chore: add Forgejo Darwin CI

### DIFF
--- a/.forgejo/workflows/ci.yml
+++ b/.forgejo/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           test ! -e "$HOME/.config/forgejo-runner/.runner"
           test -z "${FLEET_CODESIGN_IDENTITY:-}"
           test -z "${FORGEJO_ADMIN_TOKEN:-}"
-          ! git config --local --get-regexp 'http\..*\.extraheader'
+          ! git --no-pager config --local --get-regexp 'http\..*\.extraheader'
 
       - name: Build binaries
         run: cargo build --locked --bins

--- a/.forgejo/workflows/ci.yml
+++ b/.forgejo/workflows/ci.yml
@@ -12,6 +12,7 @@ permissions:
 
 env:
   CARGO_INCREMENTAL: "0"
+  GIT_SSH_COMMAND: "ssh -o BatchMode=yes -o ConnectTimeout=5 -o ConnectionAttempts=1"
 
 jobs:
   darwin:

--- a/.forgejo/workflows/ci.yml
+++ b/.forgejo/workflows/ci.yml
@@ -11,6 +11,10 @@ permissions:
   contents: read
 
 env:
+  # Format and Clippy remain platform-independent gates in GitHub CI. This
+  # workflow exercises the Darwin build and test surface specifically.
+  # One-job guests are destroyed after each run, so build caches are not
+  # persisted between jobs.
   CARGO_INCREMENTAL: "0"
   GIT_SSH_COMMAND: "ssh -o BatchMode=yes -o ConnectTimeout=5 -o ConnectionAttempts=1"
 
@@ -30,7 +34,7 @@ jobs:
         run: |
           test "$(uname -s)" = Darwin
           test "$(uname -m)" = arm64
-          test "$(security find-identity -v -p codesigning | tail -1)" = "     0 valid identities found"
+          security find-identity -v -p codesigning | grep -Eq '^[[:space:]]*0 valid identities found[[:space:]]*$'
           test ! -e "$HOME/.config/forgejo-runner/.runner"
           test -z "${FLEET_CODESIGN_IDENTITY:-}"
           test -z "${FORGEJO_ADMIN_TOKEN:-}"

--- a/.forgejo/workflows/ci.yml
+++ b/.forgejo/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: Forgejo CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  darwin:
+    name: Darwin build and test
+    runs-on: darwin-aarch64
+    timeout-minutes: 90
+    steps:
+      - name: Check out the repository
+        uses: https://data.forgejo.org/actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Verify the credential-free worker
+        shell: /bin/sh -e {0}
+        run: |
+          test "$(uname -s)" = Darwin
+          test "$(uname -m)" = arm64
+          test "$(security find-identity -v -p codesigning | tail -1)" = "     0 valid identities found"
+          test ! -e "$HOME/.config/forgejo-runner/.runner"
+          test -z "${FLEET_CODESIGN_IDENTITY:-}"
+          test -z "${FORGEJO_ADMIN_TOKEN:-}"
+          ! git config --local --get-regexp 'http\..*\.extraheader'
+
+      - name: Build binaries
+        run: cargo build --locked --bins
+
+      - name: Test workspace
+        run: cargo test --workspace --locked

--- a/crates/flotilla-daemon/tests/socket_roundtrip.rs
+++ b/crates/flotilla-daemon/tests/socket_roundtrip.rs
@@ -1,10 +1,46 @@
-use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
+use std::{collections::HashMap, fs, path::Path, process::Command as ProcessCommand, sync::Arc, time::Duration};
 
 use flotilla_core::{config::ConfigStore, daemon::DaemonHandle, providers::discovery::test_support::git_process_discovery};
 use flotilla_daemon::server::DaemonServer;
 use flotilla_protocol::{Command, CommandAction, CommandValue, DaemonEvent, RepoSelector, StreamKey};
 use flotilla_test_support::TestSocketDir;
 use tokio::time::Instant;
+
+struct LocalGitRepository {
+    _temp: tempfile::TempDir,
+    path: std::path::PathBuf,
+}
+
+impl LocalGitRepository {
+    fn new() -> Self {
+        let temp = tempfile::tempdir().expect("create temporary git directory");
+        run_git(temp.path(), &["init", "--bare", "--initial-branch=main", "origin.git"]);
+        run_git(temp.path(), &["init", "--initial-branch=main", "repo"]);
+
+        let path = temp.path().join("repo");
+        fs::write(path.join("README.md"), "# socket roundtrip test\n").expect("write test repository fixture");
+        run_git(&path, &["config", "user.name", "Flotilla Tests"]);
+        run_git(&path, &["config", "user.email", "tests@flotilla.invalid"]);
+        run_git(&path, &["config", "core.hooksPath", "/dev/null"]);
+        run_git(&path, &["add", "README.md"]);
+        run_git(&path, &["-c", "commit.gpgSign=false", "commit", "-m", "Initial commit"]);
+
+        let origin = temp.path().join("origin.git");
+        run_git(&path, &["remote", "add", "origin", origin.to_str().expect("temporary path should be UTF-8")]);
+        run_git(&path, &["push", "--set-upstream", "origin", "main"]);
+
+        Self { _temp: temp, path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+fn run_git(cwd: &Path, args: &[&str]) {
+    let output = ProcessCommand::new("git").current_dir(cwd).args(args).output().expect("run git fixture command");
+    assert!(output.status.success(), "git {} failed: {}", args.join(" "), String::from_utf8_lossy(&output.stderr));
+}
 
 /// Execute a query command via execute_query and return the result directly.
 async fn run_query(daemon: &dyn DaemonHandle, action: CommandAction) -> CommandValue {
@@ -18,10 +54,8 @@ async fn socket_roundtrip() {
     let tmp = TestSocketDir::new();
     let socket_path = tmp.socket_path("test.sock");
 
-    // Use workspace root (a real git repo) as the test repo.
-    // CARGO_MANIFEST_DIR points to crates/flotilla-daemon; go up two levels.
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let repo = manifest_dir.parent().unwrap().parent().unwrap().to_path_buf();
+    let git_repo = LocalGitRepository::new();
+    let repo = git_repo.path().to_path_buf();
 
     // Start daemon server
     let config = Arc::new(ConfigStore::with_base(tmp.path().join("config")));
@@ -149,10 +183,8 @@ async fn query_commands_roundtrip() {
     let tmp = TestSocketDir::new();
     let socket_path = tmp.socket_path("test.sock");
 
-    // Use workspace root (a real git repo) as the test repo.
-    // CARGO_MANIFEST_DIR points to crates/flotilla-daemon; go up two levels.
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let repo = manifest_dir.parent().expect("parent").parent().expect("grandparent").to_path_buf();
+    let git_repo = LocalGitRepository::new();
+    let repo = git_repo.path().to_path_buf();
 
     // Start daemon server
     let config = Arc::new(ConfigStore::with_base(tmp.path().join("config")));
@@ -282,8 +314,8 @@ async fn execute_refresh_all_roundtrip_emits_lifecycle_events() {
     let tmp = TestSocketDir::new();
     let socket_path = tmp.socket_path("test.sock");
 
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let repo = manifest_dir.parent().expect("parent").parent().expect("grandparent").to_path_buf();
+    let git_repo = LocalGitRepository::new();
+    let repo = git_repo.path().to_path_buf();
 
     let config = Arc::new(ConfigStore::with_base(tmp.path().join("config")));
     let server = DaemonServer::new(vec![repo.clone()], config, git_process_discovery(false), socket_path.clone(), Duration::from_secs(300))

--- a/crates/flotilla-daemon/tests/socket_roundtrip.rs
+++ b/crates/flotilla-daemon/tests/socket_roundtrip.rs
@@ -1,4 +1,11 @@
-use std::{collections::HashMap, fs, path::Path, process::Command as ProcessCommand, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+    process::Command as ProcessCommand,
+    sync::Arc,
+    time::Duration,
+};
 
 use flotilla_core::{config::ConfigStore, daemon::DaemonHandle, providers::discovery::test_support::git_process_discovery};
 use flotilla_daemon::server::DaemonServer;
@@ -8,7 +15,7 @@ use tokio::time::Instant;
 
 struct LocalGitRepository {
     _temp: tempfile::TempDir,
-    path: std::path::PathBuf,
+    path: PathBuf,
 }
 
 impl LocalGitRepository {


### PR DESCRIPTION
## Summary

- add the canonical Forgejo Actions workflow for Darwin builds and tests
- run it for pull requests, pushes to `main`, and manual dispatches while leaving GitHub Actions unchanged
- use a fully qualified, commit-pinned Forgejo checkout action without persisted credentials
- verify that the ephemeral worker has no code-signing identity, runner registration, or administrative credentials
- isolate daemon socket integration tests from the checkout's live remote by using a temporary local Git origin

## Live lab proof

The revised workflow passed on an ephemeral Tart macOS guest at commit `593b0922`:

https://forgejo.lab.flotilla.work/lab/flotilla/actions/runs/18

The one-job runner unregistered after completion and the guest was destroyed. The temporary lab proof branch was also removed.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- live Forgejo workflow: Darwin build and full locked workspace test suite
