### PR TITLE
fix: keep daemon root and socket identity aligned

### DIFF
--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -360,15 +360,12 @@ fn resolve_flotillad_binary() -> Result<PathBuf, String> {
         .ok_or_else(|| format!("failed to locate flotillad next to {}", current.display()))
 }
 
-fn spawn_daemon(config_dir: &Path, config_dir_override: Option<&Path>, socket_override: Option<&Path>) -> Result<(), String> {
+fn spawn_daemon(socket_path: &Path, config_dir: &Path, state_dir: &Path) -> Result<(), String> {
     let daemon_binary = resolve_flotillad_binary()?;
     let mut cmd = std::process::Command::new(&daemon_binary);
-    if let Some(dir) = config_dir_override {
-        cmd.arg("--config-dir").arg(dir);
-    }
-    if let Some(socket) = socket_override {
-        cmd.arg("--socket").arg(socket);
-    }
+    cmd.arg("--config-dir").arg(config_dir);
+    cmd.arg("--state-dir").arg(state_dir);
+    cmd.arg("--socket").arg(socket_path);
     // Detach: own session so Ctrl-C doesn't kill daemon with TUI
     use std::os::unix::process::CommandExt;
     unsafe {
@@ -390,25 +387,17 @@ fn spawn_daemon(config_dir: &Path, config_dir_override: Option<&Path>, socket_ov
     Ok(())
 }
 
-pub async fn connect_or_spawn(
-    socket_path: &Path,
-    config_dir: &Path,
-    state_dir: &Path,
-    config_dir_override: Option<&Path>,
-    socket_override: Option<&Path>,
-) -> Result<Arc<SocketDaemon>, String> {
-    connect_or_spawn_with_optional_surface(socket_path, config_dir, state_dir, config_dir_override, socket_override, None).await
+pub async fn connect_or_spawn(socket_path: &Path, config_dir: &Path, state_dir: &Path) -> Result<Arc<SocketDaemon>, String> {
+    connect_or_spawn_with_optional_surface(socket_path, config_dir, state_dir, None).await
 }
 
 pub async fn connect_or_spawn_with_surface(
     socket_path: &Path,
     config_dir: &Path,
     state_dir: &Path,
-    config_dir_override: Option<&Path>,
-    socket_override: Option<&Path>,
     surface: SurfaceDeclaration,
 ) -> Result<Arc<SocketDaemon>, String> {
-    connect_or_spawn_with_optional_surface(socket_path, config_dir, state_dir, config_dir_override, socket_override, Some(surface)).await
+    connect_or_spawn_with_optional_surface(socket_path, config_dir, state_dir, Some(surface)).await
 }
 
 /// Connect to the host daemon exposed inside a contained environment.
@@ -444,10 +433,9 @@ async fn connect_or_spawn_with_optional_surface(
     socket_path: &Path,
     config_dir: &Path,
     state_dir: &Path,
-    config_dir_override: Option<&Path>,
-    socket_override: Option<&Path>,
     surface: Option<SurfaceDeclaration>,
 ) -> Result<Arc<SocketDaemon>, String> {
+    flotilla_core::path_policy::ensure_daemon_socket_belongs_to_config(socket_path, config_dir)?;
     // An existing socket must complete the stateful Hello handshake. A
     // handshake failure means a daemon is listening but is incompatible or
     // malformed; surface that error instead of treating the socket as stale
@@ -561,7 +549,7 @@ async fn connect_or_spawn_with_optional_surface(
         let _ = std::fs::remove_file(socket_path);
 
         // Spawn daemon process
-        spawn_daemon(config_dir, config_dir_override, socket_override)?;
+        spawn_daemon(socket_path, config_dir, state_dir)?;
     }
 
     // Poll for connection with a 10s deadline (soft: the deadline is checked

--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -435,7 +435,7 @@ async fn connect_or_spawn_with_optional_surface(
     state_dir: &Path,
     surface: Option<SurfaceDeclaration>,
 ) -> Result<Arc<SocketDaemon>, String> {
-    flotilla_core::path_policy::ensure_daemon_socket_belongs_to_config(socket_path, config_dir)?;
+    let (config_dir, state_dir) = flotilla_core::path_policy::daemon_dirs_for_socket(socket_path, config_dir, state_dir)?;
     // An existing socket must complete the stateful Hello handshake. A
     // handshake failure means a daemon is listening but is incompatible or
     // malformed; surface that error instead of treating the socket as stale
@@ -451,7 +451,7 @@ async fn connect_or_spawn_with_optional_surface(
         return Ok(daemon);
     }
 
-    ensure_no_live_daemon_without_socket(state_dir, socket_path)?;
+    ensure_no_live_daemon_without_socket(&state_dir, socket_path)?;
 
     // Acquire spawn lock (tmux-style flock). The loser blocks until the
     // winner's daemon is ready, then retries connect.
@@ -542,14 +542,14 @@ async fn connect_or_spawn_with_optional_surface(
         }
     }
 
-    ensure_no_live_daemon_without_socket(state_dir, socket_path)?;
+    ensure_no_live_daemon_without_socket(&state_dir, socket_path)?;
 
     {
         // Clean up stale socket
         let _ = std::fs::remove_file(socket_path);
 
         // Spawn daemon process
-        spawn_daemon(socket_path, config_dir, state_dir)?;
+        spawn_daemon(socket_path, &config_dir, &state_dir)?;
     }
 
     // Poll for connection with a 10s deadline (soft: the deadline is checked

--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -435,7 +435,7 @@ async fn connect_or_spawn_with_optional_surface(
     state_dir: &Path,
     surface: Option<SurfaceDeclaration>,
 ) -> Result<Arc<SocketDaemon>, String> {
-    let (config_dir, state_dir) = flotilla_core::path_policy::daemon_dirs_for_socket(socket_path, config_dir, state_dir)?;
+    flotilla_core::path_policy::ensure_daemon_socket_belongs_to_config(socket_path, config_dir)?;
     // An existing socket must complete the stateful Hello handshake. A
     // handshake failure means a daemon is listening but is incompatible or
     // malformed; surface that error instead of treating the socket as stale
@@ -451,7 +451,7 @@ async fn connect_or_spawn_with_optional_surface(
         return Ok(daemon);
     }
 
-    ensure_no_live_daemon_without_socket(&state_dir, socket_path)?;
+    ensure_no_live_daemon_without_socket(state_dir, socket_path)?;
 
     // Acquire spawn lock (tmux-style flock). The loser blocks until the
     // winner's daemon is ready, then retries connect.
@@ -542,14 +542,14 @@ async fn connect_or_spawn_with_optional_surface(
         }
     }
 
-    ensure_no_live_daemon_without_socket(&state_dir, socket_path)?;
+    ensure_no_live_daemon_without_socket(state_dir, socket_path)?;
 
     {
         // Clean up stale socket
         let _ = std::fs::remove_file(socket_path);
 
         // Spawn daemon process
-        spawn_daemon(socket_path, &config_dir, &state_dir)?;
+        spawn_daemon(socket_path, config_dir, state_dir)?;
     }
 
     // Poll for connection with a 10s deadline (soft: the deadline is checked

--- a/crates/flotilla-client/src/lib/tests.rs
+++ b/crates/flotilla-client/src/lib/tests.rs
@@ -94,6 +94,12 @@ fn session_harness() -> SessionHarness {
     SessionHarness { daemon, session: server }
 }
 
+fn rooted_daemon_socket(dir: &TestSocketDir) -> PathBuf {
+    let socket_path = flotilla_core::path_policy::daemon_socket_path(dir.path());
+    std::fs::create_dir_all(socket_path.parent().expect("daemon socket parent")).expect("create daemon socket parent");
+    socket_path
+}
+
 #[tokio::test]
 async fn stateful_handshake_records_daemon_build_identity() {
     let (client, server) = message_session_pair();
@@ -147,7 +153,7 @@ async fn connect_or_spawn_never_spawns_over_daemon_that_appeared_during_lock_con
     // the spawn lock, binds a stale-version listener only after A's first
     // probe has found nothing, then releases the lock.
     let dir = TestSocketDir::new();
-    let socket_path = dir.socket_path("daemon.sock");
+    let socket_path = rooted_daemon_socket(&dir);
     let lock_path = std::path::PathBuf::from(format!("{}.lock", socket_path.display()));
 
     let lock_file = match acquire_spawn_lock(&lock_path) {
@@ -164,8 +170,7 @@ async fn connect_or_spawn_never_spawns_over_daemon_that_appeared_during_lock_con
 
     let client_socket = socket_path.clone();
     let client_dir = dir.path().to_path_buf();
-    let client_task =
-        tokio::spawn(async move { connect_or_spawn(&client_socket, &client_dir, &client_dir, None, Some(&client_socket)).await });
+    let client_task = tokio::spawn(async move { connect_or_spawn(&client_socket, &client_dir, &client_dir).await });
 
     // Give A time to run its first probe (nothing listening) and block on the lock.
     tokio::time::sleep(Duration::from_millis(250)).await;
@@ -234,17 +239,15 @@ async fn connect_or_spawn_reports_live_daemon_with_missing_socket() {
     use std::os::fd::AsRawFd;
 
     let dir = TestSocketDir::new();
-    let socket_path = dir.socket_path("missing-daemon.sock");
+    let socket_path = rooted_daemon_socket(&dir);
     let lifecycle_path = dir.path().join(flotilla_core::DAEMON_LIFECYCLE_LOCK_FILE);
     let lifecycle =
         std::fs::OpenOptions::new().create(true).truncate(false).read(true).write(true).open(&lifecycle_path).expect("open lifecycle lock");
     // SAFETY: the file owns this descriptor for the rest of the test.
     assert_eq!(unsafe { libc::flock(lifecycle.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) }, 0, "hold lifecycle lock");
 
-    let error = connect_or_spawn(&socket_path, dir.path(), dir.path(), None, Some(&socket_path))
-        .await
-        .err()
-        .expect("a live daemon with no socket should be diagnosed");
+    let error =
+        connect_or_spawn(&socket_path, dir.path(), dir.path()).await.err().expect("a live daemon with no socket should be diagnosed");
 
     assert!(error.contains("daemon process is alive"), "unexpected error: {error}");
     assert!(error.contains("socket is missing or unreachable"), "unexpected error: {error}");
@@ -254,7 +257,7 @@ async fn connect_or_spawn_reports_live_daemon_with_missing_socket() {
 #[tokio::test]
 async fn connect_or_spawn_reports_wedged_daemon_instead_of_hanging_or_respawning() {
     let dir = TestSocketDir::new();
-    let socket_path = dir.socket_path("daemon.sock");
+    let socket_path = rooted_daemon_socket(&dir);
     let listener = match UnixListener::bind(&socket_path) {
         Ok(listener) => listener,
         Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
@@ -273,7 +276,7 @@ async fn connect_or_spawn_reports_wedged_daemon_instead_of_hanging_or_respawning
         std::future::pending::<()>().await;
     });
 
-    let error = match connect_or_spawn(&socket_path, dir.path(), dir.path(), None, Some(&socket_path)).await {
+    let error = match connect_or_spawn(&socket_path, dir.path(), dir.path()).await {
         Ok(_) => panic!("a wedged daemon must surface an error, not hang or be replaced"),
         Err(error) => error,
     };
@@ -394,7 +397,7 @@ async fn connect_rejects_daemon_wire_generation_mismatch() {
 #[tokio::test]
 async fn connect_or_spawn_rejects_existing_daemon_protocol_version_mismatch() {
     let dir = TestSocketDir::new();
-    let socket_path = dir.socket_path("daemon.sock");
+    let socket_path = rooted_daemon_socket(&dir);
     let listener = match UnixListener::bind(&socket_path) {
         Ok(listener) => listener,
         Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
@@ -420,7 +423,7 @@ async fn connect_or_spawn_rejects_existing_daemon_protocol_version_mismatch() {
             .expect("write stale daemon hello");
     });
 
-    let result = connect_or_spawn(&socket_path, dir.path(), dir.path(), None, Some(&socket_path)).await;
+    let result = connect_or_spawn(&socket_path, dir.path(), dir.path()).await;
     server_task.await.expect("join server task");
 
     let error = match result {
@@ -428,6 +431,22 @@ async fn connect_or_spawn_rejects_existing_daemon_protocol_version_mismatch() {
         Err(error) => error,
     };
     assert!(error.contains("protocol version mismatch"), "unexpected error: {error}");
+}
+
+#[tokio::test]
+async fn root_scoped_client_refuses_to_spawn_on_the_default_fleet_socket() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let scoped_config = dir.path().join("live-session/config");
+    let default_socket = dir.path().join("default/config/run/flotilla.sock");
+
+    let error = match connect_or_spawn(&default_socket, &scoped_config, &dir.path().join("live-session/state")).await {
+        Ok(_) => panic!("a scoped client must not spawn a wrong-root daemon on the default socket"),
+        Err(error) => error,
+    };
+
+    assert!(error.contains("does not belong to config root"), "unexpected error: {error}");
+    assert!(!default_socket.exists(), "identity validation must run before creating or replacing the socket");
+    assert!(!PathBuf::from(format!("{}.lock", default_socket.display())).exists(), "identity validation must run before locking");
 }
 
 #[tokio::test]

--- a/crates/flotilla-client/src/lib/tests.rs
+++ b/crates/flotilla-client/src/lib/tests.rs
@@ -437,7 +437,7 @@ async fn connect_or_spawn_rejects_existing_daemon_protocol_version_mismatch() {
 async fn root_scoped_client_refuses_to_spawn_on_the_default_fleet_socket() {
     let dir = tempfile::tempdir().expect("tempdir");
     let scoped_config = dir.path().join("live-session/config");
-    let default_socket = dir.path().join("default/config/run/flotilla.sock");
+    let default_socket = dir.path().join("home/.config/flotilla/run/flotilla.sock");
 
     let error = match connect_or_spawn(&default_socket, &scoped_config, &dir.path().join("live-session/state")).await {
         Ok(_) => panic!("a scoped client must not spawn a wrong-root daemon on the default socket"),

--- a/crates/flotilla-core/src/path_policy.rs
+++ b/crates/flotilla-core/src/path_policy.rs
@@ -8,9 +8,30 @@
 //! We always use XDG-style paths, even on macOS, to keep a developer tool's
 //! config in predictable dotfile locations rather than `~/Library/...`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::path_context::DaemonHostPath;
+
+pub const DAEMON_SOCKET_RELATIVE_PATH: &str = "run/flotilla.sock";
+
+/// Return the only daemon socket owned by `config_dir`.
+pub fn daemon_socket_path(config_dir: &Path) -> PathBuf {
+    config_dir.join(DAEMON_SOCKET_RELATIVE_PATH)
+}
+
+/// Refuse a root/socket pairing that could expose one root through another root's socket.
+pub fn ensure_daemon_socket_belongs_to_config(socket_path: &Path, config_dir: &Path) -> Result<(), String> {
+    let expected = daemon_socket_path(config_dir);
+    if socket_path == expected {
+        return Ok(());
+    }
+    Err(format!(
+        "daemon socket {} does not belong to config root {}; expected {} — refusing to mix daemon root and socket identities",
+        socket_path.display(),
+        config_dir.display(),
+        expected.display()
+    ))
+}
 
 /// Resolved daemon-side directory locations.
 ///
@@ -116,5 +137,25 @@ mod tests {
             _ => None,
         });
         assert_eq!(policy.config_dir.as_path(), std::path::Path::new("/root/config"));
+    }
+
+    #[test]
+    fn scoped_root_rejects_the_default_fleet_socket() {
+        let policy = PathPolicy::from_env(|key| match key {
+            "FLOTILLA_ROOT" => Some("/work/live-session".into()),
+            "HOME" => Some("/home/test".into()),
+            _ => None,
+        });
+        let default_policy = PathPolicy::from_env(|key| match key {
+            "HOME" => Some("/home/test".into()),
+            _ => None,
+        });
+        let default_socket = daemon_socket_path(default_policy.config_dir.as_path());
+
+        let error = ensure_daemon_socket_belongs_to_config(&default_socket, policy.config_dir.as_path())
+            .expect_err("a root-scoped daemon must not bind the default fleet socket");
+
+        assert!(error.contains("does not belong to config root"), "unexpected error: {error}");
+        assert!(error.contains("/work/live-session/config/run/flotilla.sock"), "unexpected error: {error}");
     }
 }

--- a/crates/flotilla-core/src/path_policy.rs
+++ b/crates/flotilla-core/src/path_policy.rs
@@ -33,6 +33,32 @@ pub fn ensure_daemon_socket_belongs_to_config(socket_path: &Path, config_dir: &P
     ))
 }
 
+/// Resolve config and state directories from the requested socket identity.
+///
+/// Managed terminals carry `FLOTILLA_DAEMON_SOCKET` so they can reconnect to
+/// their owning daemon, but an already-running terminal server may not carry
+/// `FLOTILLA_ROOT`. A canonical root-scoped socket supplies that missing root.
+/// The default XDG socket does not end in `config/run/flotilla.sock`, so it
+/// cannot silently redirect a root-scoped client to the fleet root.
+pub fn daemon_dirs_for_socket(socket_path: &Path, config_dir: &Path, state_dir: &Path) -> Result<(PathBuf, PathBuf), String> {
+    let mismatch = match ensure_daemon_socket_belongs_to_config(socket_path, config_dir) {
+        Ok(()) => return Ok((config_dir.to_path_buf(), state_dir.to_path_buf())),
+        Err(error) => error,
+    };
+    let scoped_root = socket_path
+        .file_name()
+        .filter(|name| *name == "flotilla.sock")
+        .and_then(|_| socket_path.parent())
+        .filter(|run_dir| run_dir.file_name().is_some_and(|name| name == "run"))
+        .and_then(Path::parent)
+        .filter(|config_dir| config_dir.file_name().is_some_and(|name| name == "config"))
+        .and_then(Path::parent);
+    if let Some(root) = scoped_root {
+        return Ok((root.join("config"), root.join("state")));
+    }
+    Err(mismatch)
+}
+
 /// Resolved daemon-side directory locations.
 ///
 /// Internal to the daemon and its stores — not exposed to providers.
@@ -157,5 +183,18 @@ mod tests {
 
         assert!(error.contains("does not belong to config root"), "unexpected error: {error}");
         assert!(error.contains("/work/live-session/config/run/flotilla.sock"), "unexpected error: {error}");
+    }
+
+    #[test]
+    fn scoped_socket_supplies_the_root_for_a_managed_terminal() {
+        let (config_dir, state_dir) = daemon_dirs_for_socket(
+            Path::new("/work/live-session/config/run/flotilla.sock"),
+            Path::new("/home/test/.config/flotilla"),
+            Path::new("/home/test/.local/state/flotilla"),
+        )
+        .expect("canonical scoped socket should supply its root");
+
+        assert_eq!(config_dir, Path::new("/work/live-session/config"));
+        assert_eq!(state_dir, Path::new("/work/live-session/state"));
     }
 }

--- a/crates/flotilla-core/src/path_policy.rs
+++ b/crates/flotilla-core/src/path_policy.rs
@@ -33,18 +33,8 @@ pub fn ensure_daemon_socket_belongs_to_config(socket_path: &Path, config_dir: &P
     ))
 }
 
-/// Resolve config and state directories from the requested socket identity.
-///
-/// Managed terminals carry `FLOTILLA_DAEMON_SOCKET` so they can reconnect to
-/// their owning daemon, but an already-running terminal server may not carry
-/// `FLOTILLA_ROOT`. A canonical root-scoped socket supplies that missing root.
-/// The default XDG socket does not end in `config/run/flotilla.sock`, so it
-/// cannot silently redirect a root-scoped client to the fleet root.
-pub fn daemon_dirs_for_socket(socket_path: &Path, config_dir: &Path, state_dir: &Path) -> Result<(PathBuf, PathBuf), String> {
-    let mismatch = match ensure_daemon_socket_belongs_to_config(socket_path, config_dir) {
-        Ok(()) => return Ok((config_dir.to_path_buf(), state_dir.to_path_buf())),
-        Err(error) => error,
-    };
+/// Derive a root's config and state directories from its canonical scoped socket.
+pub fn scoped_daemon_dirs(socket_path: &Path) -> Option<(PathBuf, PathBuf)> {
     let scoped_root = socket_path
         .file_name()
         .filter(|name| *name == "flotilla.sock")
@@ -53,10 +43,7 @@ pub fn daemon_dirs_for_socket(socket_path: &Path, config_dir: &Path, state_dir: 
         .and_then(Path::parent)
         .filter(|config_dir| config_dir.file_name().is_some_and(|name| name == "config"))
         .and_then(Path::parent);
-    if let Some(root) = scoped_root {
-        return Ok((root.join("config"), root.join("state")));
-    }
-    Err(mismatch)
+    scoped_root.map(|root| (root.join("config"), root.join("state")))
 }
 
 /// Resolved daemon-side directory locations.
@@ -187,14 +174,15 @@ mod tests {
 
     #[test]
     fn scoped_socket_supplies_the_root_for_a_managed_terminal() {
-        let (config_dir, state_dir) = daemon_dirs_for_socket(
-            Path::new("/work/live-session/config/run/flotilla.sock"),
-            Path::new("/home/test/.config/flotilla"),
-            Path::new("/home/test/.local/state/flotilla"),
-        )
-        .expect("canonical scoped socket should supply its root");
+        let (config_dir, state_dir) = scoped_daemon_dirs(Path::new("/work/live-session/config/run/flotilla.sock"))
+            .expect("canonical scoped socket should supply its root");
 
         assert_eq!(config_dir, Path::new("/work/live-session/config"));
         assert_eq!(state_dir, Path::new("/work/live-session/state"));
+    }
+
+    #[test]
+    fn default_xdg_socket_does_not_claim_to_encode_a_root() {
+        assert!(scoped_daemon_dirs(Path::new("/home/test/.config/flotilla/run/flotilla.sock")).is_none());
     }
 }

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -248,7 +248,7 @@ async fn build_embedded_resource_backend(config: &ConfigStore) -> Result<Resourc
 }
 
 pub fn spawn_embedded_peer_networking(daemon: Arc<InProcessDaemon>, config: &ConfigStore) -> Result<tokio::task::JoinHandle<()>, String> {
-    let local_daemon_socket_path = config.base_path().join("run/flotilla.sock");
+    let local_daemon_socket_path = flotilla_core::path_policy::daemon_socket_path(config.base_path().as_path());
     let peer_manager = build_peer_manager(&daemon, config, local_daemon_socket_path.as_path())?;
     {
         let daemon = Arc::clone(&daemon);

--- a/crates/flotilla-tui/src/pm_connect.rs
+++ b/crates/flotilla-tui/src/pm_connect.rs
@@ -305,7 +305,13 @@ pub async fn run_connector(
 /// CLI entry: detect the PM, then keep a connector running against the local
 /// daemon, reconnecting on failure. Catalog facts fade by TTL while the
 /// daemon is away and re-assert on return.
-pub async fn run(socket_path: &Path, config_dir: &Path, require_host_daemon: bool, options: PmConnectOptions) -> Result<(), String> {
+pub async fn run(
+    socket_path: &Path,
+    config_dir: &Path,
+    state_dir: &Path,
+    require_host_daemon: bool,
+    options: PmConnectOptions,
+) -> Result<(), String> {
     // The connector runs headless in a PM pane: structured logs to stderr.
     let _ = tracing_subscriber::fmt()
         .with_env_filter(
@@ -321,8 +327,7 @@ pub async fn run(socket_path: &Path, config_dir: &Path, require_host_daemon: boo
             if require_host_daemon {
                 crate::socket::connect_required_host_daemon_with_surface(socket_path, surface).await
             } else {
-                let state_dir = flotilla_core::path_policy::PathPolicy::from_process_env().state_dir;
-                crate::socket::connect_or_spawn_with_surface(socket_path, config_dir, state_dir.as_path(), surface).await
+                crate::socket::connect_or_spawn_with_surface(socket_path, config_dir, state_dir, surface).await
             }
             .map(|daemon| daemon as Arc<dyn DaemonHandle>)
         },

--- a/crates/flotilla-tui/src/pm_connect.rs
+++ b/crates/flotilla-tui/src/pm_connect.rs
@@ -305,14 +305,7 @@ pub async fn run_connector(
 /// CLI entry: detect the PM, then keep a connector running against the local
 /// daemon, reconnecting on failure. Catalog facts fade by TTL while the
 /// daemon is away and re-assert on return.
-pub async fn run(
-    socket_path: &Path,
-    config_dir: &Path,
-    config_dir_override: Option<&Path>,
-    socket_override: Option<&Path>,
-    require_host_daemon: bool,
-    options: PmConnectOptions,
-) -> Result<(), String> {
+pub async fn run(socket_path: &Path, config_dir: &Path, require_host_daemon: bool, options: PmConnectOptions) -> Result<(), String> {
     // The connector runs headless in a PM pane: structured logs to stderr.
     let _ = tracing_subscriber::fmt()
         .with_env_filter(
@@ -329,15 +322,7 @@ pub async fn run(
                 crate::socket::connect_required_host_daemon_with_surface(socket_path, surface).await
             } else {
                 let state_dir = flotilla_core::path_policy::PathPolicy::from_process_env().state_dir;
-                crate::socket::connect_or_spawn_with_surface(
-                    socket_path,
-                    config_dir,
-                    state_dir.as_path(),
-                    config_dir_override,
-                    socket_override,
-                    surface,
-                )
-                .await
+                crate::socket::connect_or_spawn_with_surface(socket_path, config_dir, state_dir.as_path(), surface).await
             }
             .map(|daemon| daemon as Arc<dyn DaemonHandle>)
         },

--- a/src/bin/flotillad.rs
+++ b/src/bin/flotillad.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, sync::OnceLock};
 
 use clap::Parser;
-use flotilla_core::path_policy::{daemon_dirs_for_socket, daemon_socket_path, PathPolicy};
+use flotilla_core::path_policy::{daemon_socket_path, ensure_daemon_socket_belongs_to_config, PathPolicy};
 
 /// Flotilla daemon
 #[derive(Parser)]
@@ -50,6 +50,6 @@ async fn main() -> Result<(), String> {
     let config_dir = cli.config_dir();
     let state_dir = cli.state_dir();
     let socket_path = cli.socket_path();
-    let (config_dir, state_dir) = daemon_dirs_for_socket(&socket_path, &config_dir, &state_dir)?;
+    ensure_daemon_socket_belongs_to_config(&socket_path, &config_dir)?;
     flotilla_daemon::cli::run(&socket_path, &config_dir, &state_dir, cli.timeout).await
 }

--- a/src/bin/flotillad.rs
+++ b/src/bin/flotillad.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, sync::OnceLock};
 
 use clap::Parser;
-use flotilla_core::path_policy::PathPolicy;
+use flotilla_core::path_policy::{daemon_socket_path, ensure_daemon_socket_belongs_to_config, PathPolicy};
 
 /// Flotilla daemon
 #[derive(Parser)]
@@ -10,6 +10,10 @@ struct Cli {
     /// Config directory
     #[arg(long)]
     config_dir: Option<PathBuf>,
+
+    /// State directory
+    #[arg(long)]
+    state_dir: Option<PathBuf>,
 
     /// Socket path (default: ${config_dir}/run/flotilla.sock)
     #[arg(long)]
@@ -31,7 +35,11 @@ impl Cli {
     }
 
     fn socket_path(&self) -> PathBuf {
-        self.socket.clone().unwrap_or_else(|| self.config_dir().join("run/flotilla.sock"))
+        self.socket.clone().unwrap_or_else(|| daemon_socket_path(&self.config_dir()))
+    }
+
+    fn state_dir(&self) -> PathBuf {
+        self.state_dir.clone().unwrap_or_else(|| PathPolicy::from_process_env().state_dir.into_path_buf())
     }
 }
 
@@ -39,6 +47,8 @@ impl Cli {
 async fn main() -> Result<(), String> {
     flotilla_core::tls::install_default_provider();
     let cli = Cli::parse();
-    let paths = PathPolicy::from_process_env();
-    flotilla_daemon::cli::run(&cli.socket_path(), &cli.config_dir(), paths.state_dir.as_path(), cli.timeout).await
+    let config_dir = cli.config_dir();
+    let socket_path = cli.socket_path();
+    ensure_daemon_socket_belongs_to_config(&socket_path, &config_dir)?;
+    flotilla_daemon::cli::run(&socket_path, &config_dir, &cli.state_dir(), cli.timeout).await
 }

--- a/src/bin/flotillad.rs
+++ b/src/bin/flotillad.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, sync::OnceLock};
 
 use clap::Parser;
-use flotilla_core::path_policy::{daemon_socket_path, ensure_daemon_socket_belongs_to_config, PathPolicy};
+use flotilla_core::path_policy::{daemon_dirs_for_socket, daemon_socket_path, PathPolicy};
 
 /// Flotilla daemon
 #[derive(Parser)]
@@ -48,7 +48,8 @@ async fn main() -> Result<(), String> {
     flotilla_core::tls::install_default_provider();
     let cli = Cli::parse();
     let config_dir = cli.config_dir();
+    let state_dir = cli.state_dir();
     let socket_path = cli.socket_path();
-    ensure_daemon_socket_belongs_to_config(&socket_path, &config_dir)?;
-    flotilla_daemon::cli::run(&socket_path, &config_dir, &cli.state_dir(), cli.timeout).await
+    let (config_dir, state_dir) = daemon_dirs_for_socket(&socket_path, &config_dir, &state_dir)?;
+    flotilla_daemon::cli::run(&socket_path, &config_dir, &state_dir, cli.timeout).await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -361,13 +361,41 @@ struct ResourceApplyArgs {
 }
 
 impl Cli {
+    fn dirs(&self) -> (PathBuf, PathBuf) {
+        let policy = PathPolicy::from_process_env();
+        client_dirs_from(
+            self.config_dir.as_deref(),
+            policy.config_dir.as_path(),
+            policy.state_dir.as_path(),
+            std::env::var_os("FLOTILLA_DAEMON_SOCKET").as_deref(),
+        )
+    }
+
     fn config_dir(&self) -> PathBuf {
-        self.config_dir.clone().unwrap_or_else(|| PathPolicy::from_process_env().config_dir.into_path_buf())
+        self.dirs().0
+    }
+
+    fn state_dir(&self) -> PathBuf {
+        self.dirs().1
     }
 
     fn socket_path(&self) -> PathBuf {
         socket_path_from(self.socket.as_deref(), &self.config_dir(), std::env::var_os("FLOTILLA_DAEMON_SOCKET").as_deref())
     }
+}
+
+fn client_dirs_from(
+    explicit_config_dir: Option<&Path>,
+    default_config_dir: &Path,
+    default_state_dir: &Path,
+    environment_socket: Option<&std::ffi::OsStr>,
+) -> (PathBuf, PathBuf) {
+    if explicit_config_dir.is_none() {
+        if let Some(dirs) = environment_socket.map(Path::new).and_then(flotilla_core::path_policy::scoped_daemon_dirs) {
+            return dirs;
+        }
+    }
+    (explicit_config_dir.unwrap_or(default_config_dir).to_path_buf(), default_state_dir.to_path_buf())
 }
 
 fn socket_path_from(explicit: Option<&Path>, config_dir: &Path, environment: Option<&std::ffi::OsStr>) -> PathBuf {
@@ -572,11 +600,11 @@ fn default_project_landing(
 /// Run the TUI. With `scoped_view`, run in scoped mode: exactly that View,
 /// no tab shell, no open-view persistence.
 async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) -> Result<()> {
-    let paths = PathPolicy::from_process_env();
-    event_log::init_with_dir(paths.state_dir.as_path());
+    let resolved_state_dir = DaemonHostPath::new(cli.state_dir());
+    event_log::init_with_dir(resolved_state_dir.as_path());
     let startup = std::time::Instant::now();
     let resolved_config_dir = cli.config_dir();
-    let config = Arc::new(ConfigStore::new(DaemonHostPath::new(&resolved_config_dir), paths.state_dir.clone()));
+    let config = Arc::new(ConfigStore::new(DaemonHostPath::new(&resolved_config_dir), resolved_state_dir.clone()));
 
     // Initialize the terminal immediately. Full-app mode shows the splash for
     // fast visual feedback; scoped mode opens directly into its target view.
@@ -594,11 +622,11 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
     // Spawn daemon init on a separate task so full-app startup can run it
     // concurrently with the splash (which uses blocking event polling).
     let daemon_log_path =
-        paths.state_dir.as_path().join(flotilla_core::log_file::DAEMON_LOG_DIRECTORY).join(flotilla_core::log_file::DAEMON_LOG_FILE);
+        resolved_state_dir.as_path().join(flotilla_core::log_file::DAEMON_LOG_DIRECTORY).join(flotilla_core::log_file::DAEMON_LOG_FILE);
     let daemon_panic_log_path = resolved_config_dir.join("daemon-panic.log");
     let initial_socket_path = socket_path.clone();
     let initial_config_dir = resolved_config_dir.clone();
-    let initial_state_dir = paths.state_dir.clone();
+    let initial_state_dir = resolved_state_dir.clone();
     let daemon_task = tokio::spawn(async move {
         connect_cli_socket(&initial_socket_path, &initial_config_dir, initial_state_dir.as_path(), require_host_daemon)
             .await
@@ -685,7 +713,7 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
 
         terminal = ratatui::init();
         let connected = match flotilla_tui::socket::reconnect::connect_with_retry(
-            || connect_cli_socket(&socket_path, &resolved_config_dir, paths.state_dir.as_path(), require_host_daemon),
+            || connect_cli_socket(&socket_path, &resolved_config_dir, resolved_state_dir.as_path(), require_host_daemon),
             |notice| {
                 let (attempt, detail) = match notice {
                     flotilla_tui::socket::reconnect::ReconnectNotice::Attempt { attempt } => (attempt, None),
@@ -702,7 +730,7 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
         {
             Ok(connected) => connected,
             Err(error) => {
-                if let Err(handoff_error) = persist_tui_handoff(&app, paths.state_dir.as_path()) {
+                if let Err(handoff_error) = persist_tui_handoff(&app, resolved_state_dir.as_path()) {
                     tracing::warn!(error = %handoff_error, "failed to persist TUI state for re-exec");
                 }
                 flotilla_tui::terminal::restore_terminal();
@@ -743,10 +771,10 @@ fn restore_tui_handoff(app: &mut app::App) {
 
 async fn run_daemon(cli: &Cli, timeout_secs: u64) -> Result<()> {
     let daemon_binary = resolve_flotillad_binary()?;
-    let paths = PathPolicy::from_process_env();
     let config_dir = cli.config_dir();
+    let state_dir = cli.state_dir();
     let socket_path = cli.socket_path();
-    let (config_dir, state_dir) = flotilla_core::path_policy::daemon_dirs_for_socket(&socket_path, &config_dir, paths.state_dir.as_path())
+    flotilla_core::path_policy::ensure_daemon_socket_belongs_to_config(&socket_path, &config_dir)
         .map_err(|error| color_eyre::eyre::eyre!(error))?;
     let mut command = tokio::process::Command::new(&daemon_binary);
     command.arg("--timeout").arg(timeout_secs.to_string());
@@ -812,9 +840,13 @@ async fn run_pm_command(cli: &Cli, command: PmSubCommand) -> Result<()> {
                 .maybe_wheelhouse_socket(wheelhouse_socket)
                 .flotilla_bin(flotilla_bin)
                 .build();
+            let socket_path = cli.socket_path();
+            let config_dir = cli.config_dir();
+            let state_dir = cli.state_dir();
             flotilla_tui::pm_connect::run(
-                &cli.socket_path(),
-                &cli.config_dir(),
+                &socket_path,
+                &config_dir,
+                &state_dir,
                 host_daemon_socket_required(
                     std::env::var_os(flotilla_core::providers::environment::CONTAINED_DAEMON_REQUIRED_ENV).as_deref(),
                 ),
@@ -842,11 +874,11 @@ async fn run_wait(
     reset_sigpipe();
     let socket_path = cli.socket_path();
     let config_dir = cli.config_dir();
-    let paths = PathPolicy::from_process_env();
+    let state_dir = cli.state_dir();
     let daemon = connect_cli_socket(
         &socket_path,
         &config_dir,
-        paths.state_dir.as_path(),
+        &state_dir,
         host_daemon_socket_required(std::env::var_os(flotilla_core::providers::environment::CONTAINED_DAEMON_REQUIRED_ENV).as_deref()),
     )
     .await
@@ -883,11 +915,11 @@ async fn run_wait(
 async fn connect_daemon(cli: &Cli) -> Result<Arc<dyn DaemonHandle>> {
     let socket_path = cli.socket_path();
     let config_dir = cli.config_dir();
-    let paths = PathPolicy::from_process_env();
+    let state_dir = cli.state_dir();
     let daemon = connect_cli_socket(
         &socket_path,
         &config_dir,
-        paths.state_dir.as_path(),
+        &state_dir,
         host_daemon_socket_required(std::env::var_os(flotilla_core::providers::environment::CONTAINED_DAEMON_REQUIRED_ENV).as_deref()),
     )
     .await
@@ -1838,10 +1870,11 @@ mod tests {
     };
 
     use super::{
-        attach_exit_disposition, confirm_command, default_project_landing, format_human_resource_value, host_daemon_socket_required,
-        provisioning_target_for_environment, replace_host_ids, run_replica_snapshot, select_host_target, select_startup_repo_roots,
-        should_reexec_for_incompatible_daemon, show_startup_splash, socket_path_from, AttachExitDisposition, Cli, CommandValue,
-        ResourceApplyArgs, ResourceDeleteArgs, ResourceGetArgs, ResourceListArgs, ResourceSubCommand, ResourceWatchArgs, SubCommand,
+        attach_exit_disposition, client_dirs_from, confirm_command, default_project_landing, format_human_resource_value,
+        host_daemon_socket_required, provisioning_target_for_environment, replace_host_ids, run_replica_snapshot, select_host_target,
+        select_startup_repo_roots, should_reexec_for_incompatible_daemon, show_startup_splash, socket_path_from, AttachExitDisposition,
+        Cli, CommandValue, ResourceApplyArgs, ResourceDeleteArgs, ResourceGetArgs, ResourceListArgs, ResourceSubCommand, ResourceWatchArgs,
+        SubCommand,
     };
 
     fn landing_repo(path: &str, name: &str, key: Option<&str>) -> RepoInfo {
@@ -2219,6 +2252,32 @@ mod tests {
     #[test]
     fn default_socket_uses_a_dedicated_runtime_directory() {
         assert_eq!(socket_path_from(None, Path::new("/config"), None), PathBuf::from("/config/run/flotilla.sock"));
+    }
+
+    #[test]
+    fn ambient_scoped_socket_supplies_client_config_and_state_dirs() {
+        assert_eq!(
+            client_dirs_from(
+                None,
+                Path::new("/home/test/.config/flotilla"),
+                Path::new("/home/test/.local/state/flotilla"),
+                Some(std::ffi::OsStr::new("/work/live-session/config/run/flotilla.sock")),
+            ),
+            (PathBuf::from("/work/live-session/config"), PathBuf::from("/work/live-session/state")),
+        );
+    }
+
+    #[test]
+    fn explicit_config_is_not_replaced_by_a_conflicting_scoped_socket() {
+        assert_eq!(
+            client_dirs_from(
+                Some(Path::new("/work/root-b/config")),
+                Path::new("/home/test/.config/flotilla"),
+                Path::new("/home/test/.local/state/flotilla"),
+                Some(std::ffi::OsStr::new("/work/root-a/config/run/flotilla.sock")),
+            ),
+            (PathBuf::from("/work/root-b/config"), PathBuf::from("/home/test/.local/state/flotilla")),
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use flotilla_core::{
     config::ConfigStore,
     daemon::DaemonHandle,
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
-    path_policy::PathPolicy,
+    path_policy::{daemon_socket_path, PathPolicy},
     providers::{
         vcs::{git::GitVcs, Vcs},
         ProcessCommandRunner,
@@ -371,7 +371,7 @@ impl Cli {
 }
 
 fn socket_path_from(explicit: Option<&Path>, config_dir: &Path, environment: Option<&std::ffi::OsStr>) -> PathBuf {
-    environment.map(PathBuf::from).or_else(|| explicit.map(PathBuf::from)).unwrap_or_else(|| config_dir.join("run/flotilla.sock"))
+    environment.map(PathBuf::from).or_else(|| explicit.map(PathBuf::from)).unwrap_or_else(|| daemon_socket_path(config_dir))
 }
 
 fn host_daemon_socket_required(contained_marker: Option<&std::ffi::OsStr>) -> bool {
@@ -382,14 +382,12 @@ async fn connect_cli_socket(
     socket_path: &Path,
     config_dir: &Path,
     state_dir: &Path,
-    config_dir_override: Option<&Path>,
-    socket_override: Option<&Path>,
     require_host_daemon: bool,
 ) -> Result<Arc<flotilla_tui::socket::SocketDaemon>, String> {
     if require_host_daemon {
         flotilla_tui::socket::connect_required_host_daemon(socket_path).await
     } else {
-        flotilla_tui::socket::connect_or_spawn(socket_path, config_dir, state_dir, config_dir_override, socket_override).await
+        flotilla_tui::socket::connect_or_spawn(socket_path, config_dir, state_dir).await
     }
 }
 
@@ -590,8 +588,6 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
     let startup_repo_roots = startup_repo_roots(&cli.repo_root).await;
     let cli_theme = cli.theme.clone();
     let socket_path = cli.socket_path();
-    let config_dir_override = cli.config_dir.clone();
-    let socket_override = cli.socket.clone();
     let require_host_daemon =
         host_daemon_socket_required(std::env::var_os(flotilla_core::providers::environment::CONTAINED_DAEMON_REQUIRED_ENV).as_deref());
 
@@ -603,19 +599,10 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
     let initial_socket_path = socket_path.clone();
     let initial_config_dir = resolved_config_dir.clone();
     let initial_state_dir = paths.state_dir.clone();
-    let initial_config_override = config_dir_override.clone();
-    let initial_socket_override = socket_override.clone();
     let daemon_task = tokio::spawn(async move {
-        connect_cli_socket(
-            &initial_socket_path,
-            &initial_config_dir,
-            initial_state_dir.as_path(),
-            initial_config_override.as_deref(),
-            initial_socket_override.as_deref(),
-            require_host_daemon,
-        )
-        .await
-        .map(|d| d as Arc<dyn DaemonHandle>)
+        connect_cli_socket(&initial_socket_path, &initial_config_dir, initial_state_dir.as_path(), require_host_daemon)
+            .await
+            .map(|d| d as Arc<dyn DaemonHandle>)
     });
 
     show_startup_splash(scoped_view.as_ref(), || flotilla_tui::splash::show_splash(&mut terminal)).await?;
@@ -698,16 +685,7 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
 
         terminal = ratatui::init();
         let connected = match flotilla_tui::socket::reconnect::connect_with_retry(
-            || {
-                connect_cli_socket(
-                    &socket_path,
-                    &resolved_config_dir,
-                    paths.state_dir.as_path(),
-                    config_dir_override.as_deref(),
-                    socket_override.as_deref(),
-                    require_host_daemon,
-                )
-            },
+            || connect_cli_socket(&socket_path, &resolved_config_dir, paths.state_dir.as_path(), require_host_daemon),
             |notice| {
                 let (attempt, detail) = match notice {
                     flotilla_tui::socket::reconnect::ReconnectNotice::Attempt { attempt } => (attempt, None),
@@ -765,14 +743,16 @@ fn restore_tui_handoff(app: &mut app::App) {
 
 async fn run_daemon(cli: &Cli, timeout_secs: u64) -> Result<()> {
     let daemon_binary = resolve_flotillad_binary()?;
+    let paths = PathPolicy::from_process_env();
+    let config_dir = cli.config_dir();
+    let socket_path = cli.socket_path();
+    flotilla_core::path_policy::ensure_daemon_socket_belongs_to_config(&socket_path, &config_dir)
+        .map_err(|error| color_eyre::eyre::eyre!(error))?;
     let mut command = tokio::process::Command::new(&daemon_binary);
     command.arg("--timeout").arg(timeout_secs.to_string());
-    if let Some(config_dir) = cli.config_dir.as_ref() {
-        command.arg("--config-dir").arg(config_dir);
-    }
-    if let Some(socket) = cli.socket.as_ref() {
-        command.arg("--socket").arg(socket);
-    }
+    command.arg("--config-dir").arg(config_dir);
+    command.arg("--state-dir").arg(paths.state_dir.as_path());
+    command.arg("--socket").arg(socket_path);
     let status = command.status().await?;
     if status.success() {
         Ok(())
@@ -835,8 +815,6 @@ async fn run_pm_command(cli: &Cli, command: PmSubCommand) -> Result<()> {
             flotilla_tui::pm_connect::run(
                 &cli.socket_path(),
                 &cli.config_dir(),
-                cli.config_dir.as_deref(),
-                cli.socket.as_deref(),
                 host_daemon_socket_required(
                     std::env::var_os(flotilla_core::providers::environment::CONTAINED_DAEMON_REQUIRED_ENV).as_deref(),
                 ),
@@ -869,8 +847,6 @@ async fn run_wait(
         &socket_path,
         &config_dir,
         paths.state_dir.as_path(),
-        cli.config_dir.as_deref(),
-        cli.socket.as_deref(),
         host_daemon_socket_required(std::env::var_os(flotilla_core::providers::environment::CONTAINED_DAEMON_REQUIRED_ENV).as_deref()),
     )
     .await
@@ -912,8 +888,6 @@ async fn connect_daemon(cli: &Cli) -> Result<Arc<dyn DaemonHandle>> {
         &socket_path,
         &config_dir,
         paths.state_dir.as_path(),
-        cli.config_dir.as_deref(),
-        cli.socket.as_deref(),
         host_daemon_socket_required(std::env::var_os(flotilla_core::providers::environment::CONTAINED_DAEMON_REQUIRED_ENV).as_deref()),
     )
     .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -361,27 +361,34 @@ struct ResourceApplyArgs {
 }
 
 impl Cli {
-    fn dirs(&self) -> (PathBuf, PathBuf) {
+    fn client_paths(&self) -> CliPaths {
         let policy = PathPolicy::from_process_env();
-        client_dirs_from(
+        let environment_socket = std::env::var_os("FLOTILLA_DAEMON_SOCKET");
+        let (config_dir, state_dir) = client_dirs_from(
             self.config_dir.as_deref(),
             policy.config_dir.as_path(),
             policy.state_dir.as_path(),
-            std::env::var_os("FLOTILLA_DAEMON_SOCKET").as_deref(),
-        )
+            environment_socket.as_deref(),
+        );
+        let socket_path = socket_path_from(self.socket.as_deref(), &config_dir, environment_socket.as_deref());
+        CliPaths { config_dir, state_dir, socket_path }
     }
 
-    fn config_dir(&self) -> PathBuf {
-        self.dirs().0
-    }
-
-    fn state_dir(&self) -> PathBuf {
-        self.dirs().1
+    fn daemon_paths(&self) -> CliPaths {
+        let policy = PathPolicy::from_process_env();
+        daemon_paths_from(self.config_dir.as_deref(), self.socket.as_deref(), policy.config_dir.as_path(), policy.state_dir.as_path())
     }
 
     fn socket_path(&self) -> PathBuf {
-        socket_path_from(self.socket.as_deref(), &self.config_dir(), std::env::var_os("FLOTILLA_DAEMON_SOCKET").as_deref())
+        self.client_paths().socket_path
     }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct CliPaths {
+    config_dir: PathBuf,
+    state_dir: PathBuf,
+    socket_path: PathBuf,
 }
 
 fn client_dirs_from(
@@ -400,6 +407,17 @@ fn client_dirs_from(
 
 fn socket_path_from(explicit: Option<&Path>, config_dir: &Path, environment: Option<&std::ffi::OsStr>) -> PathBuf {
     environment.map(PathBuf::from).or_else(|| explicit.map(PathBuf::from)).unwrap_or_else(|| daemon_socket_path(config_dir))
+}
+
+fn daemon_paths_from(
+    explicit_config_dir: Option<&Path>,
+    explicit_socket: Option<&Path>,
+    default_config_dir: &Path,
+    default_state_dir: &Path,
+) -> CliPaths {
+    let config_dir = explicit_config_dir.unwrap_or(default_config_dir).to_path_buf();
+    let socket_path = explicit_socket.map(PathBuf::from).unwrap_or_else(|| daemon_socket_path(&config_dir));
+    CliPaths { config_dir, state_dir: default_state_dir.to_path_buf(), socket_path }
 }
 
 fn host_daemon_socket_required(contained_marker: Option<&std::ffi::OsStr>) -> bool {
@@ -600,10 +618,11 @@ fn default_project_landing(
 /// Run the TUI. With `scoped_view`, run in scoped mode: exactly that View,
 /// no tab shell, no open-view persistence.
 async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) -> Result<()> {
-    let resolved_state_dir = DaemonHostPath::new(cli.state_dir());
+    let paths = cli.client_paths();
+    let resolved_state_dir = DaemonHostPath::new(paths.state_dir);
     event_log::init_with_dir(resolved_state_dir.as_path());
     let startup = std::time::Instant::now();
-    let resolved_config_dir = cli.config_dir();
+    let resolved_config_dir = paths.config_dir;
     let config = Arc::new(ConfigStore::new(DaemonHostPath::new(&resolved_config_dir), resolved_state_dir.clone()));
 
     // Initialize the terminal immediately. Full-app mode shows the splash for
@@ -615,7 +634,7 @@ async fn run_tui(cli: Cli, scoped_view: Option<flotilla_protocol::ViewAddress>) 
 
     let startup_repo_roots = startup_repo_roots(&cli.repo_root).await;
     let cli_theme = cli.theme.clone();
-    let socket_path = cli.socket_path();
+    let socket_path = paths.socket_path;
     let require_host_daemon =
         host_daemon_socket_required(std::env::var_os(flotilla_core::providers::environment::CONTAINED_DAEMON_REQUIRED_ENV).as_deref());
 
@@ -771,9 +790,7 @@ fn restore_tui_handoff(app: &mut app::App) {
 
 async fn run_daemon(cli: &Cli, timeout_secs: u64) -> Result<()> {
     let daemon_binary = resolve_flotillad_binary()?;
-    let config_dir = cli.config_dir();
-    let state_dir = cli.state_dir();
-    let socket_path = cli.socket_path();
+    let CliPaths { config_dir, state_dir, socket_path } = cli.daemon_paths();
     flotilla_core::path_policy::ensure_daemon_socket_belongs_to_config(&socket_path, &config_dir)
         .map_err(|error| color_eyre::eyre::eyre!(error))?;
     let mut command = tokio::process::Command::new(&daemon_binary);
@@ -840,9 +857,7 @@ async fn run_pm_command(cli: &Cli, command: PmSubCommand) -> Result<()> {
                 .maybe_wheelhouse_socket(wheelhouse_socket)
                 .flotilla_bin(flotilla_bin)
                 .build();
-            let socket_path = cli.socket_path();
-            let config_dir = cli.config_dir();
-            let state_dir = cli.state_dir();
+            let CliPaths { config_dir, state_dir, socket_path } = cli.client_paths();
             flotilla_tui::pm_connect::run(
                 &socket_path,
                 &config_dir,
@@ -872,9 +887,7 @@ async fn run_wait(
     format: OutputFormat,
 ) -> Result<()> {
     reset_sigpipe();
-    let socket_path = cli.socket_path();
-    let config_dir = cli.config_dir();
-    let state_dir = cli.state_dir();
+    let CliPaths { config_dir, state_dir, socket_path } = cli.client_paths();
     let daemon = connect_cli_socket(
         &socket_path,
         &config_dir,
@@ -913,9 +926,7 @@ async fn run_wait(
 }
 
 async fn connect_daemon(cli: &Cli) -> Result<Arc<dyn DaemonHandle>> {
-    let socket_path = cli.socket_path();
-    let config_dir = cli.config_dir();
-    let state_dir = cli.state_dir();
+    let CliPaths { config_dir, state_dir, socket_path } = cli.client_paths();
     let daemon = connect_cli_socket(
         &socket_path,
         &config_dir,
@@ -1870,11 +1881,11 @@ mod tests {
     };
 
     use super::{
-        attach_exit_disposition, client_dirs_from, confirm_command, default_project_landing, format_human_resource_value,
-        host_daemon_socket_required, provisioning_target_for_environment, replace_host_ids, run_replica_snapshot, select_host_target,
-        select_startup_repo_roots, should_reexec_for_incompatible_daemon, show_startup_splash, socket_path_from, AttachExitDisposition,
-        Cli, CommandValue, ResourceApplyArgs, ResourceDeleteArgs, ResourceGetArgs, ResourceListArgs, ResourceSubCommand, ResourceWatchArgs,
-        SubCommand,
+        attach_exit_disposition, client_dirs_from, confirm_command, daemon_paths_from, default_project_landing,
+        format_human_resource_value, host_daemon_socket_required, provisioning_target_for_environment, replace_host_ids,
+        run_replica_snapshot, select_host_target, select_startup_repo_roots, should_reexec_for_incompatible_daemon, show_startup_splash,
+        socket_path_from, AttachExitDisposition, Cli, CliPaths, CommandValue, ResourceApplyArgs, ResourceDeleteArgs, ResourceGetArgs,
+        ResourceListArgs, ResourceSubCommand, ResourceWatchArgs, SubCommand,
     };
 
     fn landing_repo(path: &str, name: &str, key: Option<&str>) -> RepoInfo {
@@ -2252,6 +2263,18 @@ mod tests {
     #[test]
     fn default_socket_uses_a_dedicated_runtime_directory() {
         assert_eq!(socket_path_from(None, Path::new("/config"), None), PathBuf::from("/config/run/flotilla.sock"));
+    }
+
+    #[test]
+    fn daemon_paths_use_only_explicit_values_and_policy_defaults() {
+        assert_eq!(
+            daemon_paths_from(None, Some(Path::new("/explicit/flotilla.sock")), Path::new("/default/config"), Path::new("/default/state"),),
+            CliPaths {
+                config_dir: PathBuf::from("/default/config"),
+                state_dir: PathBuf::from("/default/state"),
+                socket_path: PathBuf::from("/explicit/flotilla.sock"),
+            },
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -746,12 +746,12 @@ async fn run_daemon(cli: &Cli, timeout_secs: u64) -> Result<()> {
     let paths = PathPolicy::from_process_env();
     let config_dir = cli.config_dir();
     let socket_path = cli.socket_path();
-    flotilla_core::path_policy::ensure_daemon_socket_belongs_to_config(&socket_path, &config_dir)
+    let (config_dir, state_dir) = flotilla_core::path_policy::daemon_dirs_for_socket(&socket_path, &config_dir, paths.state_dir.as_path())
         .map_err(|error| color_eyre::eyre::eyre!(error))?;
     let mut command = tokio::process::Command::new(&daemon_binary);
     command.arg("--timeout").arg(timeout_secs.to_string());
     command.arg("--config-dir").arg(config_dir);
-    command.arg("--state-dir").arg(paths.state_dir.as_path());
+    command.arg("--state-dir").arg(state_dir);
     command.arg("--socket").arg(socket_path);
     let status = command.status().await?;
     if status.success() {


### PR DESCRIPTION
## What changed

- define the daemon socket owned by a config root as `<config-dir>/run/flotilla.sock` and reject mismatched root/socket pairs before connecting or spawning
- pass the resolved config directory, state directory, and socket explicitly to detached `flotillad` processes so ambient `FLOTILLA_ROOT` cannot change half of their identity
- apply the same identity validation to direct daemon startup
- cover a root-scoped client attempting to spawn on the default fleet socket, including proving no socket or spawn lock is created

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo test -p flotilla-core --locked --features test-support --test in_process_daemon`
- direct `flotillad` smoke test with `FLOTILLA_ROOT` scoped and a mismatched default socket (refused before bind)

Closes #1404
