### PR TITLE
fix: reclaim remote convoy resources safely

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/checkout.rs
+++ b/crates/flotilla-controllers/src/reconcilers/checkout.rs
@@ -8,8 +8,8 @@ use flotilla_core::checkout_integration::{
 use flotilla_resources::{
     controller::{Actuation, ReconcileOutcome, Reconciler, ReplicaConvoyCheckoutWatch, SecondaryWatch},
     Checkout, CheckoutBranchProvenance, CheckoutIntegrationStatus, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutStatusPatch, Clock,
-    Clone, ClonePhase, Convoy, ConvoyPhase, IntegrationCondition, ReplicaReadResolver, ResourceBackend, ResourceError, ResourceObject,
-    ResourceProvenance, SystemClock, TypedResolver, ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL,
+    Clone, ClonePhase, Convoy, ConvoyPhase, IntegrationCondition, LifecycleAuthority, ReplicaReadResolver, Resource, ResourceBackend,
+    ResourceError, ResourceObject, ResourceProvenance, SystemClock, TypedResolver, ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL,
 };
 use tracing::warn;
 
@@ -152,6 +152,7 @@ fn convoy_claims_checkout(convoy: &ResourceObject<Convoy>, checkout_name: &str) 
 
 pub enum CheckoutDeps {
     None,
+    OwnerTerminal,
     Ready { prepared: PreparedCheckout },
     Integration { status: Box<CheckoutIntegrationStatus> },
     RetryClone { clone_name: String, failed_at: DateTime<Utc> },
@@ -175,12 +176,13 @@ fn integration_is_fresh(status: &CheckoutStatus, now: DateTime<Utc>, max_age: Du
     now.signed_duration_since(oldest_observation).to_std().is_ok_and(|age| age < max_age)
 }
 
-/// Terminal convoys keep the Landing TTL because teardown consumes the same
-/// fresh evidence and no longer probes a checkout on demand.
 fn convoy_needs_terminal_evidence(convoy: Option<&ResourceObject<Convoy>>) -> bool {
-    convoy.and_then(|convoy| convoy.status.as_ref()).is_some_and(|status| {
-        status.phase == ConvoyPhase::Landing || (status.phase.is_terminal() && status.phase != ConvoyPhase::Abandoned)
-    })
+    convoy.and_then(|convoy| convoy.status.as_ref()).is_some_and(|status| status.phase == ConvoyPhase::Landing)
+}
+
+fn convoy_authorizes_checkout_reclaim(convoy: &ResourceObject<Convoy>) -> bool {
+    convoy.metadata.deletion_timestamp.is_some()
+        || convoy.status.as_ref().is_some_and(|status| matches!(status.phase, ConvoyPhase::Landed | ConvoyPhase::Abandoned))
 }
 
 impl<R> Reconciler for CheckoutReconciler<R>
@@ -191,8 +193,18 @@ where
     type Dependencies = CheckoutDeps;
 
     async fn fetch_dependencies(&self, obj: &ResourceObject<Self::Resource>) -> Result<Self::Dependencies, ResourceError> {
+        let lifecycle_authority = obj.metadata.lifecycle_authority()?;
+        let has_convoy_owner = obj.metadata.labels.contains_key(CONVOY_LABEL)
+            || obj.metadata.owner_references.iter().any(|owner| owner.kind == Convoy::API_PATHS.kind);
+        let convoy = self.owning_convoy(obj).await?;
+        if lifecycle_authority == Some(LifecycleAuthority::Managed)
+            && has_convoy_owner
+            && convoy.as_ref().is_some_and(convoy_authorizes_checkout_reclaim)
+        {
+            return Ok(CheckoutDeps::OwnerTerminal);
+        }
+
         if obj.status.as_ref().map(|status| status.phase).unwrap_or(CheckoutPhase::Pending) != CheckoutPhase::Pending {
-            let convoy = self.owning_convoy(obj).await?;
             let terminal_evidence = convoy_needs_terminal_evidence(convoy.as_ref());
             let refresh_after = if terminal_evidence { LANDING_EVIDENCE_TTL } else { CHECKOUT_INTEGRATION_REFRESH_AFTER };
             let expected_change_request_id = convoy.as_ref().and_then(|convoy| convoy_change_request_id_for_checkout(convoy, obj));
@@ -271,7 +283,7 @@ where
                     commit: prepared.commit.clone(),
                     branch_provenance: prepared.branch_provenance,
                 }),
-                CheckoutDeps::Integration { .. } => None,
+                CheckoutDeps::Integration { .. } | CheckoutDeps::OwnerTerminal => None,
                 CheckoutDeps::RetryClone { .. } => None,
                 CheckoutDeps::Failed(message) => Some(CheckoutStatusPatch::MarkFailed { message: message.clone() }),
                 CheckoutDeps::Waiting | CheckoutDeps::None => None,
@@ -302,13 +314,18 @@ where
                         change_request: None,
                     }),
                 }),
-                CheckoutDeps::None | CheckoutDeps::Ready { .. } | CheckoutDeps::RetryClone { .. } | CheckoutDeps::Waiting => None,
+                CheckoutDeps::None
+                | CheckoutDeps::OwnerTerminal
+                | CheckoutDeps::Ready { .. }
+                | CheckoutDeps::RetryClone { .. }
+                | CheckoutDeps::Waiting => None,
             }
         } else {
             None
         };
 
         let actuations = match deps {
+            CheckoutDeps::OwnerTerminal => vec![Actuation::DeleteCheckout { name: obj.metadata.name.clone() }],
             CheckoutDeps::RetryClone { clone_name, failed_at } => {
                 vec![Actuation::RetryClone { name: clone_name.clone(), failed_at: *failed_at }]
             }

--- a/crates/flotilla-controllers/src/reconcilers/checkout.rs
+++ b/crates/flotilla-controllers/src/reconcilers/checkout.rs
@@ -177,9 +177,9 @@ fn integration_is_fresh(status: &CheckoutStatus, now: DateTime<Utc>, max_age: Du
 }
 
 fn convoy_needs_terminal_evidence(convoy: Option<&ResourceObject<Convoy>>) -> bool {
-    convoy
-        .and_then(|convoy| convoy.status.as_ref())
-        .is_some_and(|status| matches!(status.phase, ConvoyPhase::Landing | ConvoyPhase::Failed | ConvoyPhase::Cancelled))
+    convoy.and_then(|convoy| convoy.status.as_ref()).is_some_and(|status| {
+        matches!(status.phase, ConvoyPhase::Landing | ConvoyPhase::Landed | ConvoyPhase::Failed | ConvoyPhase::Cancelled)
+    })
 }
 
 fn convoy_authorizes_checkout_reclaim(convoy: &ResourceObject<Convoy>) -> bool {

--- a/crates/flotilla-controllers/src/reconcilers/checkout.rs
+++ b/crates/flotilla-controllers/src/reconcilers/checkout.rs
@@ -177,7 +177,9 @@ fn integration_is_fresh(status: &CheckoutStatus, now: DateTime<Utc>, max_age: Du
 }
 
 fn convoy_needs_terminal_evidence(convoy: Option<&ResourceObject<Convoy>>) -> bool {
-    convoy.and_then(|convoy| convoy.status.as_ref()).is_some_and(|status| status.phase == ConvoyPhase::Landing)
+    convoy
+        .and_then(|convoy| convoy.status.as_ref())
+        .is_some_and(|status| matches!(status.phase, ConvoyPhase::Landing | ConvoyPhase::Failed | ConvoyPhase::Cancelled))
 }
 
 fn convoy_authorizes_checkout_reclaim(convoy: &ResourceObject<Convoy>) -> bool {

--- a/crates/flotilla-controllers/src/reconcilers/terminal_session.rs
+++ b/crates/flotilla-controllers/src/reconcilers/terminal_session.rs
@@ -138,6 +138,11 @@ where
     type Dependencies = TerminalDeps;
 
     async fn fetch_dependencies(&self, obj: &ResourceObject<Self::Resource>) -> Result<Self::Dependencies, ResourceError> {
+        let environment = match self.environments.get(&obj.spec.env_ref).await {
+            Ok(environment) => environment,
+            Err(ResourceError::NotFound { .. }) => return Ok(TerminalDeps::OwnerMissing),
+            Err(err) => return Err(err),
+        };
         if self.session_owner_missing(obj).await? {
             return Ok(TerminalDeps::OwnerMissing);
         }
@@ -175,11 +180,6 @@ where
             return Ok(TerminalDeps::None);
         }
 
-        let environment = match self.environments.get(&obj.spec.env_ref).await {
-            Ok(environment) => environment,
-            Err(ResourceError::NotFound { .. }) => return Ok(TerminalDeps::Waiting),
-            Err(err) => return Err(err),
-        };
         if environment.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Ready) {
             return Ok(TerminalDeps::Waiting);
         }

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -25,6 +25,7 @@ use flotilla_resources::{
     ACTUATOR_SOURCE_ROOT_ANNOTATION, CHANGE_REQUEST_ID_LABEL, CONVOY_LABEL, CREDENTIAL_REFS_ANNOTATION, CREDENTIAL_REFS_ENV,
     CREDENTIAL_SCOPES_ANNOTATION, CREDENTIAL_SCOPES_ENV, VESSEL_REF_LABEL,
 };
+use sha2::{Digest, Sha256};
 use tracing::warn;
 
 const REPO_KEY_LABEL: &str = "flotilla.work/repo-key";
@@ -558,12 +559,18 @@ impl Reconciler for VesselReconciler {
                 None
             };
             let checkout_name = adopted_checkout_ref.clone().unwrap_or_else(|| match &strategy {
-                PlacementStrategy::HostDirect { .. } | PlacementStrategy::DockerWorktreeOnHostAndMount { .. } => {
-                    checkout_name(&convoy.metadata.name, &convoy_repository.workspace_slug, multi_repository)
-                }
-                PlacementStrategy::DockerFreshCloneInContainer { .. } => {
-                    checkout_name(&obj.metadata.name, &convoy_repository.workspace_slug, multi_repository)
-                }
+                PlacementStrategy::HostDirect { .. } | PlacementStrategy::DockerWorktreeOnHostAndMount { .. } => checkout_name(
+                    &convoy.metadata.name,
+                    &convoy_repository.workspace_slug,
+                    multi_repository,
+                    checkout_placement_scope(&convoy, self.local_host_ref.as_deref()).as_deref(),
+                ),
+                PlacementStrategy::DockerFreshCloneInContainer { .. } => checkout_name(
+                    &obj.metadata.name,
+                    &convoy_repository.workspace_slug,
+                    multi_repository,
+                    checkout_placement_scope(&convoy, self.local_host_ref.as_deref()).as_deref(),
+                ),
             });
             let checkout_target_path = match &strategy {
                 PlacementStrategy::HostDirect { .. } | PlacementStrategy::DockerWorktreeOnHostAndMount { .. } => {
@@ -1205,12 +1212,25 @@ fn environment_name(vessel_name: &str) -> String {
     format!("env-{vessel_name}")
 }
 
-fn checkout_name(vessel_name: &str, workspace_slug: &str, multi_repository: bool) -> String {
-    if multi_repository {
-        format!("checkout-{vessel_name}-{workspace_slug}")
-    } else {
-        format!("checkout-{vessel_name}")
+fn checkout_name(vessel_name: &str, workspace_slug: &str, multi_repository: bool, placement_scope: Option<&str>) -> String {
+    let repository_suffix = if multi_repository { format!("-{workspace_slug}") } else { String::new() };
+    let placement_suffix = placement_scope.map(|scope| format!("-{scope}")).unwrap_or_default();
+    format!("checkout-{vessel_name}{repository_suffix}{placement_suffix}")
+}
+
+fn checkout_placement_scope(convoy: &ResourceObject<Convoy>, host_ref: Option<&str>) -> Option<String> {
+    let host_ref = host_ref?;
+    let mut hash = Sha256::new();
+    hash.update(b"managed-checkout-placement-v1\0");
+    hash.update(host_ref.as_bytes());
+    hash.update([0]);
+    hash.update(convoy.metadata.creation_timestamp.to_rfc3339().as_bytes());
+    hash.update([0]);
+    if let Some(origin_root) = convoy.metadata.annotations.get(ACTUATOR_SOURCE_ROOT_ANNOTATION) {
+        hash.update(origin_root.as_bytes());
     }
+    let digest = format!("{:x}", hash.finalize());
+    Some(digest[..12].to_string())
 }
 
 fn checkout_path_component(branch: &str) -> String {
@@ -1341,9 +1361,9 @@ mod tests {
     };
 
     use flotilla_protocol::{PlacementDecision, PlacementTargetHost};
-    use flotilla_resources::ResourceBackend;
+    use flotilla_resources::{Convoy, ConvoySpec, InputMeta, ResourceBackend};
 
-    use super::{environment_with_credentials, legible_waiting_for, VesselReconciler};
+    use super::{checkout_name, checkout_placement_scope, environment_with_credentials, legible_waiting_for, VesselReconciler};
 
     #[derive(Clone)]
     struct LogCaptureWriter(Arc<Mutex<Vec<u8>>>);
@@ -1357,6 +1377,31 @@ mod tests {
         fn flush(&mut self) -> std::io::Result<()> {
             Ok(())
         }
+    }
+
+    #[tokio::test]
+    async fn managed_checkout_names_are_scoped_by_placement_and_dispatch_attempt() {
+        let backend = ResourceBackend::InMemory(Default::default());
+        let convoy = backend
+            .using::<Convoy>("flotilla")
+            .create(
+                &InputMeta::builder().name("same-name".to_string()).build(),
+                &ConvoySpec::builder().workflow_ref("scratch".to_string()).build(),
+            )
+            .await
+            .expect("create convoy");
+        let mut later_attempt = convoy.clone();
+        later_attempt.metadata.creation_timestamp += chrono::Duration::seconds(1);
+
+        let feta = checkout_placement_scope(&convoy, Some("feta-host")).expect("feta scope");
+        let kiwi = checkout_placement_scope(&convoy, Some("kiwi-host")).expect("kiwi scope");
+        let later_feta = checkout_placement_scope(&later_attempt, Some("feta-host")).expect("later feta scope");
+
+        assert_ne!(checkout_name("same-name", "flotilla", false, Some(&feta)), checkout_name("same-name", "flotilla", false, Some(&kiwi)));
+        assert_ne!(
+            checkout_name("same-name", "flotilla", false, Some(&feta)),
+            checkout_name("same-name", "flotilla", false, Some(&later_feta))
+        );
     }
 
     #[test]

--- a/crates/flotilla-controllers/tests/checkout_reconciler.rs
+++ b/crates/flotilla-controllers/tests/checkout_reconciler.rs
@@ -413,7 +413,7 @@ async fn ready_checkout_reconciler_skips_fresh_integration_probe() {
 
 #[tokio::test]
 async fn checkout_authority_observes_when_replicated_convoy_needs_terminal_evidence() {
-    for phase in [ConvoyPhase::Landing, ConvoyPhase::Failed, ConvoyPhase::Cancelled] {
+    for phase in [ConvoyPhase::Landing, ConvoyPhase::Landed, ConvoyPhase::Failed, ConvoyPhase::Cancelled] {
         let authority_root = NodeId::new("convoy-authority");
         let checkout_root = NodeId::new("checkout-authority");
         let authority = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(authority_root.clone());
@@ -446,7 +446,8 @@ async fn checkout_authority_observes_when_replicated_convoy_needs_terminal_evide
                     .name("remote-checkout".to_string())
                     .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "cross-host".to_string())]))
                     .annotations(BTreeMap::from([(ACTUATOR_SOURCE_ROOT_ANNOTATION.to_string(), "convoy-authority".to_string())]))
-                    .build(),
+                    .build()
+                    .with_lifecycle_authority(LifecycleAuthority::Adopted),
                 &CheckoutSpec::FreshClone(FreshCloneCheckoutSpec {
                     repo_ref: RepositoryKey(repo_key(REPO_URL)),
                     env_ref: "host-direct-checkout-authority".to_string(),

--- a/crates/flotilla-controllers/tests/checkout_reconciler.rs
+++ b/crates/flotilla-controllers/tests/checkout_reconciler.rs
@@ -17,10 +17,10 @@ use flotilla_controllers::reconcilers::{
 use flotilla_protocol::NodeId;
 use flotilla_resources::{
     apply_status_patch,
-    controller::{ControllerLoop, Reconciler},
+    controller::{Actuation, ControllerLoop, Reconciler},
     repo_key, Checkout, CheckoutBranchProvenance, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutWorktreeSpec, Clone, CloneSpec,
     CloneStatusPatch, ConditionValue, Convoy, ConvoyPhase, ConvoySpec, ConvoyStatus, FreshCloneCheckoutSpec, InMemoryBackend, InputMeta,
-    IntegrationCondition, RepositoryKey, ResourceBackend, ResourceError, ResourceObject, StatusPatch, VirtualClock,
+    IntegrationCondition, LifecycleAuthority, RepositoryKey, ResourceBackend, ResourceError, ResourceObject, StatusPatch, VirtualClock,
     ACTUATOR_SOURCE_ROOT_ANNOTATION, CHANGE_REQUEST_ID_LABEL, CONVOY_LABEL,
 };
 use tokio::time::timeout;
@@ -485,6 +485,65 @@ async fn checkout_authority_observes_when_replicated_convoy_enters_landing() {
 
     assert!(matches!(deps, CheckoutDeps::Integration { .. }), "Landing must shorten the observation TTL to 30 seconds");
     assert_eq!(*runtime.inspections.lock().expect("inspections lock"), 1, "only the checkout authority should probe its checkout");
+}
+
+#[tokio::test]
+async fn checkout_authority_reclaims_managed_checkout_when_replicated_convoy_is_landed() {
+    let authority_root = NodeId::new("convoy-authority");
+    let checkout_host = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(NodeId::new("checkout-authority"));
+    let authority = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(authority_root.clone());
+    let convoys = authority.clone().using::<Convoy>(NAMESPACE);
+    let convoy = convoys
+        .create(
+            &InputMeta::builder().name("cross-host".to_string()).build(),
+            &ConvoySpec::builder().workflow_ref("review-and-fix".to_string()).build(),
+        )
+        .await
+        .expect("create authority convoy");
+    convoys
+        .update_status(&convoy.metadata.name, &convoy.metadata.resource_version, &ConvoyStatus {
+            phase: ConvoyPhase::Landed,
+            ..Default::default()
+        })
+        .await
+        .expect("mark convoy Landed");
+    checkout_host
+        .replica_writer::<Convoy>(authority_root, NAMESPACE)
+        .replace(&convoys.list().await.expect("list authority convoys"), chrono::Utc::now())
+        .await
+        .expect("replicate convoy to checkout host");
+
+    let checkout = checkout_host
+        .clone()
+        .using::<Checkout>(NAMESPACE)
+        .create(
+            &InputMeta::builder()
+                .name("remote-checkout".to_string())
+                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "cross-host".to_string())]))
+                .annotations(BTreeMap::from([(ACTUATOR_SOURCE_ROOT_ANNOTATION.to_string(), "convoy-authority".to_string())]))
+                .build()
+                .with_lifecycle_authority(LifecycleAuthority::Managed),
+            &CheckoutSpec::FreshClone(FreshCloneCheckoutSpec {
+                repo_ref: RepositoryKey(repo_key(REPO_URL)),
+                env_ref: "host-direct-checkout-authority".to_string(),
+                r#ref: "feature/cross-host".to_string(),
+                base_ref: Some("main".to_string()),
+                target_path: "/checkouts/cross-host".to_string(),
+                url: REPO_URL.to_string(),
+            }),
+        )
+        .await
+        .expect("create managed checkout");
+    let runtime = Arc::new(RecordingCheckoutRuntime::default());
+    let reconciler =
+        CheckoutReconciler::new(Arc::clone(&runtime), checkout_host.clone(), NAMESPACE).with_federated_convoys(&checkout_host, NAMESPACE);
+
+    let deps = reconciler.fetch_dependencies(&checkout).await.expect("resolve replicated Landed convoy");
+    let outcome = reconciler.reconcile(&checkout, &deps, chrono::Utc::now());
+
+    assert!(matches!(deps, CheckoutDeps::OwnerTerminal));
+    assert!(matches!(outcome.actuations.as_slice(), [Actuation::DeleteCheckout { name }] if name == "remote-checkout"));
+    assert_eq!(*runtime.inspections.lock().expect("inspections lock"), 0, "Landed is durable settlement evidence");
 }
 
 #[tokio::test]

--- a/crates/flotilla-controllers/tests/checkout_reconciler.rs
+++ b/crates/flotilla-controllers/tests/checkout_reconciler.rs
@@ -412,79 +412,78 @@ async fn ready_checkout_reconciler_skips_fresh_integration_probe() {
 }
 
 #[tokio::test]
-async fn checkout_authority_observes_when_replicated_convoy_enters_landing() {
-    let authority_root = NodeId::new("convoy-authority");
-    let checkout_root = NodeId::new("checkout-authority");
-    let authority = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(authority_root.clone());
-    let checkout_host = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(checkout_root);
-    let now = chrono::DateTime::parse_from_rfc3339("2026-08-03T21:45:00Z").expect("timestamp").with_timezone(&chrono::Utc);
-    let clock = Arc::new(VirtualClock::new(now));
+async fn checkout_authority_observes_when_replicated_convoy_needs_terminal_evidence() {
+    for phase in [ConvoyPhase::Landing, ConvoyPhase::Failed, ConvoyPhase::Cancelled] {
+        let authority_root = NodeId::new("convoy-authority");
+        let checkout_root = NodeId::new("checkout-authority");
+        let authority = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(authority_root.clone());
+        let checkout_host = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(checkout_root);
+        let now = chrono::DateTime::parse_from_rfc3339("2026-08-03T21:45:00Z").expect("timestamp").with_timezone(&chrono::Utc);
+        let clock = Arc::new(VirtualClock::new(now));
 
-    let convoys = authority.clone().using::<Convoy>(NAMESPACE);
-    let convoy = convoys
-        .create(
-            &InputMeta::builder().name("cross-host".to_string()).build(),
-            &ConvoySpec::builder().workflow_ref("review-and-fix".to_string()).build(),
-        )
-        .await
-        .expect("create authority convoy");
-    convoys
-        .update_status(&convoy.metadata.name, &convoy.metadata.resource_version, &ConvoyStatus {
-            phase: ConvoyPhase::Landing,
-            ..Default::default()
-        })
-        .await
-        .expect("mark convoy Landing");
-    checkout_host
-        .replica_writer::<Convoy>(authority_root, NAMESPACE)
-        .replace(&convoys.list().await.expect("list authority convoys"), now)
-        .await
-        .expect("replicate convoy to checkout host");
+        let convoys = authority.clone().using::<Convoy>(NAMESPACE);
+        let convoy = convoys
+            .create(
+                &InputMeta::builder().name("cross-host".to_string()).build(),
+                &ConvoySpec::builder().workflow_ref("review-and-fix".to_string()).build(),
+            )
+            .await
+            .expect("create authority convoy");
+        convoys
+            .update_status(&convoy.metadata.name, &convoy.metadata.resource_version, &ConvoyStatus { phase, ..Default::default() })
+            .await
+            .expect("mark convoy in evidence-consuming phase");
+        checkout_host
+            .replica_writer::<Convoy>(authority_root, NAMESPACE)
+            .replace(&convoys.list().await.expect("list authority convoys"), now)
+            .await
+            .expect("replicate convoy to checkout host");
 
-    let checkouts = checkout_host.clone().using::<Checkout>(NAMESPACE);
-    let checkout = checkouts
-        .create(
-            &InputMeta::builder()
-                .name("remote-checkout".to_string())
-                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "cross-host".to_string())]))
-                .annotations(BTreeMap::from([(ACTUATOR_SOURCE_ROOT_ANNOTATION.to_string(), "convoy-authority".to_string())]))
-                .build(),
-            &CheckoutSpec::FreshClone(FreshCloneCheckoutSpec {
-                repo_ref: RepositoryKey(repo_key(REPO_URL)),
-                env_ref: "host-direct-checkout-authority".to_string(),
-                r#ref: "feature/cross-host".to_string(),
-                base_ref: Some("main".to_string()),
-                target_path: "/checkouts/cross-host".to_string(),
-                url: REPO_URL.to_string(),
-            }),
-        )
-        .await
-        .expect("create checkout on its authority host");
-    let observed_at = (now - chrono::Duration::seconds(31)).to_rfc3339();
-    checkouts
-        .update_status(&checkout.metadata.name, &checkout.metadata.resource_version, &CheckoutStatus {
-            phase: CheckoutPhase::Ready,
-            path: Some("/checkouts/cross-host".to_string()),
-            integration: flotilla_resources::CheckoutIntegrationStatus {
-                clean: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observed_at.clone()).build(),
-                pushed: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observed_at.clone()).build(),
-                landed: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observed_at).build(),
+        let checkouts = checkout_host.clone().using::<Checkout>(NAMESPACE);
+        let checkout = checkouts
+            .create(
+                &InputMeta::builder()
+                    .name("remote-checkout".to_string())
+                    .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "cross-host".to_string())]))
+                    .annotations(BTreeMap::from([(ACTUATOR_SOURCE_ROOT_ANNOTATION.to_string(), "convoy-authority".to_string())]))
+                    .build(),
+                &CheckoutSpec::FreshClone(FreshCloneCheckoutSpec {
+                    repo_ref: RepositoryKey(repo_key(REPO_URL)),
+                    env_ref: "host-direct-checkout-authority".to_string(),
+                    r#ref: "feature/cross-host".to_string(),
+                    base_ref: Some("main".to_string()),
+                    target_path: "/checkouts/cross-host".to_string(),
+                    url: REPO_URL.to_string(),
+                }),
+            )
+            .await
+            .expect("create checkout on its authority host");
+        let observed_at = (now - chrono::Duration::seconds(31)).to_rfc3339();
+        checkouts
+            .update_status(&checkout.metadata.name, &checkout.metadata.resource_version, &CheckoutStatus {
+                phase: CheckoutPhase::Ready,
+                path: Some("/checkouts/cross-host".to_string()),
+                integration: flotilla_resources::CheckoutIntegrationStatus {
+                    clean: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observed_at.clone()).build(),
+                    pushed: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observed_at.clone()).build(),
+                    landed: IntegrationCondition::builder().value(ConditionValue::True).observed_at(observed_at).build(),
+                    ..Default::default()
+                },
                 ..Default::default()
-            },
-            ..Default::default()
-        })
-        .await
-        .expect("record pre-Landing evidence");
+            })
+            .await
+            .expect("record pre-Landing evidence");
 
-    let checkout = checkouts.get("remote-checkout").await.expect("get checkout");
-    let runtime = Arc::new(RecordingCheckoutRuntime::default());
-    let reconciler = CheckoutReconciler::with_clock(runtime.clone(), checkout_host.clone(), NAMESPACE, clock)
-        .with_federated_convoys(&checkout_host, NAMESPACE);
+        let checkout = checkouts.get("remote-checkout").await.expect("get checkout");
+        let runtime = Arc::new(RecordingCheckoutRuntime::default());
+        let reconciler = CheckoutReconciler::with_clock(runtime.clone(), checkout_host.clone(), NAMESPACE, clock)
+            .with_federated_convoys(&checkout_host, NAMESPACE);
 
-    let deps = reconciler.fetch_dependencies(&checkout).await.expect("resolve replicated Landing convoy");
+        let deps = reconciler.fetch_dependencies(&checkout).await.expect("resolve replicated evidence-consuming convoy");
 
-    assert!(matches!(deps, CheckoutDeps::Integration { .. }), "Landing must shorten the observation TTL to 30 seconds");
-    assert_eq!(*runtime.inspections.lock().expect("inspections lock"), 1, "only the checkout authority should probe its checkout");
+        assert!(matches!(deps, CheckoutDeps::Integration { .. }), "{phase:?} must shorten the observation TTL to 30 seconds");
+        assert_eq!(*runtime.inspections.lock().expect("inspections lock"), 1, "only the checkout authority should probe its checkout");
+    }
 }
 
 #[tokio::test]

--- a/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
+++ b/crates/flotilla-controllers/tests/terminal_session_reconciler.rs
@@ -16,14 +16,28 @@ use flotilla_resources::{
         run_transition_sequence, FixpointPredicate, LivenessEnrollment, LivenessScenario, LivenessStep, ReconcileStep, Transition,
         TransitionDriver, TransitionSequence, WorldBuilder,
     },
-    Convoy, ConvoyPhase, EnvironmentSpec, EnvironmentStatus, EnvironmentStatusPatch, HostDirectEnvironmentSpec, InputMeta, ResourceBackend,
-    ResourceError, ResourceObject, StatusPatch, TerminalAttention, TerminalAttentionSource, TerminalAttentionState, TerminalSession,
-    TerminalSessionPhase, TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch, VirtualClock, CONVOY_LABEL,
-    CREDENTIAL_SCOPES_ANNOTATION, CREDENTIAL_SCOPES_SESSION_TAG, VESSEL_REF_LABEL,
+    Convoy, ConvoyPhase, EnvironmentSpec, EnvironmentStatus, EnvironmentStatusPatch, HostDirectEnvironmentSpec, InputMeta,
+    LifecycleAuthority, ResourceBackend, ResourceError, ResourceObject, StatusPatch, TerminalAttention, TerminalAttentionSource,
+    TerminalAttentionState, TerminalSession, TerminalSessionPhase, TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch,
+    VirtualClock, CONVOY_LABEL, CREDENTIAL_SCOPES_ANNOTATION, CREDENTIAL_SCOPES_SESSION_TAG, VESSEL_REF_LABEL,
 };
 
 mod common;
 use common::{create_convoy_with_single_task, meta};
+
+async fn create_ready_environment(backend: &ResourceBackend, name: &str) {
+    let environments = backend.clone().using::<flotilla_resources::Environment>("flotilla");
+    let environment = environments
+        .create(&meta(name), &EnvironmentSpec {
+            host_direct: Some(HostDirectEnvironmentSpec { host_ref: "01HXYZ".to_string(), repo_default_dir: "/workspace".to_string() }),
+            docker: None,
+        })
+        .await
+        .expect("create environment");
+    let mut status = EnvironmentStatus::default();
+    EnvironmentStatusPatch::MarkReady { docker_container_id: None, image_ref: None, image_digest: None }.apply(&mut status);
+    environments.update_status(name, &environment.metadata.resource_version, &status).await.expect("mark environment ready");
+}
 
 #[tokio::test]
 async fn terminal_session_failure_uses_injected_now_for_stopped_at() {
@@ -87,6 +101,32 @@ impl TerminalRuntime for FailingTerminalRuntime {
     async fn kill_session(&self, _session_id: &str, _spec: &TerminalSessionSpec) -> Result<(), String> {
         Ok(())
     }
+}
+
+#[tokio::test]
+async fn terminal_session_is_reclaimed_when_its_environment_is_gone() {
+    let backend = ResourceBackend::InMemory(Default::default());
+    let session = backend
+        .clone()
+        .using::<TerminalSession>("flotilla")
+        .create(&meta("terminal-orphan").with_lifecycle_authority(LifecycleAuthority::Managed), &TerminalSessionSpec {
+            env_ref: "deleted-environment".to_string(),
+            role: "coder".to_string(),
+            source: flotilla_resources::TerminalSessionSource::Tool { command: "cargo test".to_string() },
+            cwd: "/workspace".to_string(),
+            pool: "cleat".to_string(),
+        })
+        .await
+        .expect("create orphaned terminal session");
+    let reconciler = TerminalSessionReconciler::new(Arc::new(RecordingTerminalRuntime::default()), backend, "flotilla");
+
+    let deps = reconciler.fetch_dependencies(&session).await.expect("missing environment should be lifecycle state");
+    let outcome = reconciler.reconcile(&session, &deps, Utc::now());
+
+    assert!(matches!(
+        outcome.actuations.as_slice(),
+        [Actuation::DeleteTerminalSession { name }] if name == "terminal-orphan"
+    ));
 }
 
 #[tokio::test]
@@ -164,6 +204,7 @@ impl TerminalRuntime for UnavailableRunningRuntime {
 #[tokio::test(start_paused = true)]
 async fn repeated_runtime_probe_failure_becomes_visible_and_stops_retrying() {
     let backend = ResourceBackend::InMemory(Default::default());
+    create_ready_environment(&backend, "env-a").await;
     create_convoy_with_single_task(&backend, "flotilla", "demo", "work", "https://github.com/flotilla-org/flotilla", "main").await;
     let convoys = backend.clone().using::<Convoy>("flotilla");
     let sessions = backend.clone().using::<TerminalSession>("flotilla");
@@ -594,6 +635,7 @@ impl TerminalRuntime for TagRecordingRuntime {
 #[tokio::test]
 async fn a_disappeared_running_session_is_observed_as_stopped() {
     let backend = ResourceBackend::InMemory(Default::default());
+    create_ready_environment(&backend, "env-a").await;
     create_convoy_with_single_task(&backend, "flotilla", "demo", "implement", "https://github.com/flotilla-org/flotilla", "main").await;
     let sessions = backend.clone().using::<flotilla_resources::TerminalSession>("flotilla");
     let created = sessions
@@ -667,6 +709,7 @@ impl TerminalRuntime for MissingTerminalRuntime {
 #[tokio::test]
 async fn a_message_queued_during_startup_is_delivered_before_attention_observation() {
     let backend = ResourceBackend::InMemory(Default::default());
+    create_ready_environment(&backend, "env-a").await;
     create_convoy_with_single_task(&backend, "flotilla", "demo", "review", "https://github.com/flotilla-org/flotilla", "main").await;
     let sessions = backend.clone().using::<flotilla_resources::TerminalSession>("flotilla");
     let created = sessions
@@ -839,6 +882,7 @@ impl TerminalRuntime for DeliveringTerminalRuntime {
 #[tokio::test]
 async fn stale_hook_attention_decays_to_unobservable_without_changing_phase() {
     let backend = ResourceBackend::InMemory(Default::default());
+    create_ready_environment(&backend, "env-a").await;
     let sessions = backend.clone().using::<flotilla_resources::TerminalSession>("flotilla");
     let created = sessions
         .create(&meta("term-a"), &TerminalSessionSpec {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -6788,12 +6788,9 @@ impl InProcessDaemon {
             return Ok(());
         }
 
-        let checkouts = self.resource_backend.clone().using::<ResourceCheckout>(namespace);
-        let checkout_list = checkouts
-            .list_matching_labels(&BTreeMap::from([(CONVOY_LABEL.to_string(), name.to_string())]))
-            .await
-            .map_err(|err| err.to_string())?
-            .items;
+        let checkout_sources =
+            self.resource_backend.including_replicas::<ResourceCheckout>(namespace).list().await.map_err(|err| err.to_string())?;
+        let checkout_list = flotilla_resources::select_convoy_children(&convoy, &checkout_sources.items).into_values().collect::<Vec<_>>();
         self.verify_convoy_teardown_gate_for_checkouts(&convoy, &checkout_list, false).await
     }
 

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1312,6 +1312,36 @@ async fn convoy_explanation_and_resource_get_read_remote_replicas() {
     assert!(matches!(fetched.records[0].provenance, flotilla_protocol::ResourceRecordProvenance::Replica { .. }));
 }
 
+#[tokio::test]
+async fn convoy_teardown_gate_reads_checkout_replicas() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    create_explanation_convoy(&backend, "replica-gate", Some("remote-checkout"), Some((ConditionValue::True, Utc::now()))).await;
+    let checkouts = backend.clone().using::<ResourceCheckout>("flotilla");
+    let checkout = checkouts.get("remote-checkout").await.expect("local checkout fixture");
+    let observed_at = Utc::now().to_rfc3339();
+    let condition = || IntegrationCondition::builder().value(ConditionValue::True).observed_at(observed_at.clone()).build();
+    checkouts
+        .update_status("remote-checkout", &checkout.metadata.resource_version, &ResourceCheckoutStatus {
+            phase: ResourceCheckoutPhase::Ready,
+            integration: CheckoutIntegrationStatus { clean: condition(), pushed: condition(), landed: condition(), ..Default::default() },
+            ..Default::default()
+        })
+        .await
+        .expect("record safe integration evidence");
+    backend
+        .replica_writer::<ResourceCheckout>(NodeId::new("checkout-authority"), "flotilla")
+        .replace(&checkouts.list().await.expect("list checkout authority resources"), Utc::now())
+        .await
+        .expect("replicate checkout");
+    checkouts.delete("remote-checkout").await.expect("remove local fixture so only replica remains");
+    let (daemon, _temp) = explanation_daemon(backend).await;
+
+    daemon
+        .verify_convoy_teardown_gate("flotilla", "replica-gate", false)
+        .await
+        .expect("replica-inclusive gate should accept the checkout authority's evidence");
+}
+
 async fn wait_for_command_result(events: &mut tokio::sync::broadcast::Receiver<DaemonEvent>, command_id: u64) -> CommandValue {
     tokio::time::timeout(std::time::Duration::from_secs(2), async {
         loop {

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -546,6 +546,20 @@ impl Reconciler for ConvoyReconciler {
         if let Some(checkouts) = &self.checkouts {
             delete_lifecycle_owned_matching(checkouts, &selector).await?;
         }
+        if let Some(checkouts) = &self.federated_checkouts {
+            let remaining = federated_children(checkouts, obj)
+                .await?
+                .into_values()
+                .filter(|checkout| checkout.metadata.lifecycle_authority() == Ok(Some(LifecycleAuthority::Managed)))
+                .map(|checkout| checkout.metadata.name)
+                .collect::<Vec<_>>();
+            if !remaining.is_empty() {
+                return Err(ResourceError::other(format!(
+                    "waiting for checkout authorities to finalize convoy children: {}",
+                    remaining.join(", ")
+                )));
+            }
+        }
         if let Some(collector) = &self.prepared_snapshot_gc {
             collector.collect(Some(&obj.metadata.name)).await?;
         }

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -235,6 +235,55 @@ async fn convoy_finalizer_deletes_orphaned_terminal_sessions() {
     assert!(matches!(sessions.get("terminal-convoy-a-work-coder").await, Err(flotilla_resources::ResourceError::NotFound { .. })));
 }
 
+#[tokio::test]
+async fn convoy_finalizer_waits_for_remote_checkout_authority() {
+    let authority = ResourceBackend::InMemory(InMemoryBackend::default());
+    let remote = ResourceBackend::InMemory(InMemoryBackend::default());
+    let convoy =
+        authority.clone().using::<Convoy>("flotilla").create(&convoy_meta("convoy-a"), &valid_convoy_spec()).await.expect("create convoy");
+    let remote_checkouts = remote.clone().using::<Checkout>("flotilla");
+    remote_checkouts
+        .create(
+            &InputMeta::builder()
+                .name("checkout-convoy-a-feta".to_string())
+                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "convoy-a".to_string())]))
+                .build()
+                .with_lifecycle_authority(LifecycleAuthority::Managed),
+            &CheckoutSpec::Worktree(CheckoutWorktreeSpec {
+                repo_ref: RepositoryKey("repo-a".to_string()),
+                env_ref: "host-direct-feta".to_string(),
+                r#ref: "feature/a".to_string(),
+                base_ref: Some("main".to_string()),
+                target_path: "/checkouts/a".to_string(),
+                clone_ref: "clone-a".to_string(),
+            }),
+        )
+        .await
+        .expect("create remote checkout");
+    let remote_root = flotilla_protocol::NodeId::new("feta-root");
+    authority
+        .replica_writer::<Checkout>(remote_root.clone(), "flotilla")
+        .replace(&remote_checkouts.list().await.expect("list remote checkouts"), chrono::Utc::now())
+        .await
+        .expect("replicate checkout");
+    let reconciler = ConvoyReconciler::new(authority.clone().using::<WorkflowTemplate>("flotilla"))
+        .with_checkouts(authority.clone().using::<Checkout>("flotilla"))
+        .with_federated_checkouts(authority.clone().including_replicas::<Checkout>("flotilla"));
+
+    let error = reconciler.run_finalizer(&convoy).await.expect_err("remote checkout should hold convoy finalization");
+    assert!(error.to_string().contains("checkout-convoy-a-feta"));
+
+    authority
+        .replica_writer::<Checkout>(remote_root, "flotilla")
+        .replace(
+            &flotilla_resources::ResourceList { items: Vec::new(), resource_version: "2".to_string(), generation: None },
+            chrono::Utc::now(),
+        )
+        .await
+        .expect("replicate remote checkout deletion");
+    reconciler.run_finalizer(&convoy).await.expect("finalizer should complete after authority cleanup");
+}
+
 fn vessel_meta(name: &str, convoy_name: &str, task: &str) -> InputMeta {
     let repository_key =
         flotilla_resources::RepositorySpec::remote("https://github.com/flotilla-org/flotilla").expect("repository identity").key();

--- a/src/main.rs
+++ b/src/main.rs
@@ -300,6 +300,9 @@ struct ResourceListArgs {
     /// Show only records authored by the queried host
     #[arg(long)]
     local_only: bool,
+    /// Include read-only replicas from peer roots (the default)
+    #[arg(long, conflicts_with = "local_only")]
+    include_replicas: bool,
 }
 
 #[derive(clap::Args)]
@@ -1085,7 +1088,7 @@ async fn run_resource_command(cli: &Cli, command: ResourceSubCommand, format: Ou
                         .kind(args.kind)
                         .namespace(args.namespace)
                         .maybe_node_id(node_id.clone())
-                        .include_replicas(!args.local_only)
+                        .include_replicas(args.include_replicas || !args.local_only)
                         .build(),
                 )
                 .await
@@ -2093,8 +2096,29 @@ mod tests {
         assert!(matches!(
             list.command,
             Some(SubCommand::Resource {
-                command: ResourceSubCommand::List(ResourceListArgs { kind, namespace, host: Some(host), local_only: false })
+                command: ResourceSubCommand::List(ResourceListArgs {
+                    kind,
+                    namespace,
+                    host: Some(host),
+                    local_only: false,
+                    include_replicas: false,
+                })
             }) if kind == "convoys" && namespace == "flotilla" && host == "feta"
+        ));
+
+        let include_replicas = Cli::try_parse_from(["flotilla", "resource", "list", "hosts", "--include-replicas"])
+            .expect("legacy explicit replica selection should still parse");
+        assert!(matches!(
+            include_replicas.command,
+            Some(SubCommand::Resource {
+                command: ResourceSubCommand::List(ResourceListArgs {
+                    kind,
+                    namespace,
+                    host: None,
+                    local_only: false,
+                    include_replicas: true,
+                })
+            }) if kind == "hosts" && namespace == "flotilla"
         ));
 
         let get = Cli::try_parse_from(["flotilla", "resource", "get", "convoys", "demo", "--namespace", "ops"])

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,9 +297,9 @@ struct ResourceListArgs {
     /// Route the query to a peer host
     #[arg(long)]
     host: Option<String>,
-    /// Include read-only replicas from peer roots
+    /// Show only records authored by the queried host
     #[arg(long)]
-    include_replicas: bool,
+    local_only: bool,
 }
 
 #[derive(clap::Args)]
@@ -1085,7 +1085,7 @@ async fn run_resource_command(cli: &Cli, command: ResourceSubCommand, format: Ou
                         .kind(args.kind)
                         .namespace(args.namespace)
                         .maybe_node_id(node_id.clone())
-                        .include_replicas(args.include_replicas)
+                        .include_replicas(!args.local_only)
                         .build(),
                 )
                 .await
@@ -2093,7 +2093,7 @@ mod tests {
         assert!(matches!(
             list.command,
             Some(SubCommand::Resource {
-                command: ResourceSubCommand::List(ResourceListArgs { kind, namespace, host: Some(host), include_replicas: false })
+                command: ResourceSubCommand::List(ResourceListArgs { kind, namespace, host: Some(host), local_only: false })
             }) if kind == "convoys" && namespace == "flotilla" && host == "feta"
         ));
 


### PR DESCRIPTION
## Summary

- make teardown gates and resource listing replica-aware by default
- let checkout authorities reclaim managed records for landed, abandoned, or deleting convoys while the convoy finalizer waits for replicated cleanup to converge
- scope managed checkout identities by placement and dispatch generation so redispatches cannot collide with stale same-named records
- garbage-collect terminal sessions whose owning environment has disappeared

## Root cause

Cleanup decisions mixed local-only and federated resource views. That made remote checkout authorities invisible to manual teardown, while name-only managed checkout identities let stale records from an earlier placement collide with a later redispatch. Abandon also had no authority-side reclamation path.

## Validation

- `cargo test --workspace --locked`
- `cargo test -p flotilla-daemon --locked --features skip-no-sandbox-tests`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo +nightly-2026-03-12 fmt --check`
- `git diff --check`

Closes #1402
