### PR TITLE
feat: add observed usage resource

### DIFF
--- a/crates/flotilla-core/src/leaf_engine.rs
+++ b/crates/flotilla-core/src/leaf_engine.rs
@@ -5,7 +5,7 @@ use flotilla_protocol::{DaemonEvent, Leaf, LeafAddress, LeafFire, WaitSubscripti
 use flotilla_resources::{
     admit_leaf, controller::SecondaryWatch, evaluate_leaf, instantiate_exit, select_convoy_children, ChangeRequest,
     ChangeRequestLeafSubject, Checkout, Convoy, ConvoyLeafSubject, ConvoyPhase, InstantiatedExit, ResourceBackend, ResourceError,
-    ResourceObject, ThreeValue, Vessel, VesselLeafSubject, WatchEvent, WatchStart, WorkLeafSubject,
+    ResourceObject, ThreeValue, Usage, UsageLeafSubject, Vessel, VesselLeafSubject, WatchEvent, WatchStart, WorkLeafSubject,
 };
 use futures::StreamExt;
 use tokio::{
@@ -182,15 +182,18 @@ impl LeafSubscriptionTable {
         let convoys = self.inner.backend.including_replicas::<Convoy>(&row.namespace);
         let vessels = self.inner.backend.including_replicas::<Vessel>(&row.namespace);
         let change_requests = self.inner.backend.including_replicas::<ChangeRequest>(&row.namespace);
+        let usages = self.inner.backend.including_replicas::<Usage>(&row.namespace);
         // Open watches before taking the level-triggered snapshots. Writes
         // racing the lists are then buffered by the streams and replayed by
         // the loop instead of falling through a list-then-watch gap.
         let mut convoy_watch = convoys.watch().await.map_err(|error| error.to_string())?;
         let mut vessel_watch = vessels.watch().await.map_err(|error| error.to_string())?;
         let mut change_request_watch = change_requests.watch().await.map_err(|error| error.to_string())?;
+        let mut usage_watch = usages.watch().await.map_err(|error| error.to_string())?;
         let convoy_list = convoys.list().await.map_err(|error| error.to_string())?;
         let vessel_list = vessels.list().await.map_err(|error| error.to_string())?;
         let change_request_list = change_requests.list().await.map_err(|error| error.to_string())?;
+        let usage_list = usages.list().await.map_err(|error| error.to_string())?;
         let mut convoy_objects = convoy_list.items.into_iter().fold(HashMap::new(), |mut objects, item| {
             objects.entry(item.object.metadata.name.clone()).or_insert(item.object);
             objects
@@ -203,10 +206,19 @@ impl LeafSubscriptionTable {
             objects.entry(item.object.metadata.name.clone()).or_insert(item.object);
             objects
         });
+        let mut usage_objects = usage_list.items.into_iter().fold(HashMap::new(), |mut objects, item| {
+            objects.entry(item.object.metadata.name.clone()).or_insert(item.object);
+            objects
+        });
 
-        if let Some(fire) =
-            evaluate_row(&row, &convoy_objects, &vessel_objects, &change_request_objects, self.inner.change_requests.stale_after())?
-        {
+        if let Some(fire) = evaluate_row(
+            &row,
+            &convoy_objects,
+            &vessel_objects,
+            &change_request_objects,
+            &usage_objects,
+            self.inner.change_requests.stale_after(),
+        )? {
             self.fire(row.id, fire).await;
             return Ok(());
         }
@@ -225,10 +237,19 @@ impl LeafSubscriptionTable {
                     let event = event.ok_or_else(|| "change request resource watch closed".to_string())?.map_err(|error| error.to_string())?;
                     apply_read_event(event, &mut change_request_objects);
                 }
+                event = usage_watch.next() => {
+                    let event = event.ok_or_else(|| "usage resource watch closed".to_string())?.map_err(|error| error.to_string())?;
+                    apply_read_event(event, &mut usage_objects);
+                }
             }
-            if let Some(fire) =
-                evaluate_row(&row, &convoy_objects, &vessel_objects, &change_request_objects, self.inner.change_requests.stale_after())?
-            {
+            if let Some(fire) = evaluate_row(
+                &row,
+                &convoy_objects,
+                &vessel_objects,
+                &change_request_objects,
+                &usage_objects,
+                self.inner.change_requests.stale_after(),
+            )? {
                 self.fire(row.id, fire).await;
                 return Ok(());
             }
@@ -439,6 +460,7 @@ fn evaluate_row(
     convoys: &HashMap<String, ResourceObject<Convoy>>,
     vessels: &HashMap<String, ResourceObject<Vessel>>,
     change_requests: &HashMap<String, ResourceObject<ChangeRequest>>,
+    usages: &HashMap<String, ResourceObject<Usage>>,
     change_request_stale_after: std::time::Duration,
 ) -> Result<Option<LeafFire>, String> {
     let require_all = matches!(row.watcher, LeafWatcher::ReconcilerWake { .. });
@@ -466,6 +488,11 @@ fn evaluate_row(
                     now: Utc::now(),
                     stale_after: change_request_stale_after,
                 });
+                evaluate_leaf(leaf, subject.as_ref().map(|subject| subject as &dyn flotilla_resources::LeafSubject), row.freshness_demand)?
+            }
+            LeafAddress::Usage { account } => {
+                let name = flotilla_resources::usage_record_name(account);
+                let subject = usages.get(&name).map(UsageLeafSubject);
                 evaluate_leaf(leaf, subject.as_ref().map(|subject| subject as &dyn flotilla_resources::LeafSubject), row.freshness_demand)?
             }
         };
@@ -698,6 +725,56 @@ mod tests {
     #[tokio::test]
     async fn sqlite_leaf_subscription_contract() {
         assert_leaf_subscription_contract(ResourceBackend::Sqlite(SqliteBackend::open_in_memory().expect("open sqlite"))).await;
+    }
+
+    #[tokio::test]
+    async fn usage_leaf_fires_from_the_named_window_in_the_replicated_resource_path() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let account = "user@example.com";
+        let records = backend.using::<Usage>("flotilla");
+        let created = records
+            .create(&InputMeta::builder().name(flotilla_resources::usage_record_name(account)).build(), &flotilla_resources::UsageSpec {
+                account: account.to_string(),
+            })
+            .await
+            .expect("create usage record");
+        records
+            .update_status(
+                &created.metadata.name,
+                &created.metadata.resource_version,
+                &flotilla_resources::UsageStatus::builder()
+                    .provider("codex")
+                    .windows(vec![
+                        flotilla_resources::UsageWindow::builder().name("session").used_percent(8.0).build(),
+                        flotilla_resources::UsageWindow::builder().name("weekly").used_percent(100.0).build(),
+                    ])
+                    .observed_at(Utc::now())
+                    .build(),
+            )
+            .await
+            .expect("publish usage status");
+
+        let (event_tx, _) = broadcast::channel(16);
+        let refresher = ChangeRequestRefresher::new(
+            backend.clone(),
+            "test-host".to_string(),
+            Arc::new(UnavailableChangeRequests),
+            crate::change_request_observer::ChangeRequestRefreshCadence::default(),
+        );
+        let table = LeafSubscriptionTable::new(backend, event_tx.clone(), refresher);
+        let mut events = event_tx.subscribe();
+        let mut usage_leaf = leaf(LeafAddress::Usage { account: account.to_string() }, ".windows.weekly.used-percent", "90");
+        usage_leaf.operator = LeafOperator::GreaterThan;
+        let subscription_id = table
+            .subscribe_wait(uuid::Uuid::new_v4(), WaitSubscriptionRequest {
+                namespace: "flotilla".to_string(),
+                leaves: vec![usage_leaf],
+                freshness_demand: None,
+            })
+            .await
+            .expect("subscribe usage leaf");
+
+        assert_eq!(receive_fire(&mut events, subscription_id).await.value, "100");
     }
 
     #[tokio::test]

--- a/crates/flotilla-protocol/src/leaf.rs
+++ b/crates/flotilla-protocol/src/leaf.rs
@@ -49,6 +49,7 @@ pub enum LeafAddress {
     Vessel { name: String },
     Work { convoy: String, work: String },
     ChangeRequest { service: String, scope: String, number: u64 },
+    Usage { account: String },
 }
 
 impl LeafAddress {
@@ -58,6 +59,7 @@ impl LeafAddress {
             Self::Vessel { .. } => LeafKind::Vessel,
             Self::Work { .. } => LeafKind::Work,
             Self::ChangeRequest { .. } => LeafKind::ChangeRequest,
+            Self::Usage { .. } => LeafKind::Usage,
         }
     }
 }
@@ -77,8 +79,9 @@ impl FromStr for LeafAddress {
                 let number = number.parse().map_err(|_| format!("invalid change request number `{number}` in leaf address `{value}`"))?;
                 Ok(Self::ChangeRequest { service: (*service).to_string(), scope: scope.join("/"), number })
             }
+            ["usage", account] if !account.is_empty() => Ok(Self::Usage { account: (*account).to_string() }),
             _ => Err(format!(
-                "invalid leaf address `{value}`; expected convoy/<name>, vessel/<name>, work/<convoy>/<work>, or cr/<service>/<scope>/<number>"
+                "invalid leaf address `{value}`; expected convoy/<name>, vessel/<name>, work/<convoy>/<work>, cr/<service>/<scope>/<number>, or usage/<account>"
             )),
         }
     }
@@ -91,6 +94,7 @@ impl fmt::Display for LeafAddress {
             Self::Vessel { name } => write!(f, "vessel/{name}"),
             Self::Work { convoy, work } => write!(f, "work/{convoy}/{work}"),
             Self::ChangeRequest { service, scope, number } => write!(f, "cr/{service}/{scope}/{number}"),
+            Self::Usage { account } => write!(f, "usage/{account}"),
         }
     }
 }
@@ -102,6 +106,7 @@ pub enum LeafKind {
     Vessel,
     Work,
     ChangeRequest,
+    Usage,
 }
 
 impl fmt::Display for LeafKind {
@@ -111,6 +116,7 @@ impl fmt::Display for LeafKind {
             Self::Vessel => "vessel",
             Self::Work => "work",
             Self::ChangeRequest => "cr",
+            Self::Usage => "usage",
         })
     }
 }
@@ -219,5 +225,12 @@ mod tests {
         ] {
             assert!(address.parse::<LeafAddress>().is_err(), "collection or query address must be rejected: {address}");
         }
+    }
+
+    #[test]
+    fn parses_subject_keyed_usage_address() {
+        let leaf: Leaf = "usage/user@example.com .windows.weekly.used-percent > 90".parse().expect("parse usage leaf");
+        assert_eq!(leaf.address, LeafAddress::Usage { account: "user@example.com".to_string() });
+        assert_eq!(leaf.to_string(), "usage/user@example.com .windows.weekly.used-percent > 90");
     }
 }

--- a/crates/flotilla-resources/src/crds/usage.crd.yaml
+++ b/crates/flotilla-resources/src/crds/usage.crd.yaml
@@ -1,0 +1,100 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: usages.flotilla.work
+spec:
+  group: flotilla.work
+  scope: Namespaced
+  names:
+    plural: usages
+    singular: usage
+    kind: Usage
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          required: [spec]
+          properties:
+            spec:
+              type: object
+              required: [account]
+              properties:
+                account:
+                  type: string
+            status:
+              type: object
+              required: [provider, windows, observed_at]
+              properties:
+                provider:
+                  type: string
+                plan:
+                  type: string
+                organization:
+                  type: string
+                windows:
+                  type: array
+                  items:
+                    type: object
+                    required: [name, used_percent]
+                    properties:
+                      name:
+                        type: string
+                      label:
+                        type: string
+                      used_percent:
+                        type: number
+                      resets_at:
+                        type: string
+                        format: date-time
+                      window_minutes:
+                        type: integer
+                        minimum: 0
+                pace:
+                  type: array
+                  items:
+                    type: object
+                    required: [window, stage, delta_percent, expected_used_percent, will_last_to_reset]
+                    properties:
+                      window:
+                        type: string
+                      stage:
+                        type: string
+                      delta_percent:
+                        type: number
+                      expected_used_percent:
+                        type: number
+                      will_last_to_reset:
+                        type: boolean
+                      eta_seconds:
+                        type: integer
+                        minimum: 0
+                      run_out_probability:
+                        type: number
+                provider_cost:
+                  type: object
+                  required: [used, limit, currency_code]
+                  properties:
+                    used:
+                      type: number
+                    limit:
+                      type: number
+                    currency_code:
+                      type: string
+                    period:
+                      type: string
+                    resets_at:
+                      type: string
+                      format: date-time
+                    balance:
+                      type: number
+                reset_credits_available:
+                  type: integer
+                  minimum: 0
+                observed_at:
+                  type: string
+                  format: date-time

--- a/crates/flotilla-resources/src/leaf.rs
+++ b/crates/flotilla-resources/src/leaf.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, time::Duration};
 use chrono::{DateTime, Utc};
 use flotilla_protocol::{Leaf, LeafKind, LeafOperator};
 
-use crate::{ChangeRequest, Convoy, CrewWorkPhase, CrewWorkState, ResourceObject, Vessel, WorkState};
+use crate::{ChangeRequest, Convoy, CrewWorkPhase, CrewWorkState, ResourceObject, Usage, Vessel, WorkState};
 
 pub const ADMITTED_LEAF_VOCABULARY: &[(&str, &str)] = &[
     ("convoy", ".status.phase"),
@@ -25,9 +25,10 @@ pub enum ThreeValue {
     Unknown,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum LeafValue {
     Text(String),
+    Number(f64),
     Timestamp(DateTime<Utc>),
 }
 
@@ -35,12 +36,13 @@ impl std::fmt::Display for LeafValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Text(value) => f.write_str(value),
+            Self::Number(value) => write!(f, "{value}"),
             Self::Timestamp(value) => write!(f, "{}", value.to_rfc3339()),
         }
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct LeafEvaluation {
     pub result: ThreeValue,
     pub value: Option<LeafValue>,
@@ -60,19 +62,41 @@ pub trait LeafSubject {
 
 pub fn admit_leaf(leaf: &Leaf) -> Result<(), String> {
     let kind = leaf.address.kind();
-    let admitted =
-        ADMITTED_LEAF_VOCABULARY.iter().any(|(candidate_kind, path)| *candidate_kind == kind.to_string() && *path == leaf.field_path);
+    let usage_field = kind == LeafKind::Usage && admitted_usage_field(&leaf.field_path);
+    let admitted = usage_field
+        || ADMITTED_LEAF_VOCABULARY.iter().any(|(candidate_kind, path)| *candidate_kind == kind.to_string() && *path == leaf.field_path);
     if !admitted {
-        let vocabulary = ADMITTED_LEAF_VOCABULARY.iter().map(|(kind, path)| format!("{kind}{path}")).collect::<Vec<_>>().join(", ");
+        let mut vocabulary = ADMITTED_LEAF_VOCABULARY.iter().map(|(kind, path)| format!("{kind}{path}")).collect::<Vec<_>>();
+        vocabulary.extend([
+            "usage.provider".to_string(),
+            "usage.plan".to_string(),
+            "usage.organization".to_string(),
+            "usage.windows.<name>.{used-percent,resets-at,window-minutes}".to_string(),
+        ]);
+        let vocabulary = vocabulary.join(", ");
         return Err(format!("leaf path `{kind}{}` is not admitted; admitted vocabulary: {vocabulary}", leaf.field_path));
     }
-    if leaf.field_path != ".latest-claim.claimed-at" && !matches!(leaf.operator, LeafOperator::Equal | LeafOperator::NotEqual) {
+    let ordered_usage_field = kind == LeafKind::Usage
+        && usage_window_path(&leaf.field_path).is_some_and(|(_, field)| matches!(field, "used-percent" | "window-minutes" | "resets-at"));
+    if leaf.field_path != ".latest-claim.claimed-at"
+        && !ordered_usage_field
+        && !matches!(leaf.operator, LeafOperator::Equal | LeafOperator::NotEqual)
+    {
         return Err(format!("operator `{}` is not admitted for text leaf `{kind}{}`; use `==` or `!=`", leaf.operator, leaf.field_path));
     }
-    if leaf.field_path == ".latest-claim.claimed-at" {
+    if leaf.field_path == ".latest-claim.claimed-at"
+        || (kind == LeafKind::Usage && usage_window_path(&leaf.field_path).is_some_and(|(_, field)| field == "resets-at"))
+    {
         leaf.literal
             .parse::<DateTime<Utc>>()
-            .map_err(|error| format!("invalid timestamp literal `{}` for work.latest-claim.claimed-at: {error}", leaf.literal))?;
+            .map_err(|error| format!("invalid timestamp literal `{}` for {kind}{}: {error}", leaf.literal, leaf.field_path))?;
+    }
+    if kind == LeafKind::Usage
+        && usage_window_path(&leaf.field_path).is_some_and(|(_, field)| matches!(field, "used-percent" | "window-minutes"))
+    {
+        leaf.literal
+            .parse::<f64>()
+            .map_err(|error| format!("invalid number literal `{}` for usage{}: {error}", leaf.literal, leaf.field_path))?;
     }
     Ok(())
 }
@@ -109,11 +133,14 @@ pub fn evaluate_leaf(
 }
 
 fn bind_literal(path: &str, literal: &str) -> Result<LeafValue, String> {
-    if path == ".latest-claim.claimed-at" {
+    if path == ".latest-claim.claimed-at" || usage_window_path(path).is_some_and(|(_, field)| field == "resets-at") {
         return literal
             .parse::<DateTime<Utc>>()
             .map(LeafValue::Timestamp)
             .map_err(|error| format!("invalid timestamp literal `{literal}`: {error}"));
+    }
+    if usage_window_path(path).is_some_and(|(_, field)| matches!(field, "used-percent" | "window-minutes")) {
+        return literal.parse::<f64>().map(LeafValue::Number).map_err(|error| format!("invalid number literal `{literal}`: {error}"));
     }
     Ok(LeafValue::Text(literal.to_string()))
 }
@@ -121,6 +148,9 @@ fn bind_literal(path: &str, literal: &str) -> Result<LeafValue, String> {
 fn compare_values(left: &LeafValue, right: &LeafValue) -> Result<Ordering, String> {
     match (left, right) {
         (LeafValue::Text(left), LeafValue::Text(right)) => Ok(left.cmp(right)),
+        (LeafValue::Number(left), LeafValue::Number(right)) => {
+            left.partial_cmp(right).ok_or_else(|| "leaf number cannot be compared".to_string())
+        }
         (LeafValue::Timestamp(left), LeafValue::Timestamp(right)) => Ok(left.cmp(right)),
         _ => Err("leaf value and bound literal have different types".to_string()),
     }
@@ -194,6 +224,48 @@ pub struct ChangeRequestLeafSubject<'a> {
     pub change_request: &'a ResourceObject<ChangeRequest>,
     pub now: DateTime<Utc>,
     pub stale_after: Duration,
+}
+
+pub struct UsageLeafSubject<'a>(pub &'a ResourceObject<Usage>);
+
+impl LeafSubject for UsageLeafSubject<'_> {
+    fn kind(&self) -> LeafKind {
+        LeafKind::Usage
+    }
+
+    fn value(&self, field_path: &str) -> Option<LeafValue> {
+        let status = self.0.status.as_ref()?;
+        match field_path {
+            ".provider" => Some(LeafValue::Text(status.provider.clone())),
+            ".plan" => status.plan.clone().map(LeafValue::Text),
+            ".organization" => status.organization.clone().map(LeafValue::Text),
+            path => {
+                let (window_name, field) = usage_window_path(path)?;
+                let window = status.windows.iter().find(|window| window.name == window_name)?;
+                match field {
+                    "used-percent" => Some(LeafValue::Number(window.used_percent)),
+                    "resets-at" => window.resets_at.map(LeafValue::Timestamp),
+                    "window-minutes" => window.window_minutes.map(|minutes| LeafValue::Number(minutes as f64)),
+                    _ => None,
+                }
+            }
+        }
+    }
+
+    fn observed_at(&self, _field_path: &str) -> Option<DateTime<Utc>> {
+        self.0.status.as_ref().map(|status| status.observed_at)
+    }
+}
+
+fn usage_window_path(path: &str) -> Option<(&str, &str)> {
+    let path = path.strip_prefix(".windows.")?;
+    let (window, field) = path.rsplit_once('.')?;
+    (!window.is_empty() && !field.is_empty()).then_some((window, field))
+}
+
+fn admitted_usage_field(path: &str) -> bool {
+    matches!(path, ".provider" | ".plan" | ".organization")
+        || usage_window_path(path).is_some_and(|(_, field)| matches!(field, "used-percent" | "resets-at" | "window-minutes"))
 }
 
 impl ChangeRequestLeafSubject<'_> {
@@ -357,5 +429,47 @@ mod tests {
             literal: "merged".to_string(),
         };
         assert_eq!(evaluate_leaf(&leaf, Some(&subject), None).expect("evaluate").result, ThreeValue::Unknown);
+    }
+
+    #[test]
+    fn usage_leaf_selects_named_window_without_collapsing_the_set() {
+        let observed_at = "2026-08-06T10:39:55Z".parse().expect("timestamp");
+        let object = ResourceObject::<Usage> {
+            metadata: crate::ObjectMeta {
+                name: "usage-account".to_string(),
+                namespace: "flotilla".to_string(),
+                resource_version: "1".to_string(),
+                labels: Default::default(),
+                annotations: Default::default(),
+                owner_references: Vec::new(),
+                finalizers: Vec::new(),
+                deletion_timestamp: None,
+                creation_timestamp: observed_at,
+                merge: None,
+            },
+            spec: crate::UsageSpec { account: "user@example.com".to_string() },
+            status: Some(
+                crate::UsageStatus::builder()
+                    .provider("codex")
+                    .windows(vec![
+                        crate::UsageWindow::builder().name("session").used_percent(8.0).build(),
+                        crate::UsageWindow::builder().name("weekly").used_percent(100.0).build(),
+                    ])
+                    .observed_at(observed_at)
+                    .build(),
+            ),
+        };
+        let subject = UsageLeafSubject(&object);
+        let leaf = Leaf {
+            address: LeafAddress::Usage { account: "user@example.com".to_string() },
+            field_path: ".windows.weekly.used-percent".to_string(),
+            operator: LeafOperator::GreaterThan,
+            literal: "90".to_string(),
+        };
+
+        let evaluation = evaluate_leaf(&leaf, Some(&subject), None).expect("evaluate usage window");
+        assert_eq!(evaluation.result, ThreeValue::True);
+        assert_eq!(evaluation.value, Some(LeafValue::Number(100.0)));
+        assert_eq!(subject.observed_at(&leaf.field_path), Some(observed_at));
     }
 }

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -34,6 +34,7 @@ mod terminal_session;
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_support;
 pub mod tls;
+mod usage;
 mod vessel;
 mod watch;
 mod workflow_template;
@@ -87,7 +88,7 @@ pub use labels::{
 };
 pub use leaf::{
     admit_leaf, evaluate_leaf, ChangeRequestLeafSubject, ConvoyLeafSubject, LeafEvaluation, LeafSubject, LeafValue, ThreeValue,
-    VesselLeafSubject, WorkLeafSubject, ADMITTED_LEAF_VOCABULARY,
+    UsageLeafSubject, VesselLeafSubject, WorkLeafSubject, ADMITTED_LEAF_VOCABULARY,
 };
 pub use material_pool::{
     MaterialPool, MaterialPoolLease, MaterialPoolSpec, MaterialPoolStatus, MaterialPoolStatusPatch, MaterialPoolUnitSpec,
@@ -139,6 +140,7 @@ pub use terminal_session::{
     TerminalSessionAttachTarget, TerminalSessionDegradedCondition, TerminalSessionIdentity, TerminalSessionPhase, TerminalSessionSource,
     TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch, TerminalSessionTag,
 };
+pub use usage::{usage_record_name, Usage, UsagePace, UsageProviderCost, UsageSpec, UsageStatus, UsageStatusPatch, UsageWindow};
 pub use vessel::{
     Vessel, VesselPhase, VesselSpec, VesselStatus, VesselStatusPatch, ACTUATOR_HOST_REF_ANNOTATION, ACTUATOR_SOURCE_ROOT_ANNOTATION,
 };

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -13,7 +13,8 @@ use crate::{
     ChangeRequest, Checkout, Clone as CloneResource, Convoy, CredentialGrant, CredentialSpec, Demand, DispatchObservation, Environment,
     FieldOwnedResource, Host, InputMeta, MaterialPool, ObjectMeta, OwnerReference, PlacementPolicy, Presentation, Project,
     ReadResourceList, ReadWatchEvent, Regard, ReplicaCursor, ReplicationClass, Repository, Resource, ResourceBackend, ResourceError,
-    ResourceList, ResourceObject, ResourceProvenance, TerminalSession, Vessel, WatchEvent, WatchStart, WorkflowTemplate, WriterIdentity,
+    ResourceList, ResourceObject, ResourceProvenance, TerminalSession, Usage, Vessel, WatchEvent, WatchStart, WorkflowTemplate,
+    WriterIdentity,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -44,6 +45,7 @@ enum RegisteredResource {
     Regard,
     Repository,
     TerminalSession,
+    Usage,
     Vessel,
     WorkflowTemplate,
 }
@@ -129,6 +131,7 @@ pub const REGISTERED_RESOURCE_KINDS: &[RegisteredResourceKind] = &[
         "terminal-session",
         "terminal-sessions",
     ]),
+    kind::<Usage>(RegisteredResource::Usage, &[]),
     kind::<Vessel>(RegisteredResource::Vessel, &[]),
     kind::<WorkflowTemplate>(RegisteredResource::WorkflowTemplate, &[
         "workflowtemplate",
@@ -169,6 +172,7 @@ macro_rules! dispatch_resource_kind {
             RegisteredResource::Regard => $body::<Regard>($($arg),*).await,
             RegisteredResource::Repository => $body::<Repository>($($arg),*).await,
             RegisteredResource::TerminalSession => $body::<TerminalSession>($($arg),*).await,
+            RegisteredResource::Usage => $body::<Usage>($($arg),*).await,
             RegisteredResource::Vessel => $body::<Vessel>($($arg),*).await,
             RegisteredResource::WorkflowTemplate => $body::<WorkflowTemplate>($($arg),*).await,
         }
@@ -192,6 +196,7 @@ macro_rules! dispatch_resource_kind {
             RegisteredResource::Regard => $body::<Regard>(),
             RegisteredResource::Repository => $body::<Repository>(),
             RegisteredResource::TerminalSession => $body::<TerminalSession>(),
+            RegisteredResource::Usage => $body::<Usage>(),
             RegisteredResource::Vessel => $body::<Vessel>(),
             RegisteredResource::WorkflowTemplate => $body::<WorkflowTemplate>(),
         }
@@ -215,6 +220,7 @@ macro_rules! dispatch_resource_kind {
             RegisteredResource::Regard => $body::<Regard>($($arg),*),
             RegisteredResource::Repository => $body::<Repository>($($arg),*),
             RegisteredResource::TerminalSession => $body::<TerminalSession>($($arg),*),
+            RegisteredResource::Usage => $body::<Usage>($($arg),*),
             RegisteredResource::Vessel => $body::<Vessel>($($arg),*),
             RegisteredResource::WorkflowTemplate => $body::<WorkflowTemplate>($($arg),*),
         }

--- a/crates/flotilla-resources/src/usage.rs
+++ b/crates/flotilla-resources/src/usage.rs
@@ -1,0 +1,173 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{ApiPaths, ReplicationClass, Resource, ResourceError, StatusPatch};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Usage;
+
+impl Resource for Usage {
+    type Spec = UsageSpec;
+    type Status = UsageStatus;
+    type StatusPatch = UsageStatusPatch;
+
+    const API_PATHS: ApiPaths = ApiPaths { group: "flotilla.work", version: "v1", plural: "usages", kind: "Usage" };
+    const REPLICATION_CLASS: ReplicationClass = ReplicationClass::Observations;
+
+    fn validate_spec_update(current: &Self::Spec, requested: &Self::Spec) -> Result<(), ResourceError> {
+        if current == requested {
+            Ok(())
+        } else {
+            Err(ResourceError::invalid("Usage account subject is immutable"))
+        }
+    }
+}
+
+/// The account is the stable subject. Provider, plan, organization, and quota
+/// data are observations because each can change independently over time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UsageSpec {
+    pub account: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, bon::Builder)]
+#[builder(on(String, into))]
+pub struct UsageWindow {
+    /// Stable lane name such as `session`, `weekly`, or a provider-specific
+    /// scoped pool identifier.
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    pub used_percent: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resets_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_minutes: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, bon::Builder)]
+#[builder(on(String, into))]
+pub struct UsagePace {
+    /// Name of the window this projection describes.
+    pub window: String,
+    pub stage: String,
+    pub delta_percent: f64,
+    pub expected_used_percent: f64,
+    pub will_last_to_reset: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub eta_seconds: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_out_probability: Option<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, bon::Builder)]
+#[builder(on(String, into))]
+pub struct UsageProviderCost {
+    pub used: f64,
+    pub limit: f64,
+    pub currency_code: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub period: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resets_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub balance: Option<f64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, bon::Builder)]
+#[builder(on(String, into))]
+pub struct UsageStatus {
+    pub provider: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub organization: Option<String>,
+    /// Quota lanes remain a set of independently resetting windows. Pollers
+    /// must not select one window as the account's scalar usage value.
+    #[serde(default)]
+    #[builder(default)]
+    pub windows: Vec<UsageWindow>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[builder(default)]
+    pub pace: Vec<UsagePace>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_cost: Option<UsageProviderCost>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reset_credits_available: Option<u64>,
+    pub observed_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum UsageStatusPatch {
+    Observed(UsageStatus),
+}
+
+impl StatusPatch<UsageStatus> for UsageStatusPatch {
+    fn apply(&self, status: &mut UsageStatus) {
+        match self {
+            Self::Observed(observation) => *status = observation.clone(),
+        }
+    }
+}
+
+/// Produce a DNS-safe, fixed-size resource name for a raw account subject.
+pub fn usage_record_name(account: &str) -> String {
+    let normalized = account.trim().to_lowercase();
+    let mut hash = Sha256::new();
+    hash.update(b"usage-account-v1\0");
+    hash.update(normalized.as_bytes());
+    let digest = format!("{:x}", hash.finalize());
+    format!("usage-{}", &digest[..54])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{InMemoryBackend, InputMeta, ResourceBackend, SqliteBackend};
+
+    fn status(used_percent: f64, observed_at: DateTime<Utc>) -> UsageStatus {
+        UsageStatus::builder()
+            .provider("codex")
+            .windows(vec![UsageWindow::builder().name("weekly").used_percent(used_percent).build()])
+            .observed_at(observed_at)
+            .build()
+    }
+
+    async fn assert_observation_history_is_thin(backend: ResourceBackend) {
+        let records = backend.using::<Usage>("flotilla");
+        let created = records
+            .create(&InputMeta::builder().name("usage-account".to_string()).build(), &UsageSpec { account: "user@example.com".to_string() })
+            .await
+            .expect("create usage observation");
+        let first = records
+            .update_status("usage-account", &created.metadata.resource_version, &status(8.0, "2026-08-06T10:00:00Z".parse().expect("time")))
+            .await
+            .expect("publish first usage observation");
+        records
+            .update_status("usage-account", &first.metadata.resource_version, &status(100.0, "2026-08-06T10:05:00Z".parse().expect("time")))
+            .await
+            .expect("publish second usage observation");
+
+        let diagnostics = backend.diagnostics().await.expect("diagnostics").expect("embedded store diagnostics");
+        assert_eq!(diagnostics.event_count, 1, "usage observations retain only the latest watch handoff event");
+    }
+
+    #[test]
+    fn account_record_names_are_stable_case_insensitive_and_bounded() {
+        let lower = usage_record_name("user@example.com");
+        assert_eq!(lower, usage_record_name(" User@Example.COM "));
+        assert!(lower.starts_with("usage-"));
+        assert_eq!(lower.len(), 60);
+    }
+
+    #[tokio::test]
+    async fn in_memory_observation_history_is_thin() {
+        assert_observation_history_is_thin(ResourceBackend::InMemory(InMemoryBackend::default())).await;
+    }
+
+    #[tokio::test]
+    async fn sqlite_observation_history_is_thin() {
+        assert_observation_history_is_thin(ResourceBackend::Sqlite(SqliteBackend::open_in_memory().expect("sqlite backend"))).await;
+    }
+}

--- a/crates/flotilla-resources/tests/resource_projection.rs
+++ b/crates/flotilla-resources/tests/resource_projection.rs
@@ -5,7 +5,8 @@ use std::collections::BTreeMap;
 use common::{convoy_object, convoy_spec, convoy_status, timestamp};
 use flotilla_resources::{
     Checkout, CheckoutSpec, CheckoutWorktreeSpec, Convoy, ConvoyPhase, ConvoyRepositorySpec, InputMeta, K8sResourceObject,
-    LifecycleAuthority, ObservedCheckoutSpec, RepositoryKey, ResourceError, ResourceObject, AUTHORITY_LABEL,
+    LifecycleAuthority, ObservedCheckoutSpec, RepositoryKey, ResourceError, ResourceObject, Usage, UsageSpec, UsageStatus, UsageWindow,
+    AUTHORITY_LABEL,
 };
 
 #[test]
@@ -98,6 +99,57 @@ fn dispatch_observation_crd_parses_with_immutable_record_fields() {
     assert!(!required.iter().any(|field| field == "placement_policy"));
     assert!(required.iter().any(|field| field == "stance"));
     assert!(required.iter().any(|field| field == "time_from_ready_seconds"));
+}
+
+#[test]
+fn usage_resource_roundtrips_account_subject_and_window_set() {
+    let observed_at = "2026-08-06T10:39:55Z".parse().expect("valid timestamp");
+    let object = ResourceObject::<Usage> {
+        metadata: common::object_meta("usage-example", "flotilla", "3"),
+        spec: UsageSpec { account: "user@example.com".to_string() },
+        status: Some(UsageStatus {
+            provider: "codex".to_string(),
+            plan: Some("plus".to_string()),
+            organization: Some("example-org".to_string()),
+            windows: vec![
+                UsageWindow::builder().name("session").used_percent(8.0).window_minutes(300_u64).resets_at(observed_at).build(),
+                UsageWindow::builder().name("weekly").used_percent(100.0).window_minutes(10_080_u64).resets_at(observed_at).build(),
+            ],
+            pace: Vec::new(),
+            provider_cost: None,
+            reset_credits_available: Some(2),
+            observed_at,
+        }),
+    };
+
+    let json = serde_json::to_value(object.to_k8s_object()).expect("usage projection should serialize");
+    assert_eq!(json["spec"]["account"], "user@example.com");
+    assert_eq!(json["status"]["windows"][0]["name"], "session");
+    assert_eq!(json["status"]["windows"][1]["used_percent"], 100.0);
+    assert_eq!(json["status"]["observed_at"], "2026-08-06T10:39:55Z");
+
+    let roundtripped = ResourceObject::<Usage>::from_k8s_object(serde_json::from_value(json).expect("deserialize usage"))
+        .expect("usage projection should roundtrip");
+    assert_eq!(roundtripped.metadata.name, object.metadata.name);
+    assert_eq!(roundtripped.spec, object.spec);
+    assert_eq!(roundtripped.status, object.status);
+}
+
+#[test]
+fn usage_crd_requires_account_windows_and_observation_time() {
+    let usage: serde_json::Value = serde_yml::from_str(include_str!("../src/crds/usage.crd.yaml")).expect("Usage CRD should parse");
+
+    assert_eq!(usage["metadata"]["name"], "usages.flotilla.work");
+    assert_eq!(usage["spec"]["names"]["kind"], "Usage");
+    let spec_required = usage["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]["required"]
+        .as_array()
+        .expect("required usage spec fields");
+    assert!(spec_required.iter().any(|field| field == "account"));
+    let status_required = usage["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["status"]["required"]
+        .as_array()
+        .expect("required usage status fields");
+    assert!(status_required.iter().any(|field| field == "windows"));
+    assert!(status_required.iter().any(|field| field == "observed_at"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add the subject-keyed `Usage` observed resource and Kubernetes CRD
- preserve quota windows as a named list with pace, provider cost, reset-credit, identity, and observation metadata
- replicate usage observations fleet-wide and expose numeric/timestamp leaf paths through `usage/<account>`
- keep usage records standing (no demand-scoped garbage collection) with thin observation event history

Slice 2, the CodexBar poller/independent, remains out of scope pending #1396.

## Test plan

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1412