### PR TITLE
fix: redrive failed clones on new demand

### DIFF
--- a/crates/flotilla-controllers/src/actuators/mod.rs
+++ b/crates/flotilla-controllers/src/actuators/mod.rs
@@ -9,27 +9,11 @@ use flotilla_core::{
             CONTAINED_DAEMON_REQUIRED_ENV,
         },
         terminal::TerminalPool,
-        vcs::{CloneInspection, CloneProvisioner},
     },
 };
 use flotilla_resources::{
     DockerEnvironmentSpec, EnvironmentMount, EnvironmentMountMode, FreshCloneCheckoutSpec, TerminalSessionSource, TerminalSessionSpec,
 };
-
-pub struct CloneActuator {
-    provisioner: Arc<dyn CloneProvisioner>,
-}
-
-impl CloneActuator {
-    pub fn new(provisioner: Arc<dyn CloneProvisioner>) -> Self {
-        Self { provisioner }
-    }
-
-    pub async fn clone_and_inspect(&self, repo_url: &str, target_path: &ExecutionEnvironmentPath) -> Result<CloneInspection, String> {
-        self.provisioner.clone_repo(repo_url, target_path).await?;
-        self.provisioner.inspect_clone(target_path).await
-    }
-}
 
 pub struct DockerEnvironmentActuator {
     daemon_socket_path: DaemonHostPath,

--- a/crates/flotilla-controllers/src/reconcilers/checkout.rs
+++ b/crates/flotilla-controllers/src/reconcilers/checkout.rs
@@ -6,7 +6,7 @@ use flotilla_core::checkout_integration::{
     checkout_observation_lacks_convoy_association, convoy_change_request_id_for_checkout, LANDING_EVIDENCE_TTL,
 };
 use flotilla_resources::{
-    controller::{ReconcileOutcome, Reconciler, ReplicaConvoyCheckoutWatch, SecondaryWatch},
+    controller::{Actuation, ReconcileOutcome, Reconciler, ReplicaConvoyCheckoutWatch, SecondaryWatch},
     Checkout, CheckoutBranchProvenance, CheckoutIntegrationStatus, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutStatusPatch, Clock,
     Clone, ClonePhase, Convoy, ConvoyPhase, IntegrationCondition, ReplicaReadResolver, ResourceBackend, ResourceError, ResourceObject,
     ResourceProvenance, SystemClock, TypedResolver, ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL,
@@ -154,6 +154,7 @@ pub enum CheckoutDeps {
     None,
     Ready { prepared: PreparedCheckout },
     Integration { status: Box<CheckoutIntegrationStatus> },
+    RetryClone { clone_name: String, failed_at: DateTime<Utc> },
     Waiting,
     Failed(String),
 }
@@ -218,6 +219,22 @@ where
                     Err(ResourceError::NotFound { .. }) => return Ok(CheckoutDeps::Waiting),
                     Err(err) => return Err(err),
                 };
+                if clone.status.as_ref().map(|status| status.phase) == Some(ClonePhase::Failed) {
+                    let failed_at = clone.status.as_ref().and_then(|status| status.failed_at).unwrap_or(clone.metadata.creation_timestamp);
+                    if failed_at <= obj.metadata.creation_timestamp {
+                        return Ok(CheckoutDeps::RetryClone { clone_name: clone.metadata.name, failed_at });
+                    }
+                    let detail = clone
+                        .status
+                        .as_ref()
+                        .and_then(|status| status.message.as_deref())
+                        .map_or(String::new(), |message| format!(": {message}"));
+                    return Ok(CheckoutDeps::Failed(format!(
+                        "clone {} is Failed since {}{detail}",
+                        clone.metadata.name,
+                        failed_at.to_rfc3339()
+                    )));
+                }
                 if clone.status.as_ref().map(|status| status.phase) != Some(ClonePhase::Ready) {
                     return Ok(CheckoutDeps::Waiting);
                 }
@@ -255,6 +272,7 @@ where
                     branch_provenance: prepared.branch_provenance,
                 }),
                 CheckoutDeps::Integration { .. } => None,
+                CheckoutDeps::RetryClone { .. } => None,
                 CheckoutDeps::Failed(message) => Some(CheckoutStatusPatch::MarkFailed { message: message.clone() }),
                 CheckoutDeps::Waiting | CheckoutDeps::None => None,
             }
@@ -284,13 +302,19 @@ where
                         change_request: None,
                     }),
                 }),
-                CheckoutDeps::None | CheckoutDeps::Ready { .. } | CheckoutDeps::Waiting => None,
+                CheckoutDeps::None | CheckoutDeps::Ready { .. } | CheckoutDeps::RetryClone { .. } | CheckoutDeps::Waiting => None,
             }
         } else {
             None
         };
 
-        let mut outcome = ReconcileOutcome::new(patch);
+        let actuations = match deps {
+            CheckoutDeps::RetryClone { clone_name, failed_at } => {
+                vec![Actuation::RetryClone { name: clone_name.clone(), failed_at: *failed_at }]
+            }
+            _ => Vec::new(),
+        };
+        let mut outcome = ReconcileOutcome::with_actuations(patch, actuations);
         if obj.status.as_ref().map(|status| status.phase).unwrap_or(CheckoutPhase::Pending) == CheckoutPhase::Pending
             && !matches!(deps, CheckoutDeps::Failed(_))
         {

--- a/crates/flotilla-controllers/src/reconcilers/clone.rs
+++ b/crates/flotilla-controllers/src/reconcilers/clone.rs
@@ -78,14 +78,14 @@ where
         &self,
         obj: &ResourceObject<Self::Resource>,
         deps: &Self::Dependencies,
-        _now: chrono::DateTime<chrono::Utc>,
+        now: chrono::DateTime<chrono::Utc>,
     ) -> ReconcileOutcome<Self::Resource> {
         let phase = obj.status.as_ref().map(|status| status.phase).unwrap_or(ClonePhase::Pending);
         let patch = if matches!(phase, ClonePhase::Pending | ClonePhase::Cloning) {
             match deps {
                 CloneDeps::Ready { default_branch } => Some(CloneStatusPatch::MarkReady { default_branch: default_branch.clone() }),
                 CloneDeps::Retrying(message) => Some(CloneStatusPatch::MarkRetrying { message: message.clone() }),
-                CloneDeps::Failed(message) => Some(CloneStatusPatch::MarkFailed { message: message.clone() }),
+                CloneDeps::Failed(message) => Some(CloneStatusPatch::MarkFailed { message: message.clone(), failed_at: now }),
                 CloneDeps::None => None,
             }
         } else {

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -15,8 +15,8 @@ use flotilla_resources::{
     controller::{
         delete_lifecycle_owned_matching, Actuation, LabelJoinWatch, LabelMappedWatch, ReconcileOutcome, Reconciler, SecondaryWatch,
     },
-    repository_workspace_slugs, Checkout, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, Convoy,
-    CrewSource, CrewWorkPhase, DockerCheckoutStrategy, DockerEnvironmentSpec, DockerImagePullPolicy, Environment, EnvironmentMount,
+    repository_workspace_slugs, Checkout, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, CloneSpec, Convoy, CrewSource,
+    CrewWorkPhase, DockerCheckoutStrategy, DockerEnvironmentSpec, DockerImagePullPolicy, Environment, EnvironmentMount,
     EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec, EnvironmentWaitReason, FreshCloneCheckoutSpec,
     HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta, LifecycleAuthority, OwnerReference, PlacementPolicy,
     PlacementPolicySpec, ReplicaReadResolver, Repository, RepositoryIdentity, RepositoryKey, RepositorySpec, Resource, ResourceBackend,
@@ -515,14 +515,6 @@ impl Reconciler for VesselReconciler {
                     Ok(existing) => {
                         if existing.spec.repo_ref != repository_key || existing.spec.env_ref != clone_env_ref {
                             return Ok(VesselDeps::failed(format!("clone {clone_name} does not match expected repo/env tuple")));
-                        }
-                        if existing.status.as_ref().map(|status| status.phase) == Some(ClonePhase::Failed) {
-                            let message = existing
-                                .status
-                                .as_ref()
-                                .and_then(|status| status.message.clone())
-                                .unwrap_or_else(|| format!("clone {clone_name} failed"));
-                            return Ok(VesselDeps::failed(message));
                         }
                     }
                     Err(ResourceError::NotFound { .. }) => {

--- a/crates/flotilla-controllers/tests/actuators.rs
+++ b/crates/flotilla-controllers/tests/actuators.rs
@@ -6,30 +6,12 @@ use flotilla_core::{
     providers::{
         environment::{CreateOpts, EnvironmentProvider, ImagePullPolicy, ProvisionedEnvironment, ProvisionedMount, ProvisionedMountMode},
         terminal::{TerminalEnvVars, TerminalPool, TerminalSession as PoolSession},
-        vcs::CloneProvisioner,
     },
 };
 use flotilla_protocol::{EnvironmentId, ImageId};
 use flotilla_resources::{
     DockerEnvironmentSpec, DockerImagePullPolicy, EnvironmentMount, EnvironmentMountMode, FreshCloneCheckoutSpec, TerminalSessionSpec,
 };
-
-#[derive(Default)]
-struct FakeCloneProvisioner;
-
-#[async_trait]
-impl CloneProvisioner for FakeCloneProvisioner {
-    async fn clone_repo(&self, _repo_url: &str, _target_path: &ExecutionEnvironmentPath) -> Result<(), String> {
-        Ok(())
-    }
-
-    async fn inspect_clone(
-        &self,
-        _target_path: &ExecutionEnvironmentPath,
-    ) -> Result<flotilla_core::providers::vcs::CloneInspection, String> {
-        Ok(flotilla_core::providers::vcs::CloneInspection { default_branch: Some("main".to_string()) })
-    }
-}
 
 #[derive(Default)]
 struct FakeEnvironmentProvider;
@@ -86,17 +68,6 @@ impl TerminalPool for FakeTerminalPool {
     async fn kill_session(&self, _session_name: &str) -> Result<(), String> {
         Ok(())
     }
-}
-
-#[tokio::test]
-async fn clone_actuator_returns_default_branch_from_provisioner() {
-    let actuator = flotilla_controllers::actuators::CloneActuator::new(Arc::new(FakeCloneProvisioner));
-    let outcome = actuator
-        .clone_and_inspect("git@github.com:flotilla-org/flotilla.git", &ExecutionEnvironmentPath::new("/tmp/flotilla"))
-        .await
-        .expect("clone should succeed");
-
-    assert_eq!(outcome.default_branch.as_deref(), Some("main"));
 }
 
 #[tokio::test]

--- a/crates/flotilla-controllers/tests/checkout_reconciler.rs
+++ b/crates/flotilla-controllers/tests/checkout_reconciler.rs
@@ -16,11 +16,12 @@ use flotilla_controllers::reconcilers::{
 };
 use flotilla_protocol::NodeId;
 use flotilla_resources::{
+    apply_status_patch,
     controller::{ControllerLoop, Reconciler},
-    repo_key, Checkout, CheckoutBranchProvenance, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutWorktreeSpec, ConditionValue,
-    Convoy, ConvoyPhase, ConvoySpec, ConvoyStatus, FreshCloneCheckoutSpec, InMemoryBackend, InputMeta, IntegrationCondition, RepositoryKey,
-    ResourceBackend, ResourceError, ResourceObject, StatusPatch, VirtualClock, ACTUATOR_SOURCE_ROOT_ANNOTATION, CHANGE_REQUEST_ID_LABEL,
-    CONVOY_LABEL,
+    repo_key, Checkout, CheckoutBranchProvenance, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutWorktreeSpec, Clone, CloneSpec,
+    CloneStatusPatch, ConditionValue, Convoy, ConvoyPhase, ConvoySpec, ConvoyStatus, FreshCloneCheckoutSpec, InMemoryBackend, InputMeta,
+    IntegrationCondition, RepositoryKey, ResourceBackend, ResourceError, ResourceObject, StatusPatch, VirtualClock,
+    ACTUATOR_SOURCE_ROOT_ANNOTATION, CHANGE_REQUEST_ID_LABEL, CONVOY_LABEL,
 };
 use tokio::time::timeout;
 
@@ -120,6 +121,50 @@ async fn finalizer_error_maps_to_failed_checkout_status() {
 
     assert_eq!(status.phase, CheckoutPhase::Failed);
     assert_eq!(status.message.as_deref(), Some("checkout teardown failed: remove worktree: permission denied"));
+}
+
+#[tokio::test]
+async fn clone_failure_from_the_current_checkout_attempt_is_reported_as_a_historical_dependency() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let clones = backend.clone().using::<Clone>(NAMESPACE);
+    clones
+        .create(&meta("clone-a"), &CloneSpec {
+            repo_ref: RepositoryKey(repo_key(REPO_URL)),
+            url: REPO_URL.to_string(),
+            env_ref: "host-direct-a".to_string(),
+            path: "/clones/repo".to_string(),
+        })
+        .await
+        .expect("clone should create");
+    let checkouts = backend.clone().using::<Checkout>(NAMESPACE);
+    let checkout = checkouts
+        .create(
+            &meta("checkout-a"),
+            &CheckoutSpec::Worktree(CheckoutWorktreeSpec {
+                repo_ref: RepositoryKey(repo_key(REPO_URL)),
+                env_ref: "host-direct-a".to_string(),
+                r#ref: "fix/clone-failed-latch".to_string(),
+                base_ref: Some("main".to_string()),
+                target_path: "/checkouts/repo.fix-clone-failed-latch".to_string(),
+                clone_ref: "clone-a".to_string(),
+            }),
+        )
+        .await
+        .expect("checkout should create");
+    let failed_at = checkout.metadata.creation_timestamp + chrono::Duration::seconds(1);
+    apply_status_patch(&clones, "clone-a", &CloneStatusPatch::MarkFailed { message: "authentication failed".to_string(), failed_at })
+        .await
+        .expect("clone failure should apply");
+    let reconciler = CheckoutReconciler::new(Arc::new(RecordingCheckoutRuntime::default()), backend, NAMESPACE);
+
+    let deps = reconciler.fetch_dependencies(&checkout).await.expect("dependencies should load");
+    let outcome = reconciler.reconcile(&checkout, &deps, failed_at);
+
+    assert!(matches!(
+        outcome.patch,
+        Some(flotilla_resources::CheckoutStatusPatch::MarkFailed { message })
+            if message == format!("clone clone-a is Failed since {}: authentication failed", failed_at.to_rfc3339())
+    ));
 }
 
 async fn create_deleting_checkout(backend: &ResourceBackend, name: &str, target_path: &str) {

--- a/crates/flotilla-controllers/tests/clone_reconciler.rs
+++ b/crates/flotilla-controllers/tests/clone_reconciler.rs
@@ -152,7 +152,7 @@ async fn clone_failure_retries_once_before_marking_failed() {
 
     assert!(matches!(
         repeated_outcome.patch,
-        Some(flotilla_resources::CloneStatusPatch::MarkFailed { message }) if message == "authentication failed"
+        Some(flotilla_resources::CloneStatusPatch::MarkFailed { message, .. }) if message == "authentication failed"
     ));
     assert!(repeated_outcome.requeue_after.is_none());
 }

--- a/crates/flotilla-controllers/tests/common/mod.rs
+++ b/crates/flotilla-controllers/tests/common/mod.rs
@@ -275,6 +275,7 @@ pub async fn create_ready_clone(
             phase: ClonePhase::Ready,
             default_branch: Some("main".to_string()),
             message: None,
+            failed_at: None,
         })
         .await
         .expect("clone status update should succeed");

--- a/crates/flotilla-controllers/tests/provisioning_in_memory.rs
+++ b/crates/flotilla-controllers/tests/provisioning_in_memory.rs
@@ -33,10 +33,10 @@ use flotilla_core::{
     HostName,
 };
 use flotilla_resources::{
-    canonicalize_repo_url, clone_key,
+    apply_status_patch, canonicalize_repo_url, clone_key,
     controller::{ControllerLoop, ReconcileOutcome, Reconciler},
-    Checkout, CheckoutBranchProvenance, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, Convoy,
-    ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec, DockerEnvironmentSpec, Environment, EnvironmentMount,
+    Checkout, CheckoutBranchProvenance, CheckoutPhase, CheckoutSpec, CheckoutWorktreeSpec, Clone, ClonePhase, CloneSpec, CloneStatusPatch,
+    Convoy, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CrewSource, CrewSpec, DockerEnvironmentSpec, Environment, EnvironmentMount,
     EnvironmentMountMode, EnvironmentPhase, EnvironmentSpec, Host, HostDirectEnvironmentSpec, HostSpec, HostStatus, Presentation,
     PresentationPhase, PresentationSpec, Repository, RepositorySpec, ResourceBackend, ResourceError, ResourceObject, Stance, StatusPatch,
     TerminalSession, TerminalSessionPhase, Vessel, VesselPhase, VesselRequirement, CONVOY_LABEL, CREW_ORDINAL_LABEL, VESSEL_ORDINAL_LABEL,
@@ -497,6 +497,89 @@ async fn clone_controller_marks_clone_ready() {
     let status = clone.status.expect("clone status should be present");
     assert_eq!(status.phase, flotilla_resources::ClonePhase::Ready);
     assert_eq!(status.default_branch.as_deref(), Some("main"));
+
+    harness.shutdown().await;
+}
+
+#[tokio::test]
+async fn new_checkout_demand_redrives_a_previously_failed_clone() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let repository_spec = RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository spec");
+    flotilla_resources::ensure_repository(&backend.clone().using::<Repository>(NAMESPACE), &repository_spec.key(), &repository_spec)
+        .await
+        .expect("repository create should succeed");
+    let clone_name = format!("clone-{}", clone_key("https://github.com/flotilla-org/flotilla", "host-direct-01HXYZ"));
+    let clones = backend.clone().using::<Clone>(NAMESPACE);
+    clones
+        .create(&controller_meta().name(&clone_name).call(), &CloneSpec {
+            repo_ref: repository_spec.key(),
+            url: "git@github.com:flotilla-org/flotilla.git".to_string(),
+            env_ref: "host-direct-01HXYZ".to_string(),
+            path: "/Users/alice/dev/flotilla".to_string(),
+        })
+        .await
+        .expect("clone create should succeed");
+    apply_status_patch(&clones, &clone_name, &CloneStatusPatch::MarkFailed {
+        message: "destination path already exists and is not an empty directory".to_string(),
+        failed_at: Utc::now() - chrono::Duration::minutes(5),
+    })
+    .await
+    .expect("clone failure should apply");
+
+    let checkouts = backend.clone().using::<Checkout>(NAMESPACE);
+    checkouts
+        .create(
+            &controller_meta().name("checkout-new-demand").call(),
+            &CheckoutSpec::Worktree(CheckoutWorktreeSpec {
+                repo_ref: repository_spec.key(),
+                env_ref: "host-direct-01HXYZ".to_string(),
+                r#ref: "fix/clone-failed-latch".to_string(),
+                base_ref: Some("main".to_string()),
+                target_path: "/Users/alice/dev/flotilla.fix-clone-failed-latch".to_string(),
+                clone_ref: clone_name.clone(),
+            }),
+        )
+        .await
+        .expect("checkout create should succeed");
+
+    let mut harness = ControllerLoopHarness::new(backend.clone());
+    harness.spawn(
+        ControllerLoop {
+            primary: clones.clone(),
+            secondaries: vec![],
+            reconciler: CloneReconciler::new(Arc::new(FakeCloneRuntime), backend.clone().using(NAMESPACE)),
+            resync_interval: Duration::from_secs(60),
+            backend: backend.clone(),
+        }
+        .run(),
+    );
+    harness.spawn(
+        ControllerLoop {
+            primary: checkouts.clone(),
+            secondaries: vec![],
+            reconciler: CheckoutReconciler::new(Arc::new(FakeCheckoutRuntime), backend.clone(), NAMESPACE),
+            resync_interval: Duration::from_secs(60),
+            backend,
+        }
+        .run(),
+    );
+
+    harness
+        .wait_until(Duration::from_secs(3), || {
+            let clones = clones.clone();
+            let checkouts = checkouts.clone();
+            let clone_name = clone_name.clone();
+            async move {
+                matches!(
+                    clones.get(&clone_name).await.ok().and_then(|clone| clone.status),
+                    Some(status) if status.phase == ClonePhase::Ready
+                ) && matches!(
+                    checkouts.get("checkout-new-demand").await.ok().and_then(|checkout| checkout.status),
+                    Some(status) if status.phase == CheckoutPhase::Ready
+                )
+            }
+        })
+        .await;
 
     harness.shutdown().await;
 }

--- a/crates/flotilla-controllers/tests/repository_reconciler.rs
+++ b/crates/flotilla-controllers/tests/repository_reconciler.rs
@@ -105,6 +105,7 @@ async fn repository_status_groups_typed_checkout_associations_by_explicit_host()
             phase: ClonePhase::Ready,
             default_branch: Some("main".to_string()),
             message: None,
+            failed_at: None,
         })
         .await
         .expect("clone status");

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -3323,6 +3323,30 @@ mod tests {
         assert_eq!(default_branch.as_deref(), Some("main"));
     }
 
+    #[tokio::test]
+    async fn clone_runtime_rejects_a_dirty_target_then_recovers_after_it_is_removed() {
+        let temp = TempDir::new().expect("tempdir");
+        let source = TestGitRepo::init(temp.path().join("source")).with_initial_commit();
+        let target = temp.path().join("clone");
+        fs::create_dir_all(&target).expect("dirty target directory");
+        fs::write(target.join("leftover"), "debris").expect("dirty target contents");
+        let runtime = CloneControllerRuntime { runner: Arc::new(ProcessCommandRunner), flights: Arc::new(CloneFlights::default()) };
+        let repo_url = source.path().to_str().expect("utf-8 source path");
+        let target_path = target.to_str().expect("utf-8 target path");
+
+        let error = runtime.clone_and_inspect(repo_url, target_path).await.expect_err("dirty target should not be overwritten");
+
+        assert!(error.contains("clone target") && error.contains("already exists"), "unexpected dirty-target error: {error}");
+        assert!(target.join("leftover").exists(), "dirty target must remain untouched");
+        assert!(!Path::new(&clone_staging_path(target_path)).exists(), "rejected target must not start a staged clone");
+
+        fs::remove_dir_all(&target).expect("remove transient obstruction");
+        let default_branch =
+            runtime.clone_and_inspect(repo_url, target_path).await.expect("clone should recover after obstruction removal");
+
+        assert_eq!(default_branch.as_deref(), Some("main"));
+    }
+
     struct TestInteriorEnvironmentProvider {
         handle: Mutex<Option<EnvironmentHandle>>,
     }

--- a/crates/flotilla-resources/src/clone.rs
+++ b/crates/flotilla-resources/src/clone.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::{resource::define_resource, status_patch::StatusPatch, RepositoryKey};
@@ -28,6 +29,8 @@ pub struct CloneStatus {
     pub default_branch: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failed_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -35,7 +38,7 @@ pub enum CloneStatusPatch {
     MarkCloning,
     MarkRetrying { message: String },
     MarkReady { default_branch: Option<String> },
-    MarkFailed { message: String },
+    MarkFailed { message: String, failed_at: DateTime<Utc> },
 }
 
 impl StatusPatch<CloneStatus> for CloneStatusPatch {
@@ -44,19 +47,23 @@ impl StatusPatch<CloneStatus> for CloneStatusPatch {
             Self::MarkCloning => {
                 status.phase = ClonePhase::Cloning;
                 status.message = None;
+                status.failed_at = None;
             }
             Self::MarkRetrying { message } => {
                 status.phase = ClonePhase::Cloning;
                 status.message = Some(message.clone());
+                status.failed_at = None;
             }
             Self::MarkReady { default_branch } => {
                 status.phase = ClonePhase::Ready;
                 status.default_branch = default_branch.clone();
                 status.message = None;
+                status.failed_at = None;
             }
-            Self::MarkFailed { message } => {
+            Self::MarkFailed { message, failed_at } => {
                 status.phase = ClonePhase::Failed;
                 status.message = Some(message.clone());
+                status.failed_at = Some(*failed_at);
             }
         }
     }

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -147,6 +147,7 @@ pub enum Actuation {
     CreateRepository { key: crate::RepositoryKey, spec: crate::RepositorySpec },
     CreateEnvironment { meta: InputMeta, spec: EnvironmentSpec },
     CreateClone { meta: InputMeta, spec: CloneSpec },
+    RetryClone { name: String, failed_at: DateTime<Utc> },
     CreateCheckout { meta: InputMeta, spec: CheckoutSpec },
     CreateTerminalSession { meta: InputMeta, spec: TerminalSessionSpec },
     RestartTerminalSession { name: String },
@@ -457,6 +458,20 @@ impl<R: Reconciler> ControllerLoop<R> {
             Actuation::CreateClone { meta, spec } => {
                 let resolver = backend.using::<crate::Clone>(namespace);
                 Self::create_if_missing(&resolver, meta, spec).await
+            }
+            Actuation::RetryClone { name, failed_at } => {
+                let resolver = backend.using::<crate::Clone>(namespace);
+                let clone = match resolver.get(&name).await {
+                    Ok(clone) => clone,
+                    Err(ResourceError::NotFound { .. }) => return Ok(()),
+                    Err(error) => return Err(error),
+                };
+                let current_failed_at =
+                    clone.status.as_ref().and_then(|status| status.failed_at).unwrap_or(clone.metadata.creation_timestamp);
+                if clone.status.as_ref().map(|status| status.phase) != Some(crate::ClonePhase::Failed) || current_failed_at != failed_at {
+                    return Ok(());
+                }
+                crate::apply_status_patch(&resolver, &name, &crate::CloneStatusPatch::MarkCloning).await.map(|_| ())
             }
             Actuation::CreateCheckout { meta, spec } => {
                 let resolver = backend.using::<crate::Checkout>(namespace);


### PR DESCRIPTION
## Summary

- redrive a shared Clone once when a newly-created worktree Checkout observes an older failure
- record the Clone failure timestamp and surface dependency failures as `clone <name> is Failed since <time>: <detail>`
- remove the unused direct-to-target Clone actuator, leaving the staged, adopting, single-flight daemon runtime as the only shared-clone route
- cover failed-clone recovery, current-attempt failure context, dirty targets, and concurrent clone flights

## Root cause

`ClonePhase::Failed` was terminal, and Vessel reconciliation copied the Clone's old message directly into the child failure. New convoy demand therefore never changed the Clone state and could not distinguish the historical failure from a new attempt. Separately, an unused public actuator still exposed the original direct-to-target clone behavior even though the live daemon route had moved to staged publication and single-flight deduplication.

The Checkout now compares the Clone failure time with its own creation time. An older failure requests one timestamp-guarded retry; a failure produced after that Checkout began becomes a named, timestamped dependency failure.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #1400
