### PR TITLE
feat: add workflow exit disposition tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,6 +1262,7 @@ dependencies = [
  "flotilla-core",
  "flotilla-protocol",
  "futures",
+ "indexmap",
  "reqwest",
  "rstest",
  "rusqlite",

--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -101,6 +101,7 @@ pub async fn create_convoy_with_single_task(
     convoys
         .update_status(name, &convoy.metadata.resource_version, &ConvoyStatus {
             workflow_snapshot: Some(WorkflowSnapshot {
+                exit: None,
                 vessels: vec![VesselRequirement {
                     name: task.to_string(),
                     stance: Default::default(),

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -402,6 +402,7 @@ async fn controller_materializes_a_missing_repository_for_a_multi_repository_con
     convoys
         .update_status("convoy-multi", &convoy.metadata.resource_version, &ConvoyStatus {
             workflow_snapshot: Some(flotilla_resources::WorkflowSnapshot {
+                exit: None,
                 vessels: vec![VesselRequirement {
                     name: "implement".to_string(),
                     stance: Stance::Trusted,

--- a/crates/flotilla-controllers/tests/vessel_reconciler.rs
+++ b/crates/flotilla-controllers/tests/vessel_reconciler.rs
@@ -114,6 +114,7 @@ async fn repositoryless_vessel_runs_tools_without_provisioning_a_checkout() {
         .using::<Convoy>(NAMESPACE)
         .update_status("convoy-scratch", &convoy.metadata.resource_version, &ConvoyStatus {
             workflow_snapshot: Some(WorkflowSnapshot {
+                exit: None,
                 vessels: vec![VesselRequirement {
                     name: "work".to_string(),
                     stance: Stance::Trusted,
@@ -490,6 +491,7 @@ async fn multi_repository_vessel_provisions_every_checkout_and_runs_crew_at_work
         .using::<Convoy>(NAMESPACE)
         .update_status("convoy-multi", &convoy.metadata.resource_version, &ConvoyStatus {
             workflow_snapshot: Some(WorkflowSnapshot {
+                exit: None,
                 vessels: vec![VesselRequirement {
                     name: "implement".to_string(),
                     stance: Stance::Trusted,
@@ -669,6 +671,7 @@ async fn multi_repository_docker_mounts_the_workspace_and_each_git_common_dir() 
         .using::<Convoy>(NAMESPACE)
         .update_status("convoy-multi-docker", &convoy.metadata.resource_version, &ConvoyStatus {
             workflow_snapshot: Some(WorkflowSnapshot {
+                exit: None,
                 vessels: vec![VesselRequirement {
                     name: "implement".to_string(),
                     stance: Stance::Contained,
@@ -843,6 +846,7 @@ async fn multi_repository_docker_fresh_clone_uses_per_repository_paths() {
         .using::<Convoy>(NAMESPACE)
         .update_status("convoy-multi-fresh", &convoy.metadata.resource_version, &ConvoyStatus {
             workflow_snapshot: Some(WorkflowSnapshot {
+                exit: None,
                 vessels: vec![VesselRequirement {
                     name: "implement".to_string(),
                     stance: Stance::Contained,
@@ -970,6 +974,7 @@ async fn vessel_repository_scope_narrows_a_multi_repository_convoy() {
         .using::<Convoy>(NAMESPACE)
         .update_status("convoy-scoped", &convoy.metadata.resource_version, &ConvoyStatus {
             workflow_snapshot: Some(WorkflowSnapshot {
+                exit: None,
                 vessels: vec![VesselRequirement {
                     name: "implement".to_string(),
                     stance: Stance::Trusted,
@@ -1912,7 +1917,7 @@ async fn issue_carrying_convoy_without_prompt_assigns_the_issue_in_the_brief() {
         .clone()
         .using::<Convoy>(NAMESPACE)
         .update_status("convoy-issue-brief", &convoy.metadata.resource_version, &ConvoyStatus {
-            workflow_snapshot: Some(WorkflowSnapshot { vessels: interactive_single_workflow_spec().vessels }),
+            workflow_snapshot: Some(WorkflowSnapshot { exit: None, vessels: interactive_single_workflow_spec().vessels }),
             ..Default::default()
         })
         .await
@@ -2314,6 +2319,7 @@ async fn create_convoy_with_labeled_processes(
     convoys
         .update_status(name, &convoy.metadata.resource_version, &ConvoyStatus {
             workflow_snapshot: Some(WorkflowSnapshot {
+                exit: None,
                 vessels: vec![
                     VesselRequirement {
                         name: "implement".to_string(),

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -9095,6 +9095,7 @@ impl InProcessDaemon {
         );
         let settlement = ExplainedSettlement {
             mode: match evaluation.mode {
+                SettlementMode::NoExit => "no_exit",
                 SettlementMode::ClaimExit => "claim_exit",
                 SettlementMode::WorldTerminal => "world_terminal",
             }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -367,6 +367,11 @@ fn explain_unmet_expectation(expectation: UnmetSettlementExpectation) -> Explain
         UnmetSettlementExpectation::InvalidExpectedCheckouts { message } => {
             ExplainedUnmetExpectation { reason: "invalid_expected_checkouts".to_string(), subject: "convoy".to_string(), detail: message }
         }
+        UnmetSettlementExpectation::ExitEntryAwaitingBinding { disposition, subject } => ExplainedUnmetExpectation {
+            reason: "missing_binding".to_string(),
+            subject: format!("exit/{disposition}"),
+            detail: format!("entry awaits a bound change request for {subject}"),
+        },
         UnmetSettlementExpectation::MissingCheckout { checkout } => ExplainedUnmetExpectation {
             reason: "missing_record".to_string(),
             subject: format!("checkout/{checkout}"),

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1055,7 +1055,14 @@ async fn create_explanation_convoy(
         .subpaths(Vec::new())
         .build()];
     let created = convoys.create(&empty_input_meta(name), &spec).await.expect("create convoy");
-    let mut status = ConvoyStatus { phase: ConvoyPhase::Landing, ..Default::default() };
+    let mut status = ConvoyStatus {
+        phase: ConvoyPhase::Landing,
+        workflow_snapshot: Some(WorkflowSnapshot {
+            exit: Some(flotilla_resources::ExitDeclaration::standard_table()),
+            vessels: Vec::new(),
+        }),
+        ..Default::default()
+    };
     if let Some(checkout_name) = checkout_name {
         status.work.insert(
             "work".to_string(),
@@ -1124,7 +1131,14 @@ async fn create_bound_explanation_convoy(
     let convoys = backend.using::<Convoy>("flotilla");
     let convoy = convoys.create(&empty_input_meta(name), &spec).await.expect("create bound convoy");
     convoys
-        .update_status(name, &convoy.metadata.resource_version, &ConvoyStatus { phase: ConvoyPhase::Landing, ..Default::default() })
+        .update_status(name, &convoy.metadata.resource_version, &ConvoyStatus {
+            phase: ConvoyPhase::Landing,
+            workflow_snapshot: Some(WorkflowSnapshot {
+                exit: Some(flotilla_resources::ExitDeclaration::standard_table()),
+                vessels: Vec::new(),
+            }),
+            ..Default::default()
+        })
         .await
         .expect("update bound convoy status");
 
@@ -6180,7 +6194,7 @@ async fn convoy_delete_refuses_when_destroyed_environment_leaves_no_integration_
 }
 
 #[tokio::test]
-async fn convoy_abandon_command_archives_and_retains_terminal_record() {
+async fn undeclared_exit_landing_convoy_can_be_explicitly_abandoned() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");
     std::fs::create_dir_all(&config_base).expect("create config dir");
@@ -6201,10 +6215,10 @@ async fn convoy_abandon_command_archives_and_retains_terminal_record() {
     convoys
         .update_status("active-convoy", &created.metadata.resource_version, &ConvoyStatus {
             placement_decision: None,
-            phase: ConvoyPhase::Active,
-            workflow_snapshot: None,
+            phase: ConvoyPhase::Landing,
+            workflow_snapshot: Some(WorkflowSnapshot { exit: None, vessels: Vec::new() }),
             work: BTreeMap::from([("implement".to_string(), WorkState {
-                phase: WorkPhase::Running,
+                phase: WorkPhase::Complete,
                 completion_authority: WorkCompletionAuthority::CrewRollup,
                 ready_at: None,
                 started_at: None,

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1658,6 +1658,7 @@ async fn create_two_agent_crew(daemon: &InProcessDaemon, env_ref: &str) {
         .update_status("demo", &convoy.metadata.resource_version, &ConvoyStatus {
             phase: ConvoyPhase::Active,
             workflow_snapshot: Some(WorkflowSnapshot {
+                exit: None,
                 vessels: vec![
                     VesselRequirement {
                         name: "prepare".into(),
@@ -4869,6 +4870,7 @@ async fn convoy_completion_command_updates_convoy_task_status() {
             message: None,
             started_at: None,
             finished_at: None,
+            disposition: None,
             observed_workflow_ref: Some("review-and-fix".to_string()),
             observed_workflows: None,
             target_mismatches: Vec::new(),
@@ -4960,7 +4962,7 @@ async fn convoy_admission_snapshots_every_project_repository() {
     backend
         .clone()
         .using::<WorkflowTemplate>("flotilla")
-        .create(&empty_input_meta("single-agent-contained"), &WorkflowTemplateSpec { inputs: Vec::new(), vessels: Vec::new() })
+        .create(&empty_input_meta("single-agent-contained"), &WorkflowTemplateSpec { inputs: Vec::new(), exit: None, vessels: Vec::new() })
         .await
         .expect("workflow create should succeed");
 
@@ -5003,7 +5005,7 @@ async fn create_empty_workflow(backend: &ResourceBackend, name: &str) {
     backend
         .clone()
         .using::<WorkflowTemplate>("flotilla")
-        .create(&empty_input_meta(name), &WorkflowTemplateSpec { inputs: Vec::new(), vessels: Vec::new() })
+        .create(&empty_input_meta(name), &WorkflowTemplateSpec { inputs: Vec::new(), exit: None, vessels: Vec::new() })
         .await
         .expect("workflow create should succeed");
 }
@@ -5456,6 +5458,7 @@ async fn convoy_completion_command_targets_configured_provisioning_namespace() {
             message: None,
             started_at: None,
             finished_at: None,
+            disposition: None,
             observed_workflow_ref: Some("review-and-fix".to_string()),
             observed_workflows: None,
             target_mismatches: Vec::new(),
@@ -5605,6 +5608,7 @@ async fn convoy_delete_refuses_completed_convoy_with_unpushed_checkout_until_for
             message: None,
             started_at: None,
             finished_at: Some(chrono::Utc::now()),
+            disposition: None,
             observed_workflow_ref: Some("review-and-fix".to_string()),
             observed_workflows: None,
             target_mismatches: Vec::new(),
@@ -6212,6 +6216,7 @@ async fn convoy_abandon_command_archives_and_retains_terminal_record() {
             message: None,
             started_at: None,
             finished_at: None,
+            disposition: None,
             observed_workflow_ref: Some("review-and-fix".to_string()),
             observed_workflows: None,
             target_mismatches: Vec::new(),

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1216,6 +1216,28 @@ async fn convoy_explanation_names_each_held_landing_expectation_and_claim_exit()
 }
 
 #[tokio::test]
+async fn convoy_explanation_names_closed_only_exit_waiting_for_a_bound_change_request() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let (daemon, _temp) = explanation_daemon(backend.clone()).await;
+    create_explanation_convoy(&backend, "closed-only", Some("checkout-closed"), Some((ConditionValue::True, Utc::now()))).await;
+    let convoys = backend.using::<Convoy>("flotilla");
+    let convoy = convoys.get("closed-only").await.expect("closed-only convoy");
+    let mut status = convoy.status.expect("closed-only status");
+    status.workflow_snapshot.as_mut().expect("workflow snapshot").exit = Some(flotilla_resources::ExitDeclaration::Table(
+        indexmap::IndexMap::from([("closed-without-merge".to_string(), "$cr.state == closed".parse().expect("closed exit template"))]),
+    ));
+    convoys.update_status("closed-only", &convoy.metadata.resource_version, &status).await.expect("pin closed-only exit table");
+
+    let explanation = explain(&daemon, "closed-only").await;
+
+    assert!(!explanation.settlement.satisfied);
+    assert_eq!(explanation.settlement.unmet.len(), 1, "an unsatisfied settlement must explain why it is stuck");
+    assert_eq!(explanation.settlement.unmet[0].reason, "missing_binding");
+    assert_eq!(explanation.settlement.unmet[0].subject, "exit/closed-without-merge");
+    assert_eq!(explanation.settlement.unmet[0].detail, "entry awaits a bound change request for $cr");
+}
+
+#[tokio::test]
 async fn convoy_explanation_names_missing_stale_and_open_bound_change_requests() {
     let backend = ResourceBackend::InMemory(InMemoryBackend::default());
     let (daemon, _temp) = explanation_daemon(backend.clone()).await;

--- a/crates/flotilla-core/src/leaf_engine.rs
+++ b/crates/flotilla-core/src/leaf_engine.rs
@@ -3,9 +3,9 @@ use std::{collections::HashMap, future::Future, marker::PhantomData, pin::Pin, s
 use chrono::{DateTime, Utc};
 use flotilla_protocol::{DaemonEvent, Leaf, LeafAddress, LeafFire, WaitSubscriptionRequest};
 use flotilla_resources::{
-    admit_leaf, controller::SecondaryWatch, evaluate_leaf, expected_change_request_leaves, select_convoy_children, ChangeRequest,
-    ChangeRequestLeafSubject, Checkout, Convoy, ConvoyLeafSubject, ConvoyPhase, ResourceBackend, ResourceError, ResourceObject, ThreeValue,
-    Vessel, VesselLeafSubject, WatchEvent, WatchStart, WorkLeafSubject,
+    admit_leaf, controller::SecondaryWatch, evaluate_leaf, instantiate_exit, select_convoy_children, ChangeRequest,
+    ChangeRequestLeafSubject, Checkout, Convoy, ConvoyLeafSubject, ConvoyPhase, InstantiatedExit, ResourceBackend, ResourceError,
+    ResourceObject, ThreeValue, Vessel, VesselLeafSubject, WatchEvent, WatchStart, WorkLeafSubject,
 };
 use futures::StreamExt;
 use tokio::{
@@ -343,15 +343,19 @@ impl ReconcilerWake {
             convoy.status.as_ref().is_some_and(|status| matches!(status.phase, ConvoyPhase::Landing | ConvoyPhase::Anchored))
         }) {
             let checkouts = select_convoy_children(convoy, &checkout_sources);
-            let leaves = match expected_change_request_leaves(convoy, &checkouts) {
-                Ok(leaves) => leaves,
+            let exit = match instantiate_exit(convoy, &checkouts) {
+                Ok(exit) => exit,
                 Err(error) => {
                     tracing::warn!(convoy = %convoy.metadata.name, %error, "derive reconciler leaf subscriptions failed");
                     continue;
                 }
             };
-            for leaves in leaves.chunks_exact(2) {
-                desired.push((convoy.metadata.name.clone(), leaves.to_vec()));
+            if let InstantiatedExit::Table(entries) = exit {
+                for entry in entries {
+                    if !entry.leaves.is_empty() {
+                        desired.push((convoy.metadata.name.clone(), entry.leaves));
+                    }
+                }
             }
         }
 
@@ -437,6 +441,8 @@ fn evaluate_row(
     change_requests: &HashMap<String, ResourceObject<ChangeRequest>>,
     change_request_stale_after: std::time::Duration,
 ) -> Result<Option<LeafFire>, String> {
+    let require_all = matches!(row.watcher, LeafWatcher::ReconcilerWake { .. });
+    let mut matched = None;
     for leaf in &row.leaves {
         let evaluation = match &leaf.address {
             LeafAddress::Convoy { name } => {
@@ -464,15 +470,20 @@ fn evaluate_row(
             }
         };
         if evaluation.result == ThreeValue::True {
-            return Ok(Some(LeafFire {
+            matched = Some(LeafFire {
                 subscription_id: row.id,
                 watcher_id: uuid::Uuid::nil(),
                 leaf: leaf.clone(),
                 value: evaluation.value.expect("true leaf has a value").to_string(),
-            }));
+            });
+            if !require_all {
+                return Ok(matched);
+            }
+        } else if require_all {
+            return Ok(None);
         }
     }
-    Ok(None)
+    Ok(matched)
 }
 
 #[cfg(test)]
@@ -488,8 +499,9 @@ mod tests {
     use flotilla_resources::{
         controller::ControllerLoop, BoundChangeRequest, ChangeRequestObservation, ChangeRequestState, CheckoutIntegrationStatus,
         CheckoutPhase, CheckoutSpec, CheckoutStatus, ConditionValue, ConvoyPhase, ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec,
-        ConvoyStatus, CrewWorkPhase, CrewWorkState, InMemoryBackend, InputMeta, IntegrationCondition, LifecycleAuthority,
-        ObservedCheckoutSpec, PlacementStatus, RepositoryKey, SqliteBackend, WorkPhase, WorkState, WorkflowTemplate, CONVOY_LABEL,
+        ConvoyStatus, CrewWorkPhase, CrewWorkState, ExitDeclaration, InMemoryBackend, InputMeta, IntegrationCondition, LifecycleAuthority,
+        ObservedCheckoutSpec, PlacementStatus, RepositoryKey, SqliteBackend, WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate,
+        CONVOY_LABEL,
     };
 
     use super::*;
@@ -800,6 +812,222 @@ mod tests {
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].1.len(), 1);
         assert_eq!(diagnostics[0].1[0].value, "Landed");
+    }
+
+    #[tokio::test]
+    async fn declared_exit_entry_name_is_recorded_when_its_instantiated_leaf_fires() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let (event_tx, _) = broadcast::channel(16);
+        let source = Arc::new(ControlledChangeRequests { merged: AtomicBool::new(false) });
+        let cadence = crate::change_request_observer::ChangeRequestRefreshCadence {
+            state: Duration::from_millis(20),
+            checks_pending: Duration::from_millis(20),
+            freshness_demanded: Duration::from_millis(20),
+            stale_after: Duration::from_secs(60),
+        };
+        let refresher = ChangeRequestRefresher::new(backend.clone(), "authority".to_string(), source.clone(), cadence);
+        let table = LeafSubscriptionTable::new(backend.clone(), event_tx, refresher);
+        let repo_ref = RepositoryKey("repo".to_string());
+        let spec = ConvoySpec::builder()
+            .workflow_ref("workflow".to_string())
+            .repositories(vec![ConvoyRepositorySpec::builder()
+                .url("https://github.com/flotilla-org/flotilla".to_string())
+                .repo_ref(repo_ref.clone())
+                .source_ref("feature/custom-disposition".to_string())
+                .target_ref("main".to_string())
+                .workspace_slug("flotilla".to_string())
+                .subpaths(Vec::new())
+                .build()])
+            .change_request(
+                BoundChangeRequest::builder().id("1391".to_string()).repository_ref(repo_ref).title("custom".to_string()).build(),
+            )
+            .build();
+        let mut meta =
+            InputMeta::builder().name("custom".to_string()).finalizers(vec!["flotilla.work/convoy-teardown".to_string()]).build();
+        meta.set_lifecycle_authority(LifecycleAuthority::Managed);
+        let convoys = backend.clone().using::<Convoy>("flotilla");
+        let created = convoys.create(&meta, &spec).await.expect("create custom-exit convoy");
+        let status = ConvoyStatus {
+            phase: ConvoyPhase::Landing,
+            observed_workflow_ref: Some("workflow".to_string()),
+            workflow_snapshot: Some(WorkflowSnapshot {
+                exit: Some(ExitDeclaration::Table(indexmap::IndexMap::from([(
+                    "shipped".to_string(),
+                    "$cr.state == merged".parse().expect("custom leaf template"),
+                )]))),
+                vessels: Vec::new(),
+            }),
+            work: BTreeMap::from([("work".to_string(), WorkState::builder().phase(WorkPhase::Complete).build())]),
+            ..Default::default()
+        };
+        convoys.update_status("custom", &created.metadata.resource_version, &status).await.expect("mark custom convoy Landing");
+
+        let controller = tokio::spawn(
+            ControllerLoop {
+                primary: convoys.clone(),
+                secondaries: vec![table.reconciler_wake_watch()],
+                reconciler: ConvoyReconciler::new(backend.clone().using::<WorkflowTemplate>("flotilla"))
+                    .with_change_requests(backend.including_replicas::<ChangeRequest>("flotilla"), cadence.stale_after),
+                resync_interval: Duration::from_secs(3600),
+                backend: backend.clone(),
+            }
+            .run(),
+        );
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if !table.rows().await.is_empty() {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("custom exit should instantiate at binding");
+
+        source.merged.store(true, Ordering::SeqCst);
+        let settled = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let convoy = convoys.get("custom").await.expect("convoy");
+                let status = convoy.status.expect("status");
+                if status.phase == ConvoyPhase::Landed {
+                    break status;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("custom exit leaf should settle through the engine");
+        assert_eq!(settled.disposition.as_deref(), Some("shipped"));
+        controller.abort();
+    }
+
+    #[tokio::test]
+    async fn zero_subject_landing_settles_as_claim_exit_through_engine() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let (event_tx, _) = broadcast::channel(16);
+        let cadence = crate::change_request_observer::ChangeRequestRefreshCadence::default();
+        let refresher = ChangeRequestRefresher::new(backend.clone(), "authority".to_string(), Arc::new(UnavailableChangeRequests), cadence);
+        let table = LeafSubscriptionTable::new(backend.clone(), event_tx, refresher);
+        let convoys = backend.clone().using::<Convoy>("flotilla");
+        let created = convoys
+            .create(
+                &InputMeta::builder().name("no-cr".to_string()).build(),
+                &ConvoySpec::builder().workflow_ref("workflow".to_string()).build(),
+            )
+            .await
+            .expect("create zero-subject convoy");
+        convoys
+            .update_status("no-cr", &created.metadata.resource_version, &ConvoyStatus {
+                phase: ConvoyPhase::Landing,
+                observed_workflow_ref: Some("workflow".to_string()),
+                work: BTreeMap::from([("work".to_string(), WorkState::builder().phase(WorkPhase::Complete).build())]),
+                ..Default::default()
+            })
+            .await
+            .expect("mark zero-subject convoy Landing");
+        let controller = tokio::spawn(
+            ControllerLoop {
+                primary: convoys.clone(),
+                secondaries: vec![table.reconciler_wake_watch()],
+                reconciler: ConvoyReconciler::new(backend.clone().using::<WorkflowTemplate>("flotilla")),
+                resync_interval: Duration::from_secs(3600),
+                backend,
+            }
+            .run(),
+        );
+
+        let status = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let status = convoys.get("no-cr").await.expect("convoy").status.expect("status");
+                if status.phase == ConvoyPhase::Landed {
+                    break status;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("zero-subject convoy should claim-exit");
+        assert_eq!(status.disposition.as_deref(), Some("claim"));
+        assert!(table.rows().await.is_empty(), "claim exit should not arm leaves");
+        controller.abort();
+    }
+
+    #[tokio::test]
+    async fn change_request_bound_after_claims_instantiates_and_settles() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let (event_tx, _) = broadcast::channel(16);
+        let source = Arc::new(ControlledChangeRequests { merged: AtomicBool::new(false) });
+        let cadence = crate::change_request_observer::ChangeRequestRefreshCadence {
+            state: Duration::from_millis(20),
+            checks_pending: Duration::from_millis(20),
+            freshness_demanded: Duration::from_millis(20),
+            stale_after: Duration::from_secs(60),
+        };
+        let refresher = ChangeRequestRefresher::new(backend.clone(), "authority".to_string(), source.clone(), cadence);
+        let table = LeafSubscriptionTable::new(backend.clone(), event_tx, refresher);
+        let repo_ref = RepositoryKey("repo".to_string());
+        let mut spec = ConvoySpec::builder()
+            .workflow_ref("workflow".to_string())
+            .repositories(vec![ConvoyRepositorySpec::builder()
+                .url("https://github.com/flotilla-org/flotilla".to_string())
+                .repo_ref(repo_ref.clone())
+                .source_ref("feature/adopt-late".to_string())
+                .target_ref("main".to_string())
+                .workspace_slug("flotilla".to_string())
+                .subpaths(Vec::new())
+                .build()])
+            .build();
+        let meta = InputMeta::builder().name("adopt-late".to_string()).build();
+        let convoys = backend.clone().using::<Convoy>("flotilla");
+        let created = convoys.create(&meta, &spec).await.expect("create unbound convoy");
+        let landing = convoys
+            .update_status("adopt-late", &created.metadata.resource_version, &ConvoyStatus {
+                phase: ConvoyPhase::Landing,
+                observed_workflow_ref: Some("workflow".to_string()),
+                work: BTreeMap::from([("work".to_string(), WorkState::builder().phase(WorkPhase::Complete).build())]),
+                ..Default::default()
+            })
+            .await
+            .expect("claims enter Landing before binding");
+        spec.change_request =
+            Some(BoundChangeRequest::builder().id("1391".to_string()).repository_ref(repo_ref).title("adopted late".to_string()).build());
+        convoys.update(&meta, &landing.metadata.resource_version, &spec).await.expect("bind CR after claims");
+
+        let controller = tokio::spawn(
+            ControllerLoop {
+                primary: convoys.clone(),
+                secondaries: vec![table.reconciler_wake_watch()],
+                reconciler: ConvoyReconciler::new(backend.clone().using::<WorkflowTemplate>("flotilla"))
+                    .with_change_requests(backend.including_replicas::<ChangeRequest>("flotilla"), cadence.stale_after),
+                resync_interval: Duration::from_secs(3600),
+                backend: backend.clone(),
+            }
+            .run(),
+        );
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if !table.rows().await.is_empty() {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("late binding should instantiate exit leaves");
+        source.merged.store(true, Ordering::SeqCst);
+        let status = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let status = convoys.get("adopt-late").await.expect("convoy").status.expect("status");
+                if status.phase == ConvoyPhase::Landed {
+                    break status;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("late-bound CR should settle");
+        assert_eq!(status.disposition.as_deref(), Some("merged"));
+        controller.abort();
     }
 
     #[tokio::test]

--- a/crates/flotilla-core/src/leaf_engine.rs
+++ b/crates/flotilla-core/src/leaf_engine.rs
@@ -732,6 +732,7 @@ mod tests {
         let created = convoys.create(&meta, &spec).await.expect("create Landing convoy before watcher boot");
         let status = ConvoyStatus {
             phase: ConvoyPhase::Landing,
+            workflow_snapshot: Some(WorkflowSnapshot { exit: Some(ExitDeclaration::standard_table()), vessels: Vec::new() }),
             observed_workflow_ref: Some("workflow".to_string()),
             work: BTreeMap::from([("work".to_string(), WorkState::builder().phase(WorkPhase::Complete).build())]),
             ..Default::default()
@@ -919,6 +920,7 @@ mod tests {
         convoys
             .update_status("no-cr", &created.metadata.resource_version, &ConvoyStatus {
                 phase: ConvoyPhase::Landing,
+                workflow_snapshot: Some(WorkflowSnapshot { exit: Some(ExitDeclaration::standard_table()), vessels: Vec::new() }),
                 observed_workflow_ref: Some("workflow".to_string()),
                 work: BTreeMap::from([("work".to_string(), WorkState::builder().phase(WorkPhase::Complete).build())]),
                 ..Default::default()
@@ -983,6 +985,7 @@ mod tests {
         let landing = convoys
             .update_status("adopt-late", &created.metadata.resource_version, &ConvoyStatus {
                 phase: ConvoyPhase::Landing,
+                workflow_snapshot: Some(WorkflowSnapshot { exit: Some(ExitDeclaration::standard_table()), vessels: Vec::new() }),
                 observed_workflow_ref: Some("workflow".to_string()),
                 work: BTreeMap::from([("work".to_string(), WorkState::builder().phase(WorkPhase::Complete).build())]),
                 ..Default::default()
@@ -1063,6 +1066,7 @@ mod tests {
         convoys
             .update_status("cross-host", &created.metadata.resource_version, &ConvoyStatus {
                 phase: ConvoyPhase::Landing,
+                workflow_snapshot: Some(WorkflowSnapshot { exit: Some(ExitDeclaration::standard_table()), vessels: Vec::new() }),
                 observed_workflow_ref: Some("workflow".to_string()),
                 work: BTreeMap::from([("work".to_string(), work)]),
                 ..Default::default()

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -2256,7 +2256,7 @@ async fn convoy_start_reports_failed_work_without_waiting_for_auto_attach_timeou
         &convoys,
         "bootstrap-failure",
         &convoy_controller_patches::bootstrap(
-            WorkflowSnapshot { vessels: workflow.vessels },
+            WorkflowSnapshot { exit: None, vessels: workflow.vessels },
             "single-agent-contained".into(),
             BTreeMap::new(),
             BTreeMap::from([("work".into(), WorkState::builder().phase(WorkPhase::Pending).build())]),

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -1789,6 +1789,7 @@ impl Aggregator {
                     .and_then(|demand| demand.metadata.annotations.get(RECLAIM_REFUSAL_REASON_ANNOTATION).cloned())
                     .or_else(|| status.and_then(|status| status.message.clone())),
             )
+            .maybe_disposition(status.and_then(|status| status.disposition.clone()))
             .maybe_repo(self.convoy_repo_fact(convoy).map(flotilla_protocol::RepoKey))
             .maybe_started_at(status.and_then(|status| status.started_at))
             .maybe_finished_at(status.and_then(|status| status.finished_at))
@@ -2822,6 +2823,7 @@ mod tests {
         let status = ConvoyStatus {
             phase: ResourceConvoyPhase::Active,
             workflow_snapshot: Some(WorkflowSnapshot {
+                exit: None,
                 vessels: vec![VesselRequirement::builder().name("implement".to_string()).crew(Vec::new()).build()],
             }),
             work: BTreeMap::from([("implement".to_string(), WorkState::builder().phase(ResourceWorkPhase::Ready).build())]),
@@ -3389,13 +3391,15 @@ mod tests {
             flotilla_protocol::ChangeRequestStatus::Open
         );
 
-        convoy.status = Some(ConvoyStatus { phase: ResourceConvoyPhase::Landed, ..Default::default() });
+        convoy.status =
+            Some(ConvoyStatus { phase: ResourceConvoyPhase::Landed, disposition: Some("shipped".to_string()), ..Default::default() });
         aggregator.apply_convoy_event_from(LocalSource::Durable, WatchEvent::Modified(convoy)).await;
         let DaemonEvent::ResultDelta(phase_delta) = event_rx.recv().await.expect("phase delta") else {
             panic!("expected result delta");
         };
         let phase_row = &phase_delta.changes.as_convoys().expect("convoy changes")[0];
         assert_eq!(phase_row.phase, ConvoyPhase::Landed);
+        assert_eq!(phase_row.disposition.as_deref(), Some("shipped"));
         assert_eq!(phase_row.change_request.as_ref().expect("cached change request").status, flotilla_protocol::ChangeRequestStatus::Open);
 
         apply_next_change_request_resolution(&mut aggregator).await;
@@ -3900,7 +3904,7 @@ mod tests {
             spec: ConvoySpec::builder().workflow_ref("scratch".to_string()).build(),
             status: Some(ConvoyStatus {
                 phase: convoy_phase,
-                workflow_snapshot: Some(WorkflowSnapshot { vessels: vec![definition] }),
+                workflow_snapshot: Some(WorkflowSnapshot { exit: None, vessels: vec![definition] }),
                 work,
                 ..Default::default()
             }),

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -5763,6 +5763,7 @@ mod tests {
             .update_status(&convoy.metadata.name, &convoy.metadata.resource_version, &ConvoyStatus {
                 phase: ConvoyPhase::Landing,
                 workflow_snapshot: Some(flotilla_resources::WorkflowSnapshot {
+                    exit: None,
                     vessels: vec![VesselRequirement::builder().name("work".to_string()).crew(Vec::new()).build()],
                 }),
                 work: BTreeMap::from([("work".to_string(), flotilla_resources::WorkState::builder().phase(WorkPhase::Complete).build())]),

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -752,6 +752,7 @@ fn builtin_workflow_templates() -> Vec<(&'static str, WorkflowTemplateSpec)> {
         (
             "scratch",
             WorkflowTemplateSpec::builder()
+                .exit(flotilla_resources::ExitDeclaration::standard_table())
                 .inputs(vec![InputDefinition { name: "topic".to_string(), description: Some("Short label for this convoy".into()) }])
                 .vessels(vec![VesselRequirement::builder()
                     .name("work".to_string())
@@ -5067,6 +5068,7 @@ mod tests {
             .create(
                 &empty_meta(workflow_name),
                 &WorkflowTemplateSpec::builder()
+                    .exit(flotilla_resources::ExitDeclaration::standard_table())
                     .inputs(Vec::new())
                     .vessels(vec![VesselRequirement::builder()
                         .name("work".to_string())
@@ -5763,7 +5765,7 @@ mod tests {
             .update_status(&convoy.metadata.name, &convoy.metadata.resource_version, &ConvoyStatus {
                 phase: ConvoyPhase::Landing,
                 workflow_snapshot: Some(flotilla_resources::WorkflowSnapshot {
-                    exit: None,
+                    exit: Some(flotilla_resources::ExitDeclaration::standard_table()),
                     vessels: vec![VesselRequirement::builder().name("work".to_string()).crew(Vec::new()).build()],
                 }),
                 work: BTreeMap::from([("work".to_string(), flotilla_resources::WorkState::builder().phase(WorkPhase::Complete).build())]),
@@ -6260,6 +6262,7 @@ mod tests {
             .create(
                 &empty_meta("wf-a"),
                 &WorkflowTemplateSpec::builder()
+                    .exit(flotilla_resources::ExitDeclaration::standard_table())
                     .inputs(Vec::new())
                     .vessels(vec![VesselRequirement::builder()
                         .name("implement".to_string())
@@ -7161,6 +7164,7 @@ mod tests {
             .create(
                 &empty_meta("crew-workflow"),
                 &WorkflowTemplateSpec::builder()
+                    .exit(flotilla_resources::ExitDeclaration::standard_table())
                     .inputs(Vec::new())
                     .vessels(vec![VesselRequirement::builder()
                         .name("implement".to_string())
@@ -7557,6 +7561,7 @@ mod tests {
             .create(
                 &empty_meta("unknown-capability"),
                 &WorkflowTemplateSpec::builder()
+                    .exit(flotilla_resources::ExitDeclaration::standard_table())
                     .inputs(Vec::new())
                     .vessels(vec![VesselRequirement::builder()
                         .name("implement".to_string())
@@ -7645,6 +7650,7 @@ mod tests {
             .create(
                 &empty_meta("wf-a"),
                 &WorkflowTemplateSpec::builder()
+                    .exit(flotilla_resources::ExitDeclaration::standard_table())
                     .inputs(Vec::new())
                     .vessels(vec![VesselRequirement::builder()
                         .name("implement".to_string())

--- a/crates/flotilla-daemon/tests/aggregator.rs
+++ b/crates/flotilla-daemon/tests/aggregator.rs
@@ -592,6 +592,7 @@ async fn running_convoyless_session_emits_attachable_independent_row() {
         .update_status(&convoy.metadata.name, &convoy.metadata.resource_version, &ConvoyStatus {
             phase: ResourceConvoyPhase::Active,
             workflow_snapshot: Some(WorkflowSnapshot {
+                exit: None,
                 vessels: vec![VesselRequirement::builder().name("coder".to_string()).crew(Vec::new()).build()],
             }),
             work: BTreeMap::from([("coder".to_string(), WorkState::builder().phase(ResourceWorkPhase::Running).build())]),

--- a/crates/flotilla-protocol/src/result_set.rs
+++ b/crates/flotilla-protocol/src/result_set.rs
@@ -801,6 +801,8 @@ pub struct ConvoyRow {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disposition: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repo: Option<RepoKey>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub started_at: Option<Timestamp>,

--- a/crates/flotilla-resources/Cargo.toml
+++ b/crates/flotilla-resources/Cargo.toml
@@ -18,6 +18,7 @@ tokio = { workspace = true }
 async-trait = { workspace = true }
 bon = { workspace = true }
 futures = "0.3"
+indexmap = { workspace = true, features = ["serde"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 reqwest = { workspace = true, features = ["json", "query", "stream"] }
 rustls = { workspace = true }

--- a/crates/flotilla-resources/examples/k8s_crud.rs
+++ b/crates/flotilla-resources/examples/k8s_crud.rs
@@ -128,6 +128,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             message: None,
             started_at: None,
             finished_at: None,
+            disposition: None,
             observed_workflow_ref: None,
             observed_workflows: None,
             target_mismatches: Vec::new(),

--- a/crates/flotilla-resources/examples/review-and-fix.yaml
+++ b/crates/flotilla-resources/examples/review-and-fix.yaml
@@ -4,6 +4,9 @@ metadata:
   name: review-and-fix
   namespace: flotilla
 spec:
+  exit:
+    merged: $cr.state == merged
+    closed-unmerged: $cr.state == closed
   inputs:
     - name: feature
       description: Brief description of the feature to implement

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -5,8 +5,11 @@ use flotilla_protocol::{IssueRef, IssueState, Leaf, LeafAddress, LeafOperator, P
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    resource::define_resource, status_patch::StatusPatch, workflow_template::VesselRequirement, ReadResourceObject, ReplicationClass,
-    RepositoryKey, Resource, ResourceObject, ResourceProvenance, ACTUATOR_HOST_REF_ANNOTATION, CONVOY_LABEL,
+    resource::define_resource,
+    status_patch::StatusPatch,
+    workflow_template::{ExitDeclaration, SubjectVariable, VesselRequirement},
+    ReadResourceObject, ReplicationClass, RepositoryKey, Resource, ResourceObject, ResourceProvenance, ACTUATOR_HOST_REF_ANNOTATION,
+    CONVOY_LABEL,
 };
 
 mod reconcile;
@@ -192,6 +195,81 @@ pub fn expected_change_request_leaves(
         .collect())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstantiatedExitEntry {
+    pub disposition: String,
+    pub template: crate::LeafTemplate,
+    pub leaves: Vec<Leaf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstantiatedExit {
+    Claim,
+    Table(Vec<InstantiatedExitEntry>),
+}
+
+/// Instantiate the convoy's pinned exit declaration over every bound subject.
+///
+/// A table entry is an implicit universal over its subject role. With no bound
+/// subjects, table declarations collapse to the same claim exit as `exit: claim`.
+pub fn instantiate_exit(
+    convoy: &crate::ResourceObject<Convoy>,
+    checkouts: &BTreeMap<String, crate::ResourceObject<crate::Checkout>>,
+) -> Result<InstantiatedExit, String> {
+    let declaration = convoy
+        .status
+        .as_ref()
+        .and_then(|status| status.workflow_snapshot.as_ref())
+        .and_then(|snapshot| snapshot.exit.clone())
+        .unwrap_or_else(ExitDeclaration::default_table);
+    if matches!(declaration, ExitDeclaration::Claim(_)) {
+        return Ok(InstantiatedExit::Claim);
+    }
+
+    let subjects = bound_change_request_addresses(convoy, checkouts)?;
+    if subjects.is_empty() && expected_checkout_refs(convoy)?.is_empty() {
+        return Ok(InstantiatedExit::Claim);
+    }
+    let ExitDeclaration::Table(entries) = declaration else {
+        unreachable!("claim declaration returned above");
+    };
+    Ok(InstantiatedExit::Table(
+        entries
+            .into_iter()
+            .map(|(disposition, template)| {
+                let leaves = subjects
+                    .iter()
+                    .map(|address| {
+                        let address = match template.subject {
+                            SubjectVariable::ChangeRequest => address.clone(),
+                        };
+                        Leaf {
+                            address,
+                            field_path: template.field_path.clone(),
+                            operator: template.operator,
+                            literal: template.literal.clone(),
+                        }
+                    })
+                    .collect();
+                InstantiatedExitEntry { disposition, template, leaves }
+            })
+            .collect(),
+    ))
+}
+
+fn bound_change_request_addresses(
+    convoy: &crate::ResourceObject<Convoy>,
+    checkouts: &BTreeMap<String, crate::ResourceObject<crate::Checkout>>,
+) -> Result<Vec<LeafAddress>, String> {
+    let leaves = expected_change_request_leaves(convoy, checkouts)?;
+    Ok(leaves.into_iter().map(|leaf| leaf.address).fold(Vec::new(), |mut addresses, address| {
+        if !addresses.contains(&address) {
+            addresses.push(address);
+        }
+        addresses
+    }))
+}
+
 fn change_request_address(repository_url: &str, id: &str) -> Result<LeafAddress, String> {
     let canonical = crate::canonicalize_repo_url(repository_url)?;
     let without_scheme = canonical
@@ -287,6 +365,8 @@ pub struct ConvoyStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub finished_at: Option<DateTime<Utc>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disposition: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub observed_workflow_ref: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub observed_workflows: Option<BTreeMap<String, String>>,
@@ -307,6 +387,8 @@ pub struct TargetMismatch {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkflowSnapshot {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit: Option<ExitDeclaration>,
     pub vessels: Vec<VesselRequirement>,
 }
 
@@ -449,6 +531,7 @@ pub enum ConvoyStatusPatch {
         finished_at: Option<DateTime<Utc>>,
     },
     Settle {
+        disposition: String,
         target_mismatches: Vec<TargetMismatch>,
         finished_at: DateTime<Utc>,
     },
@@ -598,10 +681,11 @@ impl StatusPatch<ConvoyStatus> for ConvoyStatusPatch {
                     status.finished_at.get_or_insert(*finished_at);
                 }
             }
-            Self::Settle { target_mismatches, finished_at } => {
+            Self::Settle { disposition, target_mismatches, finished_at } => {
                 let previous_phase = status.phase;
                 status.phase = ConvoyPhase::Landed;
                 status.target_mismatches = target_mismatches.clone();
+                status.disposition = Some(disposition.clone());
                 if previous_phase != ConvoyPhase::Landed {
                     status.finished_at = None;
                 }
@@ -819,8 +903,8 @@ pub mod controller_patches {
         ConvoyStatusPatch::RollUpPhase { phase, started_at, finished_at }
     }
 
-    pub fn settle(target_mismatches: Vec<TargetMismatch>, finished_at: DateTime<Utc>) -> ConvoyStatusPatch {
-        ConvoyStatusPatch::Settle { target_mismatches, finished_at }
+    pub fn settle(disposition: String, target_mismatches: Vec<TargetMismatch>, finished_at: DateTime<Utc>) -> ConvoyStatusPatch {
+        ConvoyStatusPatch::Settle { disposition, target_mismatches, finished_at }
     }
 
     pub fn roll_up_work(work: String, phase: WorkPhase, transitioned_at: DateTime<Utc>, message: Option<String>) -> ConvoyStatusPatch {

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -204,6 +204,7 @@ pub struct InstantiatedExitEntry {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InstantiatedExit {
+    None,
     Claim,
     Table(Vec<InstantiatedExitEntry>),
 }
@@ -211,17 +212,18 @@ pub enum InstantiatedExit {
 /// Instantiate the convoy's pinned exit declaration over every bound subject.
 ///
 /// A table entry is an implicit universal over its subject role. With no bound
-/// subjects, table declarations collapse to the same claim exit as `exit: claim`.
+/// subjects, a declared table collapses to the same claim exit as `exit: claim`.
+/// An absent declaration stays absent, leaving the convoy standing until an
+/// operator explicitly reaps it.
 pub fn instantiate_exit(
     convoy: &crate::ResourceObject<Convoy>,
     checkouts: &BTreeMap<String, crate::ResourceObject<crate::Checkout>>,
 ) -> Result<InstantiatedExit, String> {
-    let declaration = convoy
-        .status
-        .as_ref()
-        .and_then(|status| status.workflow_snapshot.as_ref())
-        .and_then(|snapshot| snapshot.exit.clone())
-        .unwrap_or_else(ExitDeclaration::default_table);
+    let Some(declaration) =
+        convoy.status.as_ref().and_then(|status| status.workflow_snapshot.as_ref()).and_then(|snapshot| snapshot.exit.clone())
+    else {
+        return Ok(InstantiatedExit::None);
+    };
     if matches!(declaration, ExitDeclaration::Claim(_)) {
         return Ok(InstantiatedExit::Claim);
     }

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -10,8 +10,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use super::{
-    controller_patches, expected_change_request_leaves, expected_checkout_refs, provisioning_patches, select_convoy_children, Convoy,
-    ConvoyPhase, ConvoyStatusPatch, CrewWorkPhase, CrewWorkState, VesselRequirement, WorkCompletionAuthority, WorkPhase, WorkState,
+    controller_patches, expected_checkout_refs, instantiate_exit, provisioning_patches, select_convoy_children, Convoy, ConvoyPhase,
+    ConvoyStatusPatch, CrewWorkPhase, CrewWorkState, InstantiatedExit, VesselRequirement, WorkCompletionAuthority, WorkPhase, WorkState,
     WorkflowSnapshot,
 };
 use crate::{
@@ -51,9 +51,9 @@ struct InternalReconcileOutcome {
     events: Vec<ConvoyEvent>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct LifecycleConditions {
-    no_change_request_outstanding: bool,
+    exit_disposition: Option<String>,
     reclaim_eligible: bool,
 }
 
@@ -90,7 +90,7 @@ pub struct ConvoyDependencies {
     vessels: BTreeMap<String, ResourceObject<Vessel>>,
     presentations: BTreeMap<String, ResourceObject<Presentation>>,
     checkouts: BTreeMap<String, ResourceObject<Checkout>>,
-    no_change_request_outstanding: bool,
+    exit_disposition: Option<String>,
     reclaim_eligible: bool,
 }
 
@@ -207,6 +207,7 @@ async fn federated_children<T: Resource + Clone>(
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SettlementMode {
+    NoExit,
     ClaimExit,
     WorldTerminal,
 }
@@ -215,6 +216,7 @@ pub enum SettlementMode {
 #[serde(tag = "reason", rename_all = "snake_case")]
 pub enum UnmetSettlementExpectation {
     InvalidExpectedCheckouts { message: String },
+    ExitEntryAwaitingBinding { disposition: String, subject: String },
     MissingCheckout { checkout: String },
     MissingCheckoutStatus { checkout: String },
     CheckoutConditionFalse { checkout: String, condition: String },
@@ -233,6 +235,11 @@ pub struct SettlementEvaluation {
     pub unmet: Vec<UnmetSettlementExpectation>,
 }
 
+struct LandingSettlement {
+    evaluation: SettlementEvaluation,
+    disposition: Option<String>,
+}
+
 /// Evaluate the exact Landing settlement condition and retain the evidence for
 /// every branch that held it false. Reconciliation and diagnostics share this
 /// function so an explanation cannot drift from the condition writer.
@@ -244,73 +251,132 @@ pub fn evaluate_landing_settlement(
     landing_evidence_stale_after: std::time::Duration,
     now: DateTime<Utc>,
 ) -> SettlementEvaluation {
+    evaluate_landing_settlement_with_disposition(
+        convoy,
+        checkouts,
+        change_requests,
+        change_request_stale_after,
+        landing_evidence_stale_after,
+        now,
+    )
+    .evaluation
+}
+
+fn evaluate_landing_settlement_with_disposition(
+    convoy: &ResourceObject<Convoy>,
+    checkouts: &BTreeMap<String, ResourceObject<Checkout>>,
+    change_requests: &BTreeMap<String, ResourceObject<ChangeRequest>>,
+    change_request_stale_after: std::time::Duration,
+    landing_evidence_stale_after: std::time::Duration,
+    now: DateTime<Utc>,
+) -> LandingSettlement {
     let expected = match expected_checkout_refs(convoy) {
         Ok(expected) => expected,
         Err(message) => {
-            return SettlementEvaluation {
-                mode: SettlementMode::WorldTerminal,
-                satisfied: false,
-                unmet: vec![UnmetSettlementExpectation::InvalidExpectedCheckouts { message }],
+            return LandingSettlement {
+                evaluation: SettlementEvaluation {
+                    mode: SettlementMode::WorldTerminal,
+                    satisfied: false,
+                    unmet: vec![UnmetSettlementExpectation::InvalidExpectedCheckouts { message }],
+                },
+                disposition: None,
             };
         }
     };
-    if expected.is_empty() && convoy.spec.change_request.is_none() {
-        return SettlementEvaluation { mode: SettlementMode::ClaimExit, satisfied: true, unmet: Vec::new() };
-    }
-
-    let mut unmet = Vec::new();
-    let leaves = match expected_change_request_leaves(convoy, checkouts) {
-        Ok(leaves) => leaves,
+    let exit = match instantiate_exit(convoy, checkouts) {
+        Ok(exit) => exit,
         Err(message) => {
-            return SettlementEvaluation {
-                mode: SettlementMode::WorldTerminal,
-                satisfied: false,
-                unmet: vec![UnmetSettlementExpectation::InvalidCondition { subject: convoy.metadata.name.clone(), message }],
+            return LandingSettlement {
+                evaluation: SettlementEvaluation {
+                    mode: SettlementMode::WorldTerminal,
+                    satisfied: false,
+                    unmet: vec![UnmetSettlementExpectation::InvalidCondition { subject: convoy.metadata.name.clone(), message }],
+                },
+                disposition: None,
             };
         }
     };
-    for terminal_leaves in leaves.chunks_exact(2) {
-        let mut record_name = None;
-        let mut observed_at = None;
-        let mut value = None;
-        let mut terminal = false;
-        for leaf in terminal_leaves {
+    let entries = match exit {
+        InstantiatedExit::None => {
+            return LandingSettlement {
+                evaluation: SettlementEvaluation { mode: SettlementMode::NoExit, satisfied: false, unmet: Vec::new() },
+                disposition: None,
+            };
+        }
+        InstantiatedExit::Claim => {
+            return LandingSettlement {
+                evaluation: SettlementEvaluation { mode: SettlementMode::ClaimExit, satisfied: true, unmet: Vec::new() },
+                disposition: Some("claim".to_string()),
+            };
+        }
+        InstantiatedExit::Table(entries) => entries,
+    };
+
+    let mut table_unmet = Vec::new();
+    let mut disposition = None;
+    for entry in entries {
+        // A checkout with landed evidence predates a bound change-request
+        // record. The default merged entry remains its concrete exit.
+        if entry.leaves.is_empty() {
+            if entry.template.field_path == ".state"
+                && entry.template.operator == flotilla_protocol::LeafOperator::Equal
+                && entry.template.literal == "merged"
+            {
+                disposition = Some(entry.disposition);
+                break;
+            }
+            table_unmet
+                .push(UnmetSettlementExpectation::ExitEntryAwaitingBinding { disposition: entry.disposition, subject: "$cr".to_string() });
+            continue;
+        }
+
+        let mut entry_unmet = Vec::new();
+        for leaf in &entry.leaves {
             let flotilla_protocol::LeafAddress::ChangeRequest { service, scope, number } = &leaf.address else {
+                entry_unmet.push(UnmetSettlementExpectation::InvalidCondition {
+                    subject: convoy.metadata.name.clone(),
+                    message: "exit table leaf did not address a change request".to_string(),
+                });
                 continue;
             };
             let name = crate::change_request_record_name(service, scope, *number);
-            record_name = Some(name.clone());
             let subject = change_requests.get(&name).map(|change_request| ChangeRequestLeafSubject {
                 change_request,
                 now,
                 stale_after: change_request_stale_after,
             });
-            observed_at = change_requests.get(&name).and_then(|record| record.status.as_ref()).map(|status| status.state.observed_at);
             match crate::evaluate_leaf(leaf, subject.as_ref().map(|subject| subject as &dyn crate::LeafSubject), None) {
-                Ok(evaluation) => {
-                    value = evaluation.value.map(|value| value.to_string()).or(value);
-                    terminal |= evaluation.result == ThreeValue::True;
+                Ok(evaluation) if evaluation.result == ThreeValue::True => {}
+                Ok(evaluation) => match change_requests.get(&name) {
+                    None => entry_unmet.push(UnmetSettlementExpectation::MissingChangeRequest { record: name }),
+                    Some(record) => {
+                        let observed_at = record.status.as_ref().map(|status| status.state.observed_at);
+                        if observed_at
+                            .and_then(|at| now.signed_duration_since(at).to_std().ok())
+                            .is_none_or(|age| age > change_request_stale_after)
+                        {
+                            entry_unmet.push(UnmetSettlementExpectation::StaleChangeRequest { record: name, observed_at });
+                        } else {
+                            entry_unmet.push(UnmetSettlementExpectation::ChangeRequestConditionFalse {
+                                record: name,
+                                value: evaluation.value.map(|value| value.to_string()),
+                            });
+                        }
+                    }
+                },
+                Err(message) => {
+                    entry_unmet.push(UnmetSettlementExpectation::InvalidCondition { subject: name, message });
                 }
-                Err(message) => unmet.push(UnmetSettlementExpectation::InvalidCondition { subject: name, message }),
             }
         }
-        if terminal {
-            continue;
+        if entry_unmet.is_empty() {
+            disposition = Some(entry.disposition);
+            break;
         }
-        let record = record_name.expect("change request terminal leaf pair has an address");
-        match change_requests.get(&record) {
-            None => unmet.push(UnmetSettlementExpectation::MissingChangeRequest { record }),
-            Some(_)
-                if observed_at
-                    .and_then(|at| now.signed_duration_since(at).to_std().ok())
-                    .is_none_or(|age| age > change_request_stale_after) =>
-            {
-                unmet.push(UnmetSettlementExpectation::StaleChangeRequest { record, observed_at });
-            }
-            Some(_) => unmet.push(UnmetSettlementExpectation::ChangeRequestConditionFalse { record, value }),
-        }
+        table_unmet.extend(entry_unmet);
     }
 
+    let mut unmet = if disposition.is_some() { Vec::new() } else { table_unmet };
     let bound_repository = convoy.spec.change_request.as_ref().map(|bound| &bound.repository_ref);
     for name in expected {
         let Some(checkout) = checkouts.get(&name) else {
@@ -352,7 +418,11 @@ pub fn evaluate_landing_settlement(
         }
     }
 
-    SettlementEvaluation { mode: SettlementMode::WorldTerminal, satisfied: unmet.is_empty(), unmet }
+    let satisfied = disposition.is_some() && unmet.is_empty();
+    LandingSettlement {
+        evaluation: SettlementEvaluation { mode: SettlementMode::WorldTerminal, satisfied, unmet },
+        disposition: satisfied.then_some(disposition).flatten(),
+    }
 }
 
 impl Reconciler for ConvoyReconciler {
@@ -412,8 +482,8 @@ impl Reconciler for ConvoyReconciler {
             }
             _ => BTreeMap::new(),
         };
-        let no_change_request_outstanding = if is_landing {
-            evaluate_landing_settlement(
+        let exit_disposition = if is_landing {
+            evaluate_landing_settlement_with_disposition(
                 obj,
                 &checkouts,
                 &change_requests,
@@ -421,9 +491,9 @@ impl Reconciler for ConvoyReconciler {
                 self.landing_evidence_stale_after,
                 self.clock.now(),
             )
-            .satisfied
+            .disposition
         } else {
-            false
+            None
         };
         let reclaim_eligible = if obj.status.as_ref().is_some_and(|status| status.phase.is_terminal()) {
             match &self.teardown_runtime {
@@ -436,7 +506,7 @@ impl Reconciler for ConvoyReconciler {
         } else {
             false
         };
-        Ok(ConvoyDependencies { template, vessels, presentations, checkouts, no_change_request_outstanding, reclaim_eligible })
+        Ok(ConvoyDependencies { template, vessels, presentations, checkouts, exit_disposition, reclaim_eligible })
     }
 
     fn reconcile(
@@ -451,10 +521,7 @@ impl Reconciler for ConvoyReconciler {
             &deps.vessels,
             &deps.presentations,
             &deps.checkouts,
-            LifecycleConditions {
-                no_change_request_outstanding: deps.no_change_request_outstanding,
-                reclaim_eligible: deps.reclaim_eligible,
-            },
+            LifecycleConditions { exit_disposition: deps.exit_disposition.clone(), reclaim_eligible: deps.reclaim_eligible },
             now,
         );
         ControllerReconcileOutcome {
@@ -490,26 +557,22 @@ impl Reconciler for ConvoyReconciler {
     }
 }
 
-/// Test-support reconcile entry that carries no vessel, presentation, or
-/// checkout state. Settlement can therefore only be judged from the convoy
-/// record itself: a convoy expecting no checkouts (no placement
-/// `checkout_refs`, no adoptions) settles on claims alone, and any expected
-/// checkout holds settlement here because this path has no integration
-/// evidence to offer. Production callers go through `ConvoyReconciler`,
-/// which supplies the federated checkout list.
+/// Test-support reconcile entry that carries no vessel, presentation, checkout,
+/// or change-request state. Claim exits can settle here; instantiated leaf
+/// tables require the production [`ConvoyReconciler`] and its observed records.
 pub fn reconcile(
     convoy: &ResourceObject<Convoy>,
     template: Option<&ResourceObject<WorkflowTemplate>>,
     now: DateTime<Utc>,
 ) -> ReconcileOutcome {
-    let no_change_request_outstanding = expected_checkout_refs(convoy).is_ok_and(|expected| expected.is_empty());
+    let exit_disposition = matches!(instantiate_exit(convoy, &BTreeMap::new()), Ok(InstantiatedExit::Claim)).then(|| "claim".to_string());
     let outcome = reconcile_internal(
         convoy,
         template,
         &BTreeMap::new(),
         &BTreeMap::new(),
         &BTreeMap::new(),
-        LifecycleConditions { no_change_request_outstanding, reclaim_eligible: false },
+        LifecycleConditions { exit_disposition, reclaim_eligible: false },
         now,
     );
     ReconcileOutcome { patch: outcome.patch, events: outcome.events }
@@ -592,7 +655,7 @@ fn reconcile_internal(
         });
     }
 
-    if let Some(outcome) = roll_up_phase_outcome(convoy, &status, checkouts, conditions.no_change_request_outstanding, now) {
+    if let Some(outcome) = roll_up_phase_outcome(convoy, &status, checkouts, conditions.exit_disposition.as_deref(), now) {
         return with_cleanup(convoy, &status, vessels, presentations, checkouts, conditions.reclaim_eligible, InternalReconcileOutcome {
             patch: outcome.patch,
             actuations: provisioning.actuations,
@@ -643,6 +706,7 @@ fn bootstrap_outcome(
     }
 
     let workflow_snapshot = WorkflowSnapshot {
+        exit: template.spec.exit.clone(),
         vessels: template
             .spec
             .vessels
@@ -899,11 +963,11 @@ fn roll_up_phase_outcome(
     convoy: &ResourceObject<Convoy>,
     status: &super::ConvoyStatus,
     checkouts: &BTreeMap<String, ResourceObject<Checkout>>,
-    no_change_request_outstanding: bool,
+    exit_disposition: Option<&str>,
     now: DateTime<Utc>,
 ) -> Option<ReconcileOutcome> {
     let all_complete = !status.work.is_empty() && status.work.values().all(|state| state.phase == WorkPhase::Complete);
-    if status.phase == ConvoyPhase::Landing && all_complete && no_change_request_outstanding {
+    if let (ConvoyPhase::Landing, true, Some(exit_disposition)) = (status.phase, all_complete, exit_disposition) {
         let target_mismatches = convoy
             .spec
             .repositories
@@ -926,7 +990,7 @@ fn roll_up_phase_outcome(
             })
             .collect();
         return Some(ReconcileOutcome {
-            patch: Some(controller_patches::settle(target_mismatches, now)),
+            patch: Some(controller_patches::settle(exit_disposition.to_string(), target_mismatches, now)),
             events: vec![ConvoyEvent::PhaseChanged { from: ConvoyPhase::Landing, to: ConvoyPhase::Landed }],
         });
     }

--- a/crates/flotilla-resources/src/crds/convoy.crd.yaml
+++ b/crates/flotilla-resources/src/crds/convoy.crd.yaml
@@ -180,6 +180,13 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                   properties:
+                    exit:
+                      oneOf:
+                        - type: string
+                          enum: [claim]
+                        - type: object
+                          additionalProperties:
+                            type: string
                     vessels:
                       type: array
                       items:
@@ -230,6 +237,8 @@ spec:
                 finished_at:
                   type: string
                   format: date-time
+                disposition:
+                  type: string
                 work:
                   type: object
                   additionalProperties:

--- a/crates/flotilla-resources/src/crds/workflow_template.crd.yaml
+++ b/crates/flotilla-resources/src/crds/workflow_template.crd.yaml
@@ -36,6 +36,15 @@ spec:
                         minLength: 1
                       description:
                         type: string
+                exit:
+                  oneOf:
+                    - type: string
+                      enum: [claim]
+                    - type: object
+                      minProperties: 1
+                      additionalProperties:
+                        type: string
+                        pattern: '^\$cr\.[^ ]+ (==|!=|<|<=|>|>=) .+$'
                 vessels:
                   type: array
                   minItems: 1

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -54,12 +54,12 @@ pub use clock::{Clock, SystemClock};
 pub use clone::{Clone, ClonePhase, CloneSpec, CloneStatus, CloneStatusPatch};
 pub use convoy::{
     bound_change_request_record_name, controller_patches, evaluate_landing_settlement, expected_change_request_leaves,
-    expected_checkout_refs, external_patches, pinned_placement_ref, pinned_workflow_ref, prepared_snapshot_pending, provisioning_patches,
-    reconcile, select_convoy_children, BoundChangeRequest, Convoy, ConvoyEvent, ConvoyIssue, ConvoyPhase, ConvoyReconciler,
-    ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, ConvoyStatusPatch, ConvoyTeardownRuntime, CrewWorkPhase, CrewWorkState, InputValue,
-    IssueSnapshot, PlacementStatus, ReconcileOutcome, SettlementEvaluation, SettlementMode, TargetMismatch, UnmetSettlementExpectation,
-    WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot, PLACEMENT_SNAPSHOT_ANNOTATION, PREPARED_SNAPSHOT_PENDING_ANNOTATION,
-    WORKFLOW_SNAPSHOT_ANNOTATION,
+    expected_checkout_refs, external_patches, instantiate_exit, pinned_placement_ref, pinned_workflow_ref, prepared_snapshot_pending,
+    provisioning_patches, reconcile, select_convoy_children, BoundChangeRequest, Convoy, ConvoyEvent, ConvoyIssue, ConvoyPhase,
+    ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, ConvoyStatusPatch, ConvoyTeardownRuntime, CrewWorkPhase,
+    CrewWorkState, InputValue, InstantiatedExit, InstantiatedExitEntry, IssueSnapshot, PlacementStatus, ReconcileOutcome,
+    SettlementEvaluation, SettlementMode, TargetMismatch, UnmetSettlementExpectation, WorkCompletionAuthority, WorkPhase, WorkState,
+    WorkflowSnapshot, PLACEMENT_SNAPSHOT_ANNOTATION, PREPARED_SNAPSHOT_PENDING_ANNOTATION, WORKFLOW_SNAPSHOT_ANNOTATION,
 };
 pub use credential::{
     CredentialConsumer, CredentialGrant, CredentialGrantSelector, CredentialGrantSpec, CredentialLifecycle,
@@ -171,7 +171,7 @@ macro_rules! for_each_registered_resource {
 }
 pub use workflow_template::{
     implement_review_workflow_spec, interactive_single_workflow_spec, single_agent_contained_workflow_spec,
-    single_agent_shepherd_workflow_spec, single_agent_trusted_workflow_spec, validate, CrewSource, CrewSpec, InputDefinition,
-    InterpolationField, InterpolationLocation, Selector, Stance, ValidationError, VesselRequirement, WorkflowTemplate,
-    WorkflowTemplateSpec,
+    single_agent_shepherd_workflow_spec, single_agent_trusted_workflow_spec, validate, ClaimExit, CrewSource, CrewSpec, ExitDeclaration,
+    InputDefinition, InterpolationField, InterpolationLocation, LeafTemplate, Selector, Stance, SubjectVariable, ValidationError,
+    VesselRequirement, WorkflowTemplate, WorkflowTemplateSpec,
 };

--- a/crates/flotilla-resources/src/workflow_template.rs
+++ b/crates/flotilla-resources/src/workflow_template.rs
@@ -1,5 +1,11 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+    str::FromStr,
+};
 
+use flotilla_protocol::LeafOperator;
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use crate::{resource::define_resource, status_patch::NoStatusPatch, RepositoryKey};
@@ -11,7 +17,133 @@ pub struct WorkflowTemplateSpec {
     #[builder(default)]
     #[serde(default)]
     pub inputs: Vec<InputDefinition>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit: Option<ExitDeclaration>,
     pub vessels: Vec<VesselRequirement>,
+}
+
+impl WorkflowTemplateSpec {
+    pub fn effective_exit(&self) -> ExitDeclaration {
+        self.exit.clone().unwrap_or_else(ExitDeclaration::default_table)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ExitDeclaration {
+    Claim(ClaimExit),
+    Table(IndexMap<String, LeafTemplate>),
+}
+
+impl ExitDeclaration {
+    pub fn default_table() -> Self {
+        Self::Table(IndexMap::from([
+            ("merged".to_string(), "$cr.state == merged".parse().expect("valid implicit merged exit")),
+            ("closed-unmerged".to_string(), "$cr.state == closed".parse().expect("valid implicit closed exit")),
+        ]))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClaimExit;
+
+impl Serialize for ClaimExit {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str("claim")
+    }
+}
+
+impl<'de> Deserialize<'de> for ClaimExit {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        if value == "claim" {
+            Ok(Self)
+        } else {
+            Err(serde::de::Error::custom("exit scalar must be `claim`"))
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeafTemplate {
+    pub subject: SubjectVariable,
+    pub field_path: String,
+    pub operator: LeafOperator,
+    pub literal: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubjectVariable {
+    ChangeRequest,
+}
+
+impl FromStr for LeafTemplate {
+    type Err = String;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let mut parts = input.split_whitespace();
+        let subject_path = parts.next().ok_or_else(|| leaf_template_syntax_error(input))?;
+        let operator = parts.next().ok_or_else(|| leaf_template_syntax_error(input))?.parse()?;
+        let literal = parts.collect::<Vec<_>>().join(" ");
+        if literal.is_empty() {
+            return Err(leaf_template_syntax_error(input));
+        }
+        let (subject, field_path) = subject_path
+            .split_once('.')
+            .map(|(subject, path)| (subject, format!(".{path}")))
+            .ok_or_else(|| leaf_template_syntax_error(input))?;
+        let subject = match subject {
+            "$cr" => SubjectVariable::ChangeRequest,
+            unknown => return Err(format!("unknown exit leaf subject variable `{unknown}`; admitted variables: $cr")),
+        };
+        if field_path == "." {
+            return Err(leaf_template_syntax_error(input));
+        }
+        let literal = literal
+            .strip_prefix('"')
+            .and_then(|value| value.strip_suffix('"'))
+            .or_else(|| literal.strip_prefix('\'').and_then(|value| value.strip_suffix('\'')))
+            .unwrap_or(&literal)
+            .to_string();
+        Ok(Self { subject, field_path, operator, literal })
+    }
+}
+
+fn leaf_template_syntax_error(input: &str) -> String {
+    format!("invalid exit leaf template `{input}`; expected `$cr.<field-path> <operator> <literal>`")
+}
+
+impl fmt::Display for LeafTemplate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let subject = match self.subject {
+            SubjectVariable::ChangeRequest => "$cr",
+        };
+        write!(f, "{subject}{} {} {}", self.field_path, self.operator, self.literal)
+    }
+}
+
+impl Serialize for LeafTemplate {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for LeafTemplate {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?.parse().map_err(serde::de::Error::custom)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -205,6 +337,8 @@ pub fn implement_review_workflow_spec() -> WorkflowTemplateSpec {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValidationError {
+    EmptyExitTable,
+    InvalidExitLeaf { disposition: String, template: String },
     DuplicateVesselName { name: String },
     EmptyRepositoryScope { vessel: String },
     DuplicateRepositoryRef { vessel: String, repo_ref: RepositoryKey },
@@ -251,6 +385,10 @@ impl std::fmt::Display for InterpolationLocation {
 impl std::fmt::Display for ValidationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            ValidationError::EmptyExitTable => f.write_str("exit table must declare at least one disposition entry"),
+            ValidationError::InvalidExitLeaf { disposition, template } => {
+                write!(f, "exit disposition `{disposition}` is not a world-terminal leaf: `{template}`")
+            }
             ValidationError::DuplicateVesselName { name } => write!(f, "duplicate vessel name `{name}`"),
             ValidationError::EmptyRepositoryScope { vessel } => write!(f, "vessel `{vessel}` has an empty repository scope"),
             ValidationError::DuplicateRepositoryRef { vessel, repo_ref } => {
@@ -292,6 +430,7 @@ pub(crate) struct TemplateToken<'a> {
 
 pub fn validate(spec: &WorkflowTemplateSpec) -> Result<(), Vec<ValidationError>> {
     let mut errors = Vec::new();
+    validate_exit(spec, &mut errors);
     let declared_inputs = collect_inputs(spec, &mut errors);
     let vessels_by_name = collect_vessels(spec, &mut errors);
 
@@ -304,6 +443,24 @@ pub fn validate(spec: &WorkflowTemplateSpec) -> Result<(), Vec<ValidationError>>
         Ok(())
     } else {
         Err(errors)
+    }
+}
+
+fn validate_exit(spec: &WorkflowTemplateSpec, errors: &mut Vec<ValidationError>) {
+    let Some(ExitDeclaration::Table(entries)) = spec.exit.as_ref() else {
+        return;
+    };
+    if entries.is_empty() {
+        push_error(errors, ValidationError::EmptyExitTable);
+    }
+    for (disposition, template) in entries {
+        let is_world_terminal = template.subject == SubjectVariable::ChangeRequest
+            && template.field_path == ".state"
+            && template.operator == LeafOperator::Equal
+            && matches!(template.literal.as_str(), "merged" | "closed");
+        if !is_world_terminal {
+            push_error(errors, ValidationError::InvalidExitLeaf { disposition: disposition.clone(), template: template.to_string() });
+        }
     }
 }
 

--- a/crates/flotilla-resources/src/workflow_template.rs
+++ b/crates/flotilla-resources/src/workflow_template.rs
@@ -22,12 +22,6 @@ pub struct WorkflowTemplateSpec {
     pub vessels: Vec<VesselRequirement>,
 }
 
-impl WorkflowTemplateSpec {
-    pub fn effective_exit(&self) -> ExitDeclaration {
-        self.exit.clone().unwrap_or_else(ExitDeclaration::default_table)
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ExitDeclaration {
@@ -36,10 +30,10 @@ pub enum ExitDeclaration {
 }
 
 impl ExitDeclaration {
-    pub fn default_table() -> Self {
+    pub fn standard_table() -> Self {
         Self::Table(IndexMap::from([
-            ("merged".to_string(), "$cr.state == merged".parse().expect("valid implicit merged exit")),
-            ("closed-unmerged".to_string(), "$cr.state == closed".parse().expect("valid implicit closed exit")),
+            ("merged".to_string(), "$cr.state == merged".parse().expect("valid standard merged exit")),
+            ("closed-unmerged".to_string(), "$cr.state == closed".parse().expect("valid standard closed exit")),
         ]))
     }
 }
@@ -250,6 +244,7 @@ pub struct Selector {
 
 pub fn single_agent_contained_workflow_spec() -> WorkflowTemplateSpec {
     WorkflowTemplateSpec::builder()
+        .exit(ExitDeclaration::standard_table())
         .vessels(vec![VesselRequirement::builder()
             .name("work".to_string())
             .stance(Stance::Contained)
@@ -267,6 +262,7 @@ pub fn single_agent_contained_workflow_spec() -> WorkflowTemplateSpec {
 /// contained smoke passes with credentials.
 pub fn single_agent_trusted_workflow_spec() -> WorkflowTemplateSpec {
     WorkflowTemplateSpec::builder()
+        .exit(ExitDeclaration::standard_table())
         .vessels(vec![VesselRequirement::builder()
             .name("work".to_string())
             .stance(Stance::Trusted)
@@ -280,6 +276,7 @@ pub fn single_agent_trusted_workflow_spec() -> WorkflowTemplateSpec {
 
 pub fn single_agent_shepherd_workflow_spec() -> WorkflowTemplateSpec {
     WorkflowTemplateSpec::builder()
+        .exit(ExitDeclaration::standard_table())
         .vessels(vec![VesselRequirement::builder()
             .name("work".to_string())
             .stance(Stance::Trusted)
@@ -297,6 +294,7 @@ pub fn single_agent_shepherd_workflow_spec() -> WorkflowTemplateSpec {
 
 pub fn interactive_single_workflow_spec() -> WorkflowTemplateSpec {
     WorkflowTemplateSpec::builder()
+        .exit(ExitDeclaration::standard_table())
         .vessels(vec![VesselRequirement::builder()
             .name("work".to_string())
             .stance(Stance::Trusted)
@@ -314,6 +312,7 @@ pub fn interactive_single_workflow_spec() -> WorkflowTemplateSpec {
 
 pub fn implement_review_workflow_spec() -> WorkflowTemplateSpec {
     WorkflowTemplateSpec::builder()
+        .exit(ExitDeclaration::standard_table())
         .vessels(vec![VesselRequirement::builder()
             .name("work".to_string())
             .stance(Stance::Contained)

--- a/crates/flotilla-resources/tests/common/mod.rs
+++ b/crates/flotilla-resources/tests/common/mod.rs
@@ -7,8 +7,8 @@ use std::{collections::BTreeMap, future::Future, time::Duration};
 use chrono::{DateTime, TimeZone, Utc};
 use flotilla_resources::{
     ApiPaths, Convoy as RealConvoy, ConvoySpec as RealConvoySpec, ConvoyStatus as RealConvoyStatus, CrewSource, CrewSpec, CrewWorkPhase,
-    CrewWorkState, InputDefinition, InputMeta, ObjectMeta, OwnerReference, Resource, ResourceObject, Selector, StatusPatch,
-    VesselRequirement, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowTemplate, WorkflowTemplateSpec,
+    CrewWorkState, ExitDeclaration, InputDefinition, InputMeta, ObjectMeta, OwnerReference, Resource, ResourceObject, Selector,
+    StatusPatch, VesselRequirement, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowTemplate, WorkflowTemplateSpec,
 };
 use serde::{Deserialize, Serialize};
 use tokio::{
@@ -120,6 +120,7 @@ pub fn workflow_template_meta(name: &str) -> InputMeta {
 
 pub fn valid_workflow_template_spec() -> WorkflowTemplateSpec {
     WorkflowTemplateSpec::builder()
+        .exit(ExitDeclaration::standard_table())
         .inputs(vec![
             InputDefinition { name: "feature".to_string(), description: Some("Brief description of the feature to implement".to_string()) },
             InputDefinition { name: "branch".to_string(), description: Some("Target git branch".to_string()) },
@@ -260,6 +261,7 @@ pub fn convoy_object(name: &str, spec: RealConvoySpec, status: Option<RealConvoy
 
 pub fn tool_only_workflow_template_spec() -> WorkflowTemplateSpec {
     WorkflowTemplateSpec::builder()
+        .exit(ExitDeclaration::standard_table())
         .inputs(vec![
             InputDefinition { name: "feature".to_string(), description: Some("Brief description of the feature to implement".to_string()) },
             InputDefinition { name: "branch".to_string(), description: Some("Target git branch".to_string()) },
@@ -295,8 +297,8 @@ pub fn tool_only_workflow_template_object(name: &str) -> ResourceObject<Workflow
 }
 
 pub fn bootstrapped_convoy_status() -> RealConvoyStatus {
-    let snapshot =
-        flotilla_resources::WorkflowSnapshot { exit: None, vessels: valid_workflow_template_spec().vessels.into_iter().collect() };
+    let workflow = valid_workflow_template_spec();
+    let snapshot = flotilla_resources::WorkflowSnapshot { exit: workflow.exit, vessels: workflow.vessels };
     let work = [("implement".to_string(), pending_task_state()), ("review".to_string(), pending_task_state())].into_iter().collect();
     let crew_work = BTreeMap::from([
         ("implement".to_string(), BTreeMap::from([("coder".to_string(), pending_crew_work_state())])),
@@ -379,9 +381,10 @@ where
 }
 
 pub fn bootstrapped_tool_only_convoy_status() -> RealConvoyStatus {
+    let workflow = tool_only_workflow_template_spec();
     let snapshot = flotilla_resources::WorkflowSnapshot {
-        exit: None,
-        vessels: tool_only_workflow_template_spec()
+        exit: workflow.exit,
+        vessels: workflow
             .vessels
             .into_iter()
             .map(|task| flotilla_resources::VesselRequirement {

--- a/crates/flotilla-resources/tests/common/mod.rs
+++ b/crates/flotilla-resources/tests/common/mod.rs
@@ -105,6 +105,7 @@ pub fn convoy_status(phase: flotilla_resources::ConvoyPhase) -> RealConvoyStatus
         finished_at: None,
         observed_workflow_ref: None,
         observed_workflows: None,
+        disposition: None,
         target_mismatches: Vec::new(),
     }
 }
@@ -294,7 +295,8 @@ pub fn tool_only_workflow_template_object(name: &str) -> ResourceObject<Workflow
 }
 
 pub fn bootstrapped_convoy_status() -> RealConvoyStatus {
-    let snapshot = flotilla_resources::WorkflowSnapshot { vessels: valid_workflow_template_spec().vessels.into_iter().collect() };
+    let snapshot =
+        flotilla_resources::WorkflowSnapshot { exit: None, vessels: valid_workflow_template_spec().vessels.into_iter().collect() };
     let work = [("implement".to_string(), pending_task_state()), ("review".to_string(), pending_task_state())].into_iter().collect();
     let crew_work = BTreeMap::from([
         ("implement".to_string(), BTreeMap::from([("coder".to_string(), pending_crew_work_state())])),
@@ -312,6 +314,7 @@ pub fn bootstrapped_convoy_status() -> RealConvoyStatus {
         finished_at: None,
         observed_workflow_ref: Some("review-and-fix".to_string()),
         observed_workflows: Some([("review-and-fix".to_string(), "42".to_string())].into_iter().collect()),
+        disposition: None,
         target_mismatches: Vec::new(),
     }
 }
@@ -377,6 +380,7 @@ where
 
 pub fn bootstrapped_tool_only_convoy_status() -> RealConvoyStatus {
     let snapshot = flotilla_resources::WorkflowSnapshot {
+        exit: None,
         vessels: tool_only_workflow_template_spec()
             .vessels
             .into_iter()
@@ -405,6 +409,7 @@ pub fn bootstrapped_tool_only_convoy_status() -> RealConvoyStatus {
         finished_at: None,
         observed_workflow_ref: Some("review-and-fix".to_string()),
         observed_workflows: Some([("review-and-fix".to_string(), "42".to_string())].into_iter().collect()),
+        disposition: None,
         target_mismatches: Vec::new(),
     }
 }

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -345,7 +345,7 @@ fn bootstrap_from_valid_template_returns_bootstrap_patch() {
     let outcome = reconcile(&convoy, Some(&template), timestamp(10));
 
     let expected_snapshot = flotilla_resources::WorkflowSnapshot {
-        exit: Some(template.spec.effective_exit()),
+        exit: template.spec.exit.clone(),
         vessels: template
             .spec
             .vessels
@@ -650,6 +650,23 @@ fn reconciler_does_not_write_the_completion_claim_edge() {
     let outcome = reconcile(&convoy, None, timestamp(40));
 
     assert_eq!(outcome.patch, None);
+}
+
+#[test]
+fn landing_convoy_with_no_declared_exit_never_settles() {
+    let mut status = bootstrapped_convoy_status();
+    status.phase = ConvoyPhase::Landing;
+    status.workflow_snapshot.as_mut().expect("workflow snapshot").exit = None;
+    for work in status.work.values_mut() {
+        work.phase = WorkPhase::Complete;
+    }
+    mark_crew_done(&mut status, "implement", "coder");
+    mark_crew_done(&mut status, "review", "reviewer");
+    let convoy = convoy_object("standing", valid_convoy_spec(), Some(status));
+
+    let outcome = reconcile(&convoy, None, timestamp(40));
+
+    assert_eq!(outcome.patch, None, "an absent exit must not synthesize a Landed transition");
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -345,6 +345,7 @@ fn bootstrap_from_valid_template_returns_bootstrap_patch() {
     let outcome = reconcile(&convoy, Some(&template), timestamp(10));
 
     let expected_snapshot = flotilla_resources::WorkflowSnapshot {
+        exit: Some(template.spec.effective_exit()),
         vessels: template
             .spec
             .vessels
@@ -498,6 +499,7 @@ fn fan_out_advances_all_newly_ready_tasks() {
     let spec = valid_convoy_spec();
     let mut status = bootstrapped_convoy_status();
     status.workflow_snapshot = Some(flotilla_resources::WorkflowSnapshot {
+        exit: None,
         vessels: vec![
             flotilla_resources::VesselRequirement {
                 name: "a".to_string(),
@@ -550,6 +552,7 @@ fn fan_out_advances_all_newly_ready_tasks() {
 fn fan_in_waits_until_all_dependencies_complete() {
     let mut status = bootstrapped_convoy_status();
     status.workflow_snapshot = Some(flotilla_resources::WorkflowSnapshot {
+        exit: None,
         vessels: vec![
             flotilla_resources::VesselRequirement {
                 name: "implement".to_string(),
@@ -665,7 +668,7 @@ async fn landing_with_settled_change_request_becomes_landed() {
     let outcome =
         reconcile_with_observed_change_request(ConvoyPhase::Landing, Some(ConditionValue::True), Some("main"), timestamp(40)).await;
 
-    assert_eq!(outcome.patch, Some(controller_patches::settle(Vec::new(), timestamp(40))));
+    assert_eq!(outcome.patch, Some(controller_patches::settle("merged".to_string(), Vec::new(), timestamp(40))));
 }
 
 #[tokio::test]
@@ -679,7 +682,7 @@ async fn landing_on_a_different_target_records_a_fact_and_still_becomes_landed()
         .declared_target_ref("main".to_string())
         .observed_target_ref("release".to_string())
         .build();
-    assert_eq!(outcome.patch, Some(controller_patches::settle(vec![expected_mismatch.clone()], timestamp(40))));
+    assert_eq!(outcome.patch, Some(controller_patches::settle("merged".to_string(), vec![expected_mismatch.clone()], timestamp(40))));
     let mut status = ConvoyStatus { phase: ConvoyPhase::Landing, ..Default::default() };
     outcome.patch.expect("settlement patch").apply(&mut status);
     assert_eq!(status.phase, ConvoyPhase::Landed);
@@ -807,7 +810,7 @@ async fn terminal_bound_change_request_settles_checkout_without_own_landed_evide
     let deps = reconciler.fetch_dependencies(&current).await.expect("dependencies");
     let outcome = reconciler.reconcile(&current, &deps, timestamp(40));
 
-    assert_eq!(outcome.patch, Some(controller_patches::settle(Vec::new(), timestamp(40))));
+    assert_eq!(outcome.patch, Some(controller_patches::settle("merged".to_string(), Vec::new(), timestamp(40))));
 }
 
 #[tokio::test]
@@ -946,6 +949,7 @@ fn advancing_ready_tasks_emits_task_phase_change_events() {
     let spec = valid_convoy_spec();
     let mut status = bootstrapped_convoy_status();
     status.workflow_snapshot = Some(flotilla_resources::WorkflowSnapshot {
+        exit: None,
         vessels: vec![
             flotilla_resources::VesselRequirement {
                 name: "a".to_string(),
@@ -1114,7 +1118,7 @@ fn all_agent_crew_done_rolls_vessel_work_complete() {
 fn interactive_convoy_stays_active_until_crew_reports_complete() {
     let mut status = bootstrapped_convoy_status();
     status.phase = ConvoyPhase::Active;
-    status.workflow_snapshot = Some(WorkflowSnapshot { vessels: interactive_single_workflow_spec().vessels });
+    status.workflow_snapshot = Some(WorkflowSnapshot { exit: None, vessels: interactive_single_workflow_spec().vessels });
     let mut work = status.work.remove("implement").expect("seed work");
     work.phase = WorkPhase::Running;
     status.work = BTreeMap::from([("work".to_string(), work)]);

--- a/crates/flotilla-resources/tests/convoy_status_patch.rs
+++ b/crates/flotilla-resources/tests/convoy_status_patch.rs
@@ -14,6 +14,7 @@ fn ts(seconds: i64) -> chrono::DateTime<Utc> {
 
 fn sample_snapshot() -> WorkflowSnapshot {
     WorkflowSnapshot {
+        exit: None,
         vessels: vec![
             VesselRequirement {
                 name: "implement".to_string(),
@@ -117,6 +118,7 @@ fn abandon_convoy_stamps_convoy_and_open_work() {
         finished_at: None,
         observed_workflow_ref: Some("review-and-fix".to_string()),
         observed_workflows: Some(BTreeMap::new()),
+        disposition: None,
         target_mismatches: Vec::new(),
     };
 
@@ -160,6 +162,7 @@ fn crew_completion_updates_only_the_calling_agent() {
         finished_at: None,
         observed_workflow_ref: Some("review-and-fix".to_string()),
         observed_workflows: Some(BTreeMap::new()),
+        disposition: None,
         target_mismatches: Vec::new(),
     };
 
@@ -204,6 +207,7 @@ fn final_crew_completion_claim_enters_landing_idempotently() {
         finished_at: None,
         observed_workflow_ref: Some("review-and-fix".to_string()),
         observed_workflows: Some(BTreeMap::new()),
+        disposition: None,
         target_mismatches: Vec::new(),
     };
 
@@ -229,6 +233,7 @@ fn crew_failure_records_terminal_state_and_message() {
         finished_at: None,
         observed_workflow_ref: Some("review-and-fix".to_string()),
         observed_workflows: Some(BTreeMap::new()),
+        disposition: None,
         target_mismatches: Vec::new(),
     };
 
@@ -270,6 +275,7 @@ fn handoff_to_done_crew_reopens_target_and_marks_sender_handed_back() {
         finished_at: Some(ts(16)),
         observed_workflow_ref: Some("review-and-fix".to_string()),
         observed_workflows: Some(BTreeMap::new()),
+        disposition: None,
         target_mismatches: Vec::new(),
     };
 
@@ -314,6 +320,7 @@ fn resume_reopens_completed_crew_without_restarting_its_timeline() {
         finished_at: Some(ts(16)),
         observed_workflow_ref: Some("single-agent-contained".to_string()),
         observed_workflows: Some(BTreeMap::new()),
+        disposition: None,
         target_mismatches: Vec::new(),
     };
 
@@ -352,6 +359,7 @@ fn running_vessel_work_starts_pending_agents_without_reopening_done_agents() {
         finished_at: None,
         observed_workflow_ref: Some("review-and-fix".to_string()),
         observed_workflows: Some(BTreeMap::new()),
+        disposition: None,
         target_mismatches: Vec::new(),
     };
 
@@ -391,6 +399,7 @@ fn running_vessel_work_leaves_latent_agents_pending() {
         finished_at: None,
         observed_workflow_ref: Some("review-and-fix".to_string()),
         observed_workflows: Some(BTreeMap::new()),
+        disposition: None,
         target_mismatches: Vec::new(),
     };
 
@@ -458,6 +467,7 @@ fn advance_work_to_ready_updates_only_selected_vessels() {
         finished_at: None,
         observed_workflow_ref: Some("review-and-fix".to_string()),
         observed_workflows: Some(BTreeMap::from([("review-and-fix".to_string(), "42".to_string())])),
+        disposition: None,
         target_mismatches: Vec::new(),
     };
 
@@ -502,6 +512,7 @@ fn fail_convoy_cancels_non_terminal_siblings_and_sets_convoy_failed() {
         finished_at: None,
         observed_workflow_ref: Some("review-and-fix".to_string()),
         observed_workflows: Some(BTreeMap::from([("review-and-fix".to_string(), "42".to_string())])),
+        disposition: None,
         target_mismatches: Vec::new(),
     };
 
@@ -538,6 +549,7 @@ fn roll_up_phase_only_touches_convoy_level_fields() {
         finished_at: None,
         observed_workflow_ref: Some("review-and-fix".to_string()),
         observed_workflows: Some(BTreeMap::from([("review-and-fix".to_string(), "42".to_string())])),
+        disposition: None,
         target_mismatches: Vec::new(),
     };
 
@@ -571,6 +583,7 @@ fn forced_work_completion_claim_enters_landing() {
         finished_at: None,
         observed_workflow_ref: Some("review-and-fix".to_string()),
         observed_workflows: Some(BTreeMap::from([("review-and-fix".to_string(), "42".to_string())])),
+        disposition: None,
         target_mismatches: Vec::new(),
     };
 
@@ -612,6 +625,7 @@ fn forced_work_completion_preserves_agent_owned_state() {
         finished_at: None,
         observed_workflow_ref: Some("review-and-fix".to_string()),
         observed_workflows: Some(BTreeMap::new()),
+        disposition: None,
         target_mismatches: Vec::new(),
     };
 
@@ -637,6 +651,7 @@ fn convoy_lifecycle_timestamps_are_set_once_per_transition() {
         finished_at: None,
         observed_workflow_ref: Some("review-and-fix".to_string()),
         observed_workflows: Some(BTreeMap::new()),
+        disposition: None,
         target_mismatches: Vec::new(),
     };
 

--- a/crates/flotilla-resources/tests/lifecycle_status_patch.rs
+++ b/crates/flotilla-resources/tests/lifecycle_status_patch.rs
@@ -206,6 +206,7 @@ fn active_convoy_status() -> ConvoyStatus {
         message: None,
         started_at: Some(ts(10)),
         finished_at: None,
+        disposition: None,
         observed_workflow_ref: None,
         observed_workflows: None,
         target_mismatches: Vec::new(),
@@ -284,7 +285,7 @@ fn duplicate_lifecycle_transitions_do_not_restamp_timestamps() {
                 let mut status = active_convoy_status();
                 let before = convoy_timestamps(&status);
                 let patch = ConvoyStatusPatch::Bootstrap {
-                    workflow_snapshot: WorkflowSnapshot { vessels: Vec::new() },
+                    workflow_snapshot: WorkflowSnapshot { exit: None, vessels: Vec::new() },
                     observed_workflow_ref: "workflow-a".to_string(),
                     observed_workflows: BTreeMap::new(),
                     work: status.work.clone(),
@@ -403,7 +404,8 @@ fn duplicate_lifecycle_transitions_do_not_restamp_timestamps() {
             exercise: || {
                 let mut status = settled_convoy_status();
                 let before = convoy_timestamps(&status);
-                let patch = ConvoyStatusPatch::Settle { target_mismatches: Vec::new(), finished_at: ts(30) };
+                let patch =
+                    ConvoyStatusPatch::Settle { disposition: "merged".to_string(), target_mismatches: Vec::new(), finished_at: ts(30) };
                 apply_and_replay(&mut status, &patch);
                 (before, convoy_timestamps(&status))
             },
@@ -842,7 +844,8 @@ fn settling_again_after_a_continuation_records_the_new_outcome_time() {
                 let mut status = settled_convoy_status();
                 status.phase = ConvoyPhase::Failed;
                 let before = convoy_timestamps(&status);
-                let patch = ConvoyStatusPatch::Settle { target_mismatches: Vec::new(), finished_at: ts(30) };
+                let patch =
+                    ConvoyStatusPatch::Settle { disposition: "merged".to_string(), target_mismatches: Vec::new(), finished_at: ts(30) };
                 apply_and_replay(&mut status, &patch);
                 (before, convoy_timestamps(&status))
             },

--- a/crates/flotilla-resources/tests/workflow_template_validation.rs
+++ b/crates/flotilla-resources/tests/workflow_template_validation.rs
@@ -2,7 +2,9 @@ mod common;
 
 use common::{valid_workflow_template_spec, valid_workflow_template_yaml};
 use flotilla_resources::{
-    validate, InterpolationField, InterpolationLocation, RepositoryKey, Stance, ValidationError, WorkflowTemplateSpec,
+    implement_review_workflow_spec, interactive_single_workflow_spec, single_agent_contained_workflow_spec,
+    single_agent_shepherd_workflow_spec, single_agent_trusted_workflow_spec, validate, ExitDeclaration, InterpolationField,
+    InterpolationLocation, RepositoryKey, Stance, ValidationError, WorkflowTemplateSpec,
 };
 use serde::Deserialize;
 
@@ -42,7 +44,8 @@ vessels:
           capability: code
 "#,
     );
-    assert_eq!(declared.effective_exit(), undeclared.effective_exit(), "transcribed and implicit defaults must behave identically");
+    assert!(declared.exit.is_some(), "transcribed table must remain declared");
+    assert!(undeclared.exit.is_none(), "an undeclared template must have no exit");
 
     let serialized = serde_yml::to_string(&declared).expect("serialize workflow template spec");
     let merged = serialized.find("merged: $cr.state == merged").expect("merged exit entry");
@@ -65,6 +68,20 @@ vessels:
 
     let serialized = serde_yml::to_string(&parse_spec(yaml)).expect("serialize workflow template spec");
     assert!(serialized.contains("exit: claim"), "claim exit should remain declarable: {serialized}");
+}
+
+#[test]
+fn stock_workflows_transcribe_the_standard_exit_table() {
+    let expected = Some(ExitDeclaration::standard_table());
+    for spec in [
+        single_agent_contained_workflow_spec(),
+        single_agent_shepherd_workflow_spec(),
+        single_agent_trusted_workflow_spec(),
+        interactive_single_workflow_spec(),
+        implement_review_workflow_spec(),
+    ] {
+        assert_eq!(spec.exit, expected);
+    }
 }
 
 #[test]

--- a/crates/flotilla-resources/tests/workflow_template_validation.rs
+++ b/crates/flotilla-resources/tests/workflow_template_validation.rs
@@ -15,6 +15,88 @@ fn parse_spec(yaml: &str) -> WorkflowTemplateSpec {
     serde_yml::from_str(yaml).expect("parse workflow template spec")
 }
 
+#[test]
+fn exit_table_roundtrips_declared_entries_in_order() {
+    let yaml = r#"
+inputs: []
+exit:
+  merged: $cr.state == merged
+  closed-unmerged: $cr.state == closed
+vessels:
+  - name: implement
+    crew:
+      - role: coder
+        selector:
+          capability: code
+"#;
+
+    let declared = parse_spec(yaml);
+    let undeclared = parse_spec(
+        r#"
+inputs: []
+vessels:
+  - name: implement
+    crew:
+      - role: coder
+        selector:
+          capability: code
+"#,
+    );
+    assert_eq!(declared.effective_exit(), undeclared.effective_exit(), "transcribed and implicit defaults must behave identically");
+
+    let serialized = serde_yml::to_string(&declared).expect("serialize workflow template spec");
+    let merged = serialized.find("merged: $cr.state == merged").expect("merged exit entry");
+    let closed = serialized.find("closed-unmerged: $cr.state == closed").expect("closed exit entry");
+    assert!(merged < closed, "exit entry declaration order should be preserved: {serialized}");
+}
+
+#[test]
+fn claim_exit_roundtrips_as_claim() {
+    let yaml = r#"
+inputs: []
+exit: claim
+vessels:
+  - name: implement
+    crew:
+      - role: coder
+        selector:
+          capability: code
+"#;
+
+    let serialized = serde_yml::to_string(&parse_spec(yaml)).expect("serialize workflow template spec");
+    assert!(serialized.contains("exit: claim"), "claim exit should remain declarable: {serialized}");
+}
+
+#[test]
+fn exit_schema_rejects_branching_and_sequencing_constructs() {
+    for exit in ["exit:\n  sequence:\n    - $cr.state == merged", "exit:\n  merged:\n    then: $cr.state == closed"] {
+        let yaml =
+            format!("inputs: []\n{exit}\nvessels:\n  - name: implement\n    crew:\n      - role: coder\n        command: cargo test\n");
+        assert!(serde_yml::from_str::<WorkflowTemplateSpec>(&yaml).is_err(), "schema extension should be rejected: {yaml}");
+    }
+}
+
+#[test]
+fn validate_rejects_non_terminal_exit_leaf() {
+    let spec = parse_spec(
+        r#"
+inputs: []
+exit:
+  still-working: $cr.state == open
+vessels:
+  - name: implement
+    crew:
+      - role: coder
+        command: cargo test
+"#,
+    );
+
+    let errors = validate(&spec).expect_err("open is not a world terminal");
+    assert!(errors
+        .iter()
+        .any(|error| matches!(error, ValidationError::InvalidExitLeaf { disposition, .. } if disposition == "still-working")));
+}
+
 fn assert_has_error(errors: &[ValidationError], expected: &ValidationError) {
     assert!(errors.contains(expected), "missing expected error {expected:?} in {errors:?}");
 }

--- a/crates/flotilla-tui/src/app/tests.rs
+++ b/crates/flotilla-tui/src/app/tests.rs
@@ -1769,6 +1769,7 @@ fn wire_convoy_row(convoy: crate::convoy_model::ConvoySummary) -> flotilla_proto
         .phase(wire_convoy_phase(convoy.phase))
         .initializing(convoy.initializing)
         .maybe_message(convoy.message)
+        .maybe_disposition(convoy.disposition)
         .maybe_repo(convoy.repo_hint)
         .maybe_project_ref(convoy.project_ref)
         .maybe_change_request(convoy.change_request)
@@ -1883,6 +1884,7 @@ fn test_convoy(
         dispatching_principal_ref: Default::default(),
         phase,
         message: None,
+        disposition: None,
         repo_hint: None,
         project_ref: None,
         issues: Vec::new(),

--- a/crates/flotilla-tui/src/convoy_model.rs
+++ b/crates/flotilla-tui/src/convoy_model.rs
@@ -170,6 +170,7 @@ pub struct ConvoySummary {
     pub phase: ConvoyPhase,
     pub placement_decision: Option<PlacementDecision>,
     pub message: Option<String>,
+    pub disposition: Option<String>,
     pub repo_hint: Option<RepoKey>,
     /// The Project this convoy belongs to (`ConvoySpec.project_ref`).
     pub project_ref: Option<String>,
@@ -197,6 +198,7 @@ impl From<&wire::ConvoyRow> for ConvoySummary {
             phase: row.phase.into(),
             placement_decision: row.placement_decision.clone(),
             message: row.message.clone(),
+            disposition: row.disposition.clone(),
             repo_hint: row.repo.clone(),
             project_ref: row.project_ref.clone(),
             issues: row.issues.clone(),

--- a/crates/flotilla-tui/src/palette.rs
+++ b/crates/flotilla-tui/src/palette.rs
@@ -815,6 +815,7 @@ mod tests {
             dispatching_principal_ref: Default::default(),
             phase: ConvoyPhase::Active,
             message: None,
+            disposition: None,
             repo_hint: None,
             project_ref: None,
             issues: Vec::new(),

--- a/crates/flotilla-tui/src/table_view.rs
+++ b/crates/flotilla-tui/src/table_view.rs
@@ -1087,7 +1087,11 @@ fn convoy_phase(row: &ConvoySummary) -> CellValue {
         ConvoyPhase::Cancelled => CellTone::Muted,
         ConvoyPhase::Abandoned => CellTone::Muted,
     };
-    CellValue::toned(row.phase.label(), tone)
+    let label = match (row.phase, row.disposition.as_deref()) {
+        (ConvoyPhase::Landed, Some(disposition)) => format!("landed · {disposition}"),
+        _ => row.phase.label().to_string(),
+    };
+    CellValue::toned(label, tone)
 }
 
 fn convoy_progress(row: &ConvoySummary) -> CellValue {
@@ -1427,6 +1431,7 @@ mod tests {
             dispatching_principal_ref: Default::default(),
             phase: ConvoyPhase::Active,
             message: None,
+            disposition: None,
             repo_hint: None,
             project_ref: Some("flotilla".into()),
             issues: Vec::new(),
@@ -1509,6 +1514,7 @@ mod tests {
     fn terminal_convoy_phases_have_distinct_row_tones() {
         let mut completed = convoy(vec![]);
         completed.phase = ConvoyPhase::Landed;
+        completed.disposition = Some("shipped".to_string());
         let mut failed = convoy(vec![]);
         failed.id = ConvoyId::new("dev", "failed");
         failed.name = "failed".into();
@@ -1516,7 +1522,7 @@ mod tests {
 
         let view = project_convoys("convoys/dev", &[&completed, &failed]).expect("convoy table");
 
-        assert_eq!(view.rows[0].cells[2], CellValue::toned("landed", CellTone::Success));
+        assert_eq!(view.rows[0].cells[2], CellValue::toned("landed · shipped", CellTone::Success));
         assert_eq!(view.rows[1].cells[2], CellValue::toned("failed", CellTone::Error));
     }
 

--- a/crates/flotilla-tui/tests/convoy_view_e2e.rs
+++ b/crates/flotilla-tui/tests/convoy_view_e2e.rs
@@ -183,6 +183,7 @@ async fn generated_table_action_completes_work() {
         placement: None,
     });
     let snapshot = WorkflowSnapshot {
+        exit: None,
         vessels: vec![VesselRequirement {
             name: "implement".into(),
             stance: Default::default(),

--- a/docs/adr/0028-world-terminal-exits-and-the-vessel-as-cache.md
+++ b/docs/adr/0028-world-terminal-exits-and-the-vessel-as-cache.md
@@ -61,10 +61,11 @@ What may **not** appear in the table, and where it goes instead:
 
 `exit: claim` remains **declarable** for artifact-less work (probes,
 instruction-only convoys with nothing observable). The pre-0021 conflation
-thereby becomes an explicit degenerate case one opts into. Migration reading:
-every current workflow implicitly declares the hardwired "no change request
-outstanding" condition as its table; flipping that to a declared table is the
-migration, and the hardwired condition is its default value.
+thereby becomes an explicit degenerate case one opts into. An undeclared exit
+means there is no `Landing` → `Landed` transition: the convoy is a standing
+facility until an operator explicitly reaps it. Migration reading: every
+current stock workflow declares the former hardwired "no change request
+outstanding" condition as an explicit table; there is no magic default.
 
 Consequence for the operator surface: **stuck = `Landing` + escalation
 raised** (or past the staleness threshold) — cleanly distinguished from a
@@ -167,7 +168,7 @@ attention flag; `Landed` rows show their disposition name.
 
 | Ruling | What it said | What stands now |
 |--------|--------------|-----------------|
-| ADR 0021 (Landing→Landed writer) | The reconciler evaluates the hardwired "no change request outstanding" condition | Workflow-declared exit tables of world terminals; the hardwired condition is the implicit default table, and `exit: claim` is a declarable degenerate case |
+| ADR 0021 (Landing→Landed writer) | The reconciler evaluates the hardwired "no change request outstanding" condition | Workflow-declared exit tables of world terminals; stock workflows transcribe the former condition explicitly, an undeclared exit makes `Landed` unreachable, and `exit: claim` is a declarable degenerate case |
 | ADR 0021 (vessel warmth) | "The vessel stays warm" during Landing | The vessel is a cache; warmth is the shallowest park depth of a declared spectrum |
 | ADR 0021 (Anchored wiring) | Entry/exit wiring deferred to a shared event-source design | That design is the leaf engine (#1322); Anchored and Landing subscribe to the same table |
 | ADR 0027 (dispositions) | Declared per-brief, recorded on the claim | Unchanged at brief scope; exit tables reuse the same vocabulary at convoy scope, bound to world-terminal leaves |

--- a/prototypes/1262-scenarios/builtin-implement-review.yaml
+++ b/prototypes/1262-scenarios/builtin-implement-review.yaml
@@ -8,6 +8,9 @@ metadata:
   labels:
     flotilla.work/managed-by: builtin
 spec:
+  exit:
+    merged: $cr.state == merged
+    closed-unmerged: $cr.state == closed
   vessels:
     - name: work
       stance: contained

--- a/prototypes/1262-scenarios/builtin-single-agent-shepherd.yaml
+++ b/prototypes/1262-scenarios/builtin-single-agent-shepherd.yaml
@@ -8,6 +8,9 @@ metadata:
   labels:
     flotilla.work/managed-by: builtin
 spec:
+  exit:
+    merged: $cr.state == merged
+    closed-unmerged: $cr.state == closed
   vessels:
     - name: work
       stance: trusted

--- a/prototypes/1262-scenarios/builtin-single-agent-trusted.yaml
+++ b/prototypes/1262-scenarios/builtin-single-agent-trusted.yaml
@@ -8,6 +8,9 @@ metadata:
   labels:
     flotilla.work/managed-by: builtin
 spec:
+  exit:
+    merged: $cr.state == merged
+    closed-unmerged: $cr.state == closed
   vessels:
     - name: work
       stance: trusted

--- a/prototypes/1262-scenarios/pr-adoption-turn.yaml
+++ b/prototypes/1262-scenarios/pr-adoption-turn.yaml
@@ -7,6 +7,9 @@ metadata:
   name: pr-adoption-turn
   namespace: flotilla
 spec:
+  exit:
+    merged: $cr.state == merged
+    closed-unmerged: $cr.state == closed
   vessels:
     - name: work
       stance: trusted

--- a/prototypes/1262-scenarios/rebase-on-conflict.yaml
+++ b/prototypes/1262-scenarios/rebase-on-conflict.yaml
@@ -6,6 +6,9 @@ metadata:
   name: rebase-on-conflict
   namespace: flotilla
 spec:
+  exit:
+    merged: $cr.state == merged
+    closed-unmerged: $cr.state == closed
   vessels:
     - name: work
       stance: contained

--- a/prototypes/1262-scenarios/review-round-trip.yaml
+++ b/prototypes/1262-scenarios/review-round-trip.yaml
@@ -6,6 +6,9 @@ metadata:
   name: review-round-trip
   namespace: flotilla
 spec:
+  exit:
+    merged: $cr.state == merged
+    closed-unmerged: $cr.state == closed
   vessels:
     - name: work
       stance: trusted


### PR DESCRIPTION
Closes #1391.

## Summary

- add ordered workflow `exit` declarations over the v1 `$cr` subject variable, including `exit: claim`; an undeclared template now has no exit and cannot reach Landed
- pin and instantiate declared exit tables at convoy binding, settle through the leaf engine, and record the declared disposition on Landed
- explicitly transcribe the former merged/closed behavior into every built-in and shipped workflow template
- project dispositions into fleet rows and render them on Landed TUI rows
- cover declared-table behavior, custom names, adopt-late binding, zero-CR claim exit, undeclared standing-convoy reaping, and schema-extension rejection

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
