### PR TITLE
fix: convoy reclaim accepts sanctioned checkout absence and retries refusals

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/checkout.rs
+++ b/crates/flotilla-controllers/src/reconcilers/checkout.rs
@@ -7,9 +7,10 @@ use flotilla_core::checkout_integration::{
 };
 use flotilla_resources::{
     controller::{Actuation, ReconcileOutcome, Reconciler, ReplicaConvoyCheckoutWatch, SecondaryWatch},
-    Checkout, CheckoutBranchProvenance, CheckoutIntegrationStatus, CheckoutPhase, CheckoutSpec, CheckoutStatus, CheckoutStatusPatch, Clock,
-    Clone, ClonePhase, Convoy, ConvoyPhase, IntegrationCondition, LifecycleAuthority, ReplicaReadResolver, Resource, ResourceBackend,
-    ResourceError, ResourceObject, ResourceProvenance, SystemClock, TypedResolver, ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL,
+    convoy_sanctions_checkout_reclaim, Checkout, CheckoutBranchProvenance, CheckoutIntegrationStatus, CheckoutPhase, CheckoutSpec,
+    CheckoutStatus, CheckoutStatusPatch, Clock, Clone, ClonePhase, Convoy, ConvoyPhase, IntegrationCondition, LifecycleAuthority,
+    ReplicaReadResolver, Resource, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance, SystemClock, TypedResolver,
+    ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL,
 };
 use tracing::warn;
 
@@ -182,11 +183,6 @@ fn convoy_needs_terminal_evidence(convoy: Option<&ResourceObject<Convoy>>) -> bo
     })
 }
 
-fn convoy_authorizes_checkout_reclaim(convoy: &ResourceObject<Convoy>) -> bool {
-    convoy.metadata.deletion_timestamp.is_some()
-        || convoy.status.as_ref().is_some_and(|status| matches!(status.phase, ConvoyPhase::Landed | ConvoyPhase::Abandoned))
-}
-
 impl<R> Reconciler for CheckoutReconciler<R>
 where
     R: CheckoutRuntime + 'static,
@@ -201,7 +197,7 @@ where
         let convoy = self.owning_convoy(obj).await?;
         if lifecycle_authority == Some(LifecycleAuthority::Managed)
             && has_convoy_owner
-            && convoy.as_ref().is_some_and(convoy_authorizes_checkout_reclaim)
+            && convoy.as_ref().is_some_and(convoy_sanctions_checkout_reclaim)
         {
             return Ok(CheckoutDeps::OwnerTerminal);
         }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -6907,12 +6907,20 @@ impl InProcessDaemon {
         if expected.is_empty() {
             return Ok(());
         }
+        // Once the convoy sanctions checkout reclaim (Landed, or the convoy is
+        // being deleted), the checkout authority's `OwnerTerminal` cascade may
+        // legitimately collect an expected checkout before this gate runs. An
+        // absent or already-deleting expected checkout under that sanction is
+        // evidence of completed reclaim, not missing evidence — refusing here
+        // would wedge vessel reclaim forever on a deletion the substrate itself
+        // authorized. Outside the sanction, absence stays a hard refusal.
+        let reclaim_sanctioned = flotilla_resources::convoy_sanctions_checkout_reclaim(convoy);
         let missing = expected
             .iter()
             .filter(|checkout_name| !checkout_list.iter().any(|checkout| &checkout.metadata.name == *checkout_name))
             .cloned()
             .collect::<Vec<_>>();
-        if !missing.is_empty() {
+        if !missing.is_empty() && !reclaim_sanctioned {
             return Err(format!(
                 "convoy {namespace}/{name} is not safe to delete: missing checkout integration evidence for {}",
                 missing.join(", ")
@@ -6920,7 +6928,11 @@ impl InProcessDaemon {
         }
 
         let mut refusals = Vec::new();
-        for checkout in checkout_list.iter().filter(|checkout| expected.contains(&checkout.metadata.name)) {
+        for checkout in checkout_list
+            .iter()
+            .filter(|checkout| expected.contains(&checkout.metadata.name))
+            .filter(|checkout| !(reclaim_sanctioned && checkout.metadata.deletion_timestamp.is_some()))
+        {
             let is_adopted = checkout.metadata.lifecycle_authority().map_err(|err| err.to_string())? == Some(LifecycleAuthority::Adopted);
             let Some(integration) = checkout.status.as_ref().map(|status| &status.integration) else {
                 refusals.push(format!("{}: integration evidence is missing", checkout.metadata.name));

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -3025,18 +3025,19 @@ mod tests {
     };
     use flotilla_resources::{
         api_version,
-        controller::Reconciler,
+        controller::{Actuation, Reconciler},
         test_support::{
             run_transition_sequence, FixpointPredicate, LivenessEnrollment, LivenessScenario, LivenessStep, ReconcileStep, Transition,
             TransitionDriver, TransitionSequence, WorldBuilder,
         },
         Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec, CheckoutSpec as ResourceCheckoutSpec,
-        CheckoutStatus as ResourceCheckoutStatus, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, CredentialConsumer,
-        CredentialGrant, CredentialLifecycle, CredentialPlacementRequirements, CredentialSource, CredentialSpec, CredentialSpecSpec,
-        CrewSource, CrewSpec, LifecycleAuthority, MaterialPoolSpec, MaterialPoolUnitSpec,
-        ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, RepositorySpec, Resource, Selector, SqliteBackend,
-        TerminalAttentionState, TerminalSession, TerminalSessionPhase, VesselRequirement, VesselStatus, VirtualClock, WorkPhase,
-        WorkflowTemplate, WorkflowTemplateSpec, ACTUATOR_HOST_REF_ANNOTATION,
+        CheckoutStatus as ResourceCheckoutStatus, CheckoutWorktreeSpec, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus,
+        CredentialConsumer, CredentialGrant, CredentialLifecycle, CredentialPlacementRequirements, CredentialSource, CredentialSpec,
+        CredentialSpecSpec, CrewSource, CrewSpec, LifecycleAuthority, MaterialPoolSpec, MaterialPoolUnitSpec,
+        ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementStatus, RepositoryKey, RepositorySpec, Resource,
+        Selector, SqliteBackend, TerminalAttentionState, TerminalSession, TerminalSessionPhase, VesselRequirement, VesselSpec,
+        VesselStatus, VirtualClock, WorkPhase, WorkState, WorkflowTemplate, WorkflowTemplateSpec, ACTUATOR_HOST_REF_ANNOTATION,
+        CONVOY_LABEL,
     };
     use futures::StreamExt;
     use tempfile::TempDir;
@@ -3140,6 +3141,140 @@ mod tests {
             "demand must preserve the checkout-specific refusal: {:?}",
             demands[0].metadata.annotations
         );
+    }
+
+    fn landed_status_with_placed_checkout(checkout_name: &str) -> ConvoyStatus {
+        ConvoyStatus {
+            phase: ConvoyPhase::Landed,
+            observed_workflow_ref: Some("wf-a".to_string()),
+            work: BTreeMap::from([(
+                "implement".to_string(),
+                WorkState::builder()
+                    .phase(WorkPhase::Complete)
+                    .placement(PlacementStatus {
+                        fields: BTreeMap::from([(
+                            "checkout_refs".to_string(),
+                            serde_json::json!(BTreeMap::from([(RepositoryKey("repo-a".to_string()), checkout_name.to_string())])),
+                        )]),
+                    })
+                    .build(),
+            )]),
+            ..Default::default()
+        }
+    }
+
+    /// #1413 leg 1: once the convoy is Landed, the checkout authority's
+    /// `OwnerTerminal` cascade may collect the managed checkout before the
+    /// convoy's own reclaim pass runs. That sanctioned absence is evidence of
+    /// completed reclaim, never "missing checkout integration evidence" —
+    /// outside the sanction (Failed) absence must keep refusing.
+    #[tokio::test]
+    async fn landed_convoy_reclaim_accepts_sanctioned_checkout_absence() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+        let daemon = InProcessDaemon::new(vec![], config, git_process_discovery(false), HostName::local()).await;
+        let convoys = daemon.resource_backend().using::<Convoy>(NAMESPACE);
+        let created = convoys
+            .create(
+                &InputMeta::builder().name("raced".to_string()).build(),
+                &ConvoySpec::builder().workflow_ref("wf-a".to_string()).build(),
+            )
+            .await
+            .expect("create convoy");
+        convoys
+            .update_status("raced", &created.metadata.resource_version, &landed_status_with_placed_checkout("checkout-raced"))
+            .await
+            .expect("mark convoy Landed");
+        let convoy = convoys.get("raced").await.expect("get convoy");
+        let runtime = DaemonConvoyTeardownRuntime::new(Arc::clone(&daemon));
+
+        runtime.verify_reclaim(&convoy, &[]).await.expect("absence of a collected checkout must pass the Landed reclaim gate");
+
+        let checkouts = daemon.resource_backend().using::<ResourceCheckout>(NAMESPACE);
+        checkouts
+            .create(
+                &InputMeta::builder()
+                    .name("checkout-raced".to_string())
+                    .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "raced".to_string())]))
+                    .finalizers(vec!["checkout".to_string()])
+                    .build()
+                    .with_lifecycle_authority(LifecycleAuthority::Managed),
+                &ResourceCheckoutSpec::Worktree(CheckoutWorktreeSpec {
+                    repo_ref: RepositoryKey("repo-a".to_string()),
+                    env_ref: "host-direct-test".to_string(),
+                    r#ref: "feature/raced".to_string(),
+                    base_ref: Some("main".to_string()),
+                    target_path: "/checkouts/raced".to_string(),
+                    clone_ref: "clone-a".to_string(),
+                }),
+            )
+            .await
+            .expect("create managed checkout");
+        checkouts.delete("checkout-raced").await.expect("request checkout deletion");
+        let deleting = checkouts.get("checkout-raced").await.expect("deleting checkout persists under its finalizer");
+        assert!(deleting.metadata.deletion_timestamp.is_some(), "finalizer must hold the deleting checkout");
+        runtime.verify_reclaim(&convoy, &[deleting]).await.expect("a checkout already being collected must not refuse reclaim");
+
+        let mut failed = convoy.clone();
+        failed.status.as_mut().expect("status").phase = ConvoyPhase::Failed;
+        let refusal = runtime.verify_reclaim(&failed, &[]).await.expect_err("unsanctioned absence must still refuse reclaim");
+        assert!(refusal.contains("missing checkout integration evidence"), "refusal must keep naming the missing evidence: {refusal}");
+    }
+
+    /// #1413: pins the cross-controller race itself — the checkout is gone
+    /// before the convoy's reclaim pass, and the convoy must still reclaim its
+    /// vessels instead of wedging forever on the deleted evidence.
+    #[tokio::test]
+    async fn convoy_reclaims_vessels_after_checkout_authority_collected_the_checkout_first() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+        let daemon = InProcessDaemon::new(vec![], config, git_process_discovery(false), HostName::local()).await;
+        let backend = daemon.resource_backend();
+        let convoys = backend.clone().using::<Convoy>(NAMESPACE);
+        let vessels = backend.clone().using::<Vessel>(NAMESPACE);
+        let created = convoys
+            .create(
+                &InputMeta::builder().name("raced".to_string()).build(),
+                &ConvoySpec::builder().workflow_ref("wf-a".to_string()).build(),
+            )
+            .await
+            .expect("create convoy");
+        convoys
+            .update_status("raced", &created.metadata.resource_version, &landed_status_with_placed_checkout("checkout-raced"))
+            .await
+            .expect("mark convoy Landed");
+        vessels
+            .create(
+                &InputMeta::builder()
+                    .name("raced-implement".to_string())
+                    .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "raced".to_string())]))
+                    .build(),
+                &VesselSpec {
+                    convoy_ref: "raced".to_string(),
+                    vessel_name: "implement".to_string(),
+                    placement_policy_ref: "host-direct-test".to_string(),
+                    adopted_checkout_refs: BTreeMap::new(),
+                },
+            )
+            .await
+            .expect("create vessel");
+
+        // The checkout authority's `OwnerTerminal` cascade already collected
+        // the managed checkout: no checkout record exists for this pass.
+        let reconciler = ConvoyReconciler::new(backend.clone().using::<WorkflowTemplate>(NAMESPACE))
+            .with_vessels(vessels)
+            .with_checkouts(backend.clone().using::<ResourceCheckout>(NAMESPACE))
+            .with_teardown_runtime(Arc::new(DaemonConvoyTeardownRuntime::new(Arc::clone(&daemon))));
+        let convoy = convoys.get("raced").await.expect("get convoy");
+        let deps = reconciler.fetch_dependencies(&convoy).await.expect("fetch dependencies");
+        let outcome = reconciler.reconcile(&convoy, &deps, Utc::now());
+
+        assert!(
+            outcome.actuations.iter().any(|actuation| matches!(actuation, Actuation::DeleteVessel { name } if name == "raced-implement")),
+            "convoy must still reclaim its vessels after the checkout was collected first: {:?}",
+            outcome.actuations
+        );
+        assert_eq!(outcome.requeue_after, None, "a successful reclaim pass must not keep requeueing");
     }
 
     #[test]

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -93,6 +93,23 @@ pub fn expected_checkout_refs(convoy: &crate::ResourceObject<Convoy>) -> Result<
     Ok(expected)
 }
 
+/// The one sanction for collecting a convoy's managed checkouts.
+///
+/// Two controllers can remove a checkout: the checkout authority's
+/// `OwnerTerminal` cascade and the convoy's own reclaim. Both must derive
+/// their authority from this single predicate — the convoy is being deleted,
+/// or has reached a phase whose reclaim the substrate sanctions (`Landed`:
+/// the world terminal fired; `Abandoned`: an explicit operator override).
+/// The teardown gate consumes the same predicate from the other side: an
+/// expected checkout that is absent while this sanction holds is evidence of
+/// completed reclaim, never missing integration evidence — otherwise the
+/// checkout authority's cascade would destroy the only evidence the gate
+/// accepts and wedge vessel reclaim forever.
+pub fn convoy_sanctions_checkout_reclaim(convoy: &crate::ResourceObject<Convoy>) -> bool {
+    convoy.metadata.deletion_timestamp.is_some()
+        || convoy.status.as_ref().is_some_and(|status| matches!(status.phase, ConvoyPhase::Landed | ConvoyPhase::Abandoned))
+}
+
 /// Canonical resource name for a convoy's explicitly bound change request.
 pub fn bound_change_request_record_name(convoy: &crate::ResourceObject<Convoy>) -> Result<Option<String>, String> {
     let Some(bound) = &convoy.spec.change_request else { return Ok(None) };

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -524,11 +524,19 @@ impl Reconciler for ConvoyReconciler {
             LifecycleConditions { exit_disposition: deps.exit_disposition.clone(), reclaim_eligible: deps.reclaim_eligible },
             now,
         );
+        // A refused reclaim must retry on its own schedule: the refusal is
+        // often transient (integration evidence mid-refresh, a checkout
+        // cascade in flight) and no watch event is guaranteed to arrive once
+        // the convoy is terminal. Retry at the evidence-staleness horizon —
+        // the freshness the gate is waiting on.
+        let reclaim_refused = self.teardown_runtime.is_some()
+            && obj.status.as_ref().is_some_and(|status| status.phase.is_terminal())
+            && !deps.reclaim_eligible;
         ControllerReconcileOutcome {
             patch: outcome.patch,
             actuations: outcome.actuations,
             events: outcome.events.into_iter().map(|event| format!("{event:?}")).collect(),
-            requeue_after: None,
+            requeue_after: reclaim_refused.then_some(self.landing_evidence_stale_after),
         }
     }
 

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -53,11 +53,11 @@ pub use clock::VirtualClock;
 pub use clock::{Clock, SystemClock};
 pub use clone::{Clone, ClonePhase, CloneSpec, CloneStatus, CloneStatusPatch};
 pub use convoy::{
-    bound_change_request_record_name, controller_patches, evaluate_landing_settlement, expected_change_request_leaves,
-    expected_checkout_refs, external_patches, instantiate_exit, pinned_placement_ref, pinned_workflow_ref, prepared_snapshot_pending,
-    provisioning_patches, reconcile, select_convoy_children, BoundChangeRequest, Convoy, ConvoyEvent, ConvoyIssue, ConvoyPhase,
-    ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, ConvoyStatusPatch, ConvoyTeardownRuntime, CrewWorkPhase,
-    CrewWorkState, InputValue, InstantiatedExit, InstantiatedExitEntry, IssueSnapshot, PlacementStatus, ReconcileOutcome,
+    bound_change_request_record_name, controller_patches, convoy_sanctions_checkout_reclaim, evaluate_landing_settlement,
+    expected_change_request_leaves, expected_checkout_refs, external_patches, instantiate_exit, pinned_placement_ref, pinned_workflow_ref,
+    prepared_snapshot_pending, provisioning_patches, reconcile, select_convoy_children, BoundChangeRequest, Convoy, ConvoyEvent,
+    ConvoyIssue, ConvoyPhase, ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus, ConvoyStatusPatch, ConvoyTeardownRuntime,
+    CrewWorkPhase, CrewWorkState, InputValue, InstantiatedExit, InstantiatedExitEntry, IssueSnapshot, PlacementStatus, ReconcileOutcome,
     SettlementEvaluation, SettlementMode, TargetMismatch, UnmetSettlementExpectation, WorkCompletionAuthority, WorkPhase, WorkState,
     WorkflowSnapshot, PLACEMENT_SNAPSHOT_ANNOTATION, PREPARED_SNAPSHOT_PENDING_ANNOTATION, WORKFLOW_SNAPSHOT_ANNOTATION,
 };

--- a/crates/flotilla-resources/tests/convoy_reconcile.rs
+++ b/crates/flotilla-resources/tests/convoy_reconcile.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use common::{
@@ -1633,6 +1633,57 @@ async fn terminal_completed_convoy_still_emits_cleanup_actuations() {
         .actuations
         .iter()
         .any(|actuation| matches!(actuation, Actuation::DeleteVessel { name } if name == "convoy-a-implement")));
+}
+
+struct NeverEligible;
+
+#[async_trait]
+impl ConvoyTeardownRuntime for NeverEligible {
+    async fn verify_reclaim(
+        &self,
+        _convoy: &flotilla_resources::ResourceObject<Convoy>,
+        _checkouts: &[flotilla_resources::ResourceObject<Checkout>],
+    ) -> Result<(), String> {
+        Err("integration evidence mid-refresh".to_string())
+    }
+}
+
+/// #1413 leg 2: a refused reclaim must retry on its own schedule instead of
+/// waiting on a watch event that nothing is guaranteed to send once the
+/// convoy is terminal.
+#[tokio::test]
+async fn refused_reclaim_requeues_at_the_evidence_staleness_horizon() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let templates = backend.clone().using::<WorkflowTemplate>("flotilla");
+    let convoys = backend.clone().using::<Convoy>("flotilla");
+    let mut status = bootstrapped_tool_only_convoy_status();
+    status.phase = ConvoyPhase::Landed;
+    status.finished_at = Some(timestamp(20));
+    for task in status.work.values_mut() {
+        task.phase = WorkPhase::Complete;
+        task.finished_at = Some(timestamp(19));
+    }
+    let source = convoy_object("convoy-a", task_provisioning_convoy_spec(), Some(status));
+    let created = convoys.create(&convoy_meta("convoy-a"), &source.spec).await.expect("convoy create");
+    convoys
+        .update_status("convoy-a", &created.metadata.resource_version, source.status.as_ref().expect("convoy status"))
+        .await
+        .expect("convoy status update");
+    let convoy = convoys.get("convoy-a").await.expect("convoy get");
+
+    let refused = ConvoyReconciler::new(templates.clone())
+        .with_teardown_runtime(Arc::new(NeverEligible))
+        .with_landing_evidence_stale_after(Duration::from_secs(7));
+    let deps = refused.fetch_dependencies(&convoy).await.expect("dependencies");
+    let outcome = refused.reconcile(&convoy, &deps, timestamp(21));
+    assert_eq!(outcome.requeue_after, Some(Duration::from_secs(7)), "a refused reclaim must requeue at the staleness horizon");
+
+    let eligible = ConvoyReconciler::new(templates)
+        .with_teardown_runtime(Arc::new(AlwaysEligible))
+        .with_landing_evidence_stale_after(Duration::from_secs(7));
+    let deps = eligible.fetch_dependencies(&convoy).await.expect("dependencies");
+    let outcome = eligible.reconcile(&convoy, &deps, timestamp(21));
+    assert_eq!(outcome.requeue_after, None, "an eligible reclaim pass must not keep requeueing");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes the cross-controller reclaim deadlock where `CheckoutReconciler`'s authorized `OwnerTerminal` cascade deletes the `Checkout` before the convoy's own reclaim pass, and the teardown gate then refuses forever with `missing checkout integration evidence`, permanently leaking the convoy's `Vessel` and `Presentation` resources.

### Design cut: one sanction, defined once

Rather than gating the checkout authority on the convoy's evidence gate (which would reintroduce #1402's cross-host wedges) or sequencing the two controllers (fragile distributed ordering), the sanction for collecting a managed checkout is now a single shared predicate in `flotilla-resources` — `convoy_sanctions_checkout_reclaim`: the convoy is being deleted, `Landed` (the world terminal fired, per ADR 0028), or `Abandoned` (explicit override).

- The checkout reconciler's `OwnerTerminal` path (from #1407) now derives from that predicate instead of its own private copy.
- The convoy teardown gate consumes the same predicate from the other side: an expected checkout that is **absent** — or already carrying a deletion timestamp — while the sanction holds is evidence of *completed reclaim*, never missing evidence. Outside the sanction (e.g. `Failed`, `Cancelled`, or a live convoy), absence stays a hard refusal.

This also fixes the operator-facing leg of #1402: `convoy delete` on a Landed convoy no longer refuses after the checkout authority already collected its record.

### Refused reclaims retry

`ConvoyReconciler::reconcile` returned `requeue_after: None`, so a transient refusal (integration evidence mid-refresh, a cascade in flight) stalled until the next full resync — or forever. A refused reclaim on a terminal convoy now requeues at the landing-evidence staleness horizon (`landing_evidence_stale_after`, the freshness the gate is waiting on). A successful or fully reclaimed pass does not requeue, so retained terminal convoys don't hot-loop.

### Regression tests

- `landed_convoy_reclaim_accepts_sanctioned_checkout_absence` — gate level: absence passes for `Landed`, a deleting checkout passes, absence still refuses for `Failed`.
- `convoy_reclaims_vessels_after_checkout_authority_collected_the_checkout_first` — pins the race itself: checkout gone before the convoy reclaim pass ⇒ `DeleteVessel` still emitted (fails on `main` without the fix).
- `refused_reclaim_requeues_at_the_evidence_staleness_horizon` — pins the retry leg.

### Validation

Reproduction confirmed without the fix on this machine (full parallel `cargo test -p flotilla-daemon --lib --locked`: `passing_teardown_gate_removes_the_managed_worktree_path` FAILED). With the fix, ten consecutive clean full-suite runs (five pre-rebase, five on the final tree rebased onto #1411):

| Run (final tree) | Result |
|---|---|
| 1 | ok, 416 passed |
| 2 | ok, 416 passed |
| 3 | ok, 416 passed |
| 4 | ok, 416 passed |
| 5 | ok, 416 passed |

Gates: `cargo +nightly-2026-03-12 fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked` — all clean.

Fixes #1413. Unblocks the red Test check that was hitting #1411 (this flake reproduced on `main` and its ancestors; #1411 has since merged and this branch is rebased on it).

https://claude.ai/code/session_01P3eF4i73CQk8zWVKBVArKp