### PR TITLE
fix: launch crew adapters by absolute path

### DIFF
--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -1132,6 +1132,23 @@ mod tests {
         assert!(plan.command.contains("--model 'opus; touch /tmp/pwned'"));
     }
 
+    #[test]
+    fn launch_plan_uses_the_discovered_absolute_binary_path() {
+        let env = EnvironmentBag::new().with(EnvironmentAssertion::binary("claude", "/x/y/claude"));
+        let registry = AgentAdapterRegistry::discover(&env, Arc::new(MockRunner::new(Vec::new())));
+        let brief =
+            flotilla_resources::TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: String::new(), copies: Vec::new() };
+
+        let plan = registry
+            .get("claude-code")
+            .expect("claude adapter")
+            .launch(&AgentLaunchRequest { role: "coder".into(), model: None, brief })
+            .expect("launch plan");
+
+        assert!(plan.command.starts_with("/x/y/claude "));
+        assert!(!plan.command.starts_with("claude "));
+    }
+
     #[tokio::test]
     async fn claude_prepare_writes_a_settings_overlay_the_launch_command_loads() {
         let temp = tempfile::tempdir().expect("tempdir");

--- a/crates/flotilla-core/src/environment_manager.rs
+++ b/crates/flotilla-core/src/environment_manager.rs
@@ -993,7 +993,16 @@ mod tests {
         let handle: EnvironmentHandle = Arc::new(MockProvisionedEnvironment {
             id: env_id.clone(),
             image: ImageId::new("mock:image"),
-            runner: Arc::new(DiscoveryMockRunner::builder().on_run("codex", &["--version"], Ok("codex-cli 1.2.3".to_string())).build()),
+            runner: Arc::new(
+                DiscoveryMockRunner::builder()
+                    .on_run("codex", &["--version"], Ok("codex-cli 1.2.3".to_string()))
+                    .on_run(
+                        "sh",
+                        &["-lc", "command -v \"$1\"", "flotilla-binary-discovery", "codex"],
+                        Ok("/usr/local/bin/codex\n".to_string()),
+                    )
+                    .build(),
+            ),
             env_vars: HashMap::from([
                 (String::from("ANTHROPIC_API_KEY"), String::from("test-key")),
                 (String::from("FLOTILLA_ENVIRONMENT_ID"), String::from("env-discover-1")),

--- a/crates/flotilla-core/src/environment_manager.rs
+++ b/crates/flotilla-core/src/environment_manager.rs
@@ -998,7 +998,7 @@ mod tests {
                     .on_run("codex", &["--version"], Ok("codex-cli 1.2.3".to_string()))
                     .on_run(
                         "sh",
-                        &["-lc", "command -v \"$1\"", "flotilla-binary-discovery", "codex"],
+                        &["-c", "command -v \"$1\"", "flotilla-binary-discovery", "codex"],
                         Ok("/usr/local/bin/codex\n".to_string()),
                     )
                     .build(),

--- a/crates/flotilla-core/src/providers/discovery/detectors/claude.rs
+++ b/crates/flotilla-core/src/providers/discovery/detectors/claude.rs
@@ -58,7 +58,7 @@ mod tests {
     async fn claude_detector_found_on_path() {
         let runner = DiscoveryMockRunner::builder()
             .on_run("claude", &["--version"], Ok("1.0.20 (Claude Code)\n".into()))
-            .on_run("sh", &["-lc", "command -v \"$1\"", "flotilla-binary-discovery", "claude"], Ok("/x/y/claude\n".into()))
+            .on_run("sh", &["-c", "command -v \"$1\"", "flotilla-binary-discovery", "claude"], Ok("/x/y/claude\n".into()))
             .build();
         let assertions = ClaudeDetector.detect(&runner, &TestEnvVars::default()).await;
         assert_eq!(assertions.len(), 1);

--- a/crates/flotilla-core/src/providers/discovery/detectors/claude.rs
+++ b/crates/flotilla-core/src/providers/discovery/detectors/claude.rs
@@ -5,7 +5,10 @@ use std::path::{Path, PathBuf};
 use async_trait::async_trait;
 
 use crate::providers::{
-    discovery::{detectors::generic::parse_first_dotted_version, EnvVars, EnvironmentAssertion, HostDetector},
+    discovery::{
+        detectors::generic::{parse_first_dotted_version, resolve_binary_path},
+        EnvVars, EnvironmentAssertion, HostDetector,
+    },
     run, CommandRunner,
 };
 
@@ -15,14 +18,14 @@ pub struct ClaudeDetector;
 #[async_trait]
 impl HostDetector for ClaudeDetector {
     async fn detect(&self, runner: &dyn CommandRunner, env: &dyn EnvVars) -> Vec<EnvironmentAssertion> {
-        // 1. Check PATH — single call proves existence and captures version
+        // 1. Check PATH, then retain the exact executable that satisfied the probe.
         if let Ok(output) = run!(runner, "claude", &["--version"], Path::new(".")) {
-            return match parse_first_dotted_version(&output) {
-                Some(version) => {
-                    vec![EnvironmentAssertion::versioned_binary("claude", "claude", version)]
-                }
-                None => vec![EnvironmentAssertion::binary("claude", "claude")],
-            };
+            if let Some(path) = resolve_binary_path(runner, "claude").await {
+                return match parse_first_dotted_version(&output) {
+                    Some(version) => vec![EnvironmentAssertion::versioned_binary("claude", path, version)],
+                    None => vec![EnvironmentAssertion::binary("claude", path)],
+                };
+            }
         }
 
         // 2. Check known installation location via runner (not local filesystem)
@@ -53,13 +56,16 @@ mod tests {
 
     #[tokio::test]
     async fn claude_detector_found_on_path() {
-        let runner = DiscoveryMockRunner::builder().on_run("claude", &["--version"], Ok("1.0.20 (Claude Code)\n".into())).build();
+        let runner = DiscoveryMockRunner::builder()
+            .on_run("claude", &["--version"], Ok("1.0.20 (Claude Code)\n".into()))
+            .on_run("sh", &["-lc", "command -v \"$1\"", "flotilla-binary-discovery", "claude"], Ok("/x/y/claude\n".into()))
+            .build();
         let assertions = ClaudeDetector.detect(&runner, &TestEnvVars::default()).await;
         assert_eq!(assertions.len(), 1);
         match &assertions[0] {
             EnvironmentAssertion::BinaryAvailable { name, path, version } => {
                 assert_eq!(name, "claude");
-                assert_eq!(*path, ExecutionEnvironmentPath::new("claude"));
+                assert_eq!(*path, ExecutionEnvironmentPath::new("/x/y/claude"));
                 assert_eq!(version.as_deref(), Some("1.0.20"));
             }
             other => panic!("expected BinaryAvailable, got {other:?}"),

--- a/crates/flotilla-core/src/providers/discovery/detectors/generic.rs
+++ b/crates/flotilla-core/src/providers/discovery/detectors/generic.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 
@@ -30,25 +30,61 @@ pub struct CommandDetector {
     command: &'static str,
     args: &'static [&'static str],
     version_parser: VersionParser,
+    path_mode: BinaryPathMode,
+}
+
+enum BinaryPathMode {
+    CommandName,
+    ResolveAbsolute,
 }
 
 impl CommandDetector {
     pub fn new(command: &'static str, args: &'static [&'static str], version_parser: VersionParser) -> Self {
-        Self { command, args, version_parser }
+        Self { command, args, version_parser, path_mode: BinaryPathMode::CommandName }
+    }
+
+    pub fn with_resolved_path(mut self) -> Self {
+        self.path_mode = BinaryPathMode::ResolveAbsolute;
+        self
     }
 }
 
 #[async_trait]
 impl HostDetector for CommandDetector {
     async fn detect(&self, runner: &dyn CommandRunner, _env: &dyn EnvVars) -> Vec<EnvironmentAssertion> {
-        run!(runner, self.command, self.args, Path::new("."))
-            .ok()
-            .map(|output| match (self.version_parser)(&output) {
-                Some(version) => vec![EnvironmentAssertion::versioned_binary(self.command, self.command, version)],
-                None => vec![EnvironmentAssertion::binary(self.command, self.command)],
-            })
-            .unwrap_or_default()
+        let Ok(output) = run!(runner, self.command, self.args, Path::new(".")) else {
+            return Vec::new();
+        };
+        let path = match self.path_mode {
+            BinaryPathMode::CommandName => PathBuf::from(self.command),
+            BinaryPathMode::ResolveAbsolute => {
+                let Some(path) = resolve_binary_path(runner, self.command).await else {
+                    return Vec::new();
+                };
+                path
+            }
+        };
+        match (self.version_parser)(&output) {
+            Some(version) => vec![EnvironmentAssertion::versioned_binary(self.command, path, version)],
+            None => vec![EnvironmentAssertion::binary(self.command, path)],
+        }
     }
+}
+
+pub(super) async fn resolve_binary_path(runner: &dyn CommandRunner, command: &str) -> Option<PathBuf> {
+    // Resolve inside the runner's environment: provisioned and remote runners
+    // intentionally do not share the daemon process's PATH.
+    let output = runner
+        .run(
+            "sh",
+            &["-lc", "command -v \"$1\"", "flotilla-binary-discovery", command],
+            Path::new("."),
+            &crate::providers::ChannelLabel::Noop,
+        )
+        .await
+        .ok()?;
+    let path = PathBuf::from(output.trim());
+    path.is_absolute().then_some(path)
 }
 
 pub fn parse_first_dotted_version(output: &str) -> Option<String> {

--- a/crates/flotilla-core/src/providers/discovery/detectors/generic.rs
+++ b/crates/flotilla-core/src/providers/discovery/detectors/generic.rs
@@ -77,7 +77,7 @@ pub(super) async fn resolve_binary_path(runner: &dyn CommandRunner, command: &st
     let output = runner
         .run(
             "sh",
-            &["-lc", "command -v \"$1\"", "flotilla-binary-discovery", command],
+            &["-c", "command -v \"$1\"", "flotilla-binary-discovery", command],
             Path::new("."),
             &crate::providers::ChannelLabel::Noop,
         )

--- a/crates/flotilla-core/src/providers/discovery/detectors/mod.rs
+++ b/crates/flotilla-core/src/providers/discovery/detectors/mod.rs
@@ -120,8 +120,8 @@ mod tests {
         let runner = DiscoveryMockRunner::builder()
             .on_run("codex", &["--version"], Ok("codex-cli 0.5.0\n".into()))
             .on_run("claude", &["--version"], Ok("1.0.0 (Claude Code)\n".into()))
-            .on_run("sh", &["-lc", "command -v \"$1\"", "flotilla-binary-discovery", "codex"], Ok("/tools/codex\n".into()))
-            .on_run("sh", &["-lc", "command -v \"$1\"", "flotilla-binary-discovery", "claude"], Ok("/tools/claude\n".into()))
+            .on_run("sh", &["-c", "command -v \"$1\"", "flotilla-binary-discovery", "codex"], Ok("/tools/codex\n".into()))
+            .on_run("sh", &["-c", "command -v \"$1\"", "flotilla-binary-discovery", "claude"], Ok("/tools/claude\n".into()))
             .build();
         let bag = run_host_detectors(&default_host_detectors(), &runner, &TestEnvVars::new([("HOME", "/mock/home")])).await;
 

--- a/crates/flotilla-core/src/providers/discovery/detectors/mod.rs
+++ b/crates/flotilla-core/src/providers/discovery/detectors/mod.rs
@@ -15,7 +15,7 @@ pub fn default_host_detectors() -> Vec<Box<dyn HostDetector>> {
         Box::new(CommandDetector::new("gh", &["--version"], parse_first_dotted_version)),
         Box::new(claude::ClaudeDetector),
         Box::new(codex::CodexAuthDetector),
-        Box::new(CommandDetector::new("codex", &["--version"], parse_first_dotted_version)),
+        Box::new(CommandDetector::new("codex", &["--version"], parse_first_dotted_version).with_resolved_path()),
         Box::new(EnvVarDetector::new("HOME")),
         Box::new(EnvVarDetector::new("CODEX_HOME")),
         Box::new(EnvVarDetector::new("ANTHROPIC_API_KEY")),
@@ -120,6 +120,8 @@ mod tests {
         let runner = DiscoveryMockRunner::builder()
             .on_run("codex", &["--version"], Ok("codex-cli 0.5.0\n".into()))
             .on_run("claude", &["--version"], Ok("1.0.0 (Claude Code)\n".into()))
+            .on_run("sh", &["-lc", "command -v \"$1\"", "flotilla-binary-discovery", "codex"], Ok("/tools/codex\n".into()))
+            .on_run("sh", &["-lc", "command -v \"$1\"", "flotilla-binary-discovery", "claude"], Ok("/tools/claude\n".into()))
             .build();
         let bag = run_host_detectors(&default_host_detectors(), &runner, &TestEnvVars::new([("HOME", "/mock/home")])).await;
 

--- a/crates/flotilla-core/src/providers/discovery/mod.rs
+++ b/crates/flotilla-core/src/providers/discovery/mod.rs
@@ -1097,7 +1097,10 @@ mod orchestrator_tests {
 
     #[tokio::test]
     async fn provisioned_host_detection_preserves_all_env_vars_and_adds_binary_assertions() {
-        let runner = DiscoveryMockRunner::builder().on_run("codex", &["--version"], Ok("codex-cli 1.2.3".to_string())).build();
+        let runner = DiscoveryMockRunner::builder()
+            .on_run("codex", &["--version"], Ok("codex-cli 1.2.3".to_string()))
+            .on_run("sh", &["-lc", "command -v \"$1\"", "flotilla-binary-discovery", "codex"], Ok("/usr/local/bin/codex\n".to_string()))
+            .build();
         let env_vars = HashMap::from([
             ("HOME".to_string(), "/home/crew".to_string()),
             ("FLOTILLA_ENVIRONMENT_ID".to_string(), "contained-work".to_string()),

--- a/crates/flotilla-core/src/providers/discovery/mod.rs
+++ b/crates/flotilla-core/src/providers/discovery/mod.rs
@@ -1099,7 +1099,7 @@ mod orchestrator_tests {
     async fn provisioned_host_detection_preserves_all_env_vars_and_adds_binary_assertions() {
         let runner = DiscoveryMockRunner::builder()
             .on_run("codex", &["--version"], Ok("codex-cli 1.2.3".to_string()))
-            .on_run("sh", &["-lc", "command -v \"$1\"", "flotilla-binary-discovery", "codex"], Ok("/usr/local/bin/codex\n".to_string()))
+            .on_run("sh", &["-c", "command -v \"$1\"", "flotilla-binary-discovery", "codex"], Ok("/usr/local/bin/codex\n".to_string()))
             .build();
         let env_vars = HashMap::from([
             ("HOME".to_string(), "/home/crew".to_string()),

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -5375,10 +5375,10 @@ mod tests {
             DiscoveryMockRunner::builder()
                 .on_run("codex", &["--version"], Ok("codex-cli 1.2.3".to_string()))
                 .on_run("claude", &["--version"], Ok("1.0.0 (Claude Code)".to_string()))
-                .on_run("sh", &["-lc", "command -v \"$1\"", "flotilla-binary-discovery", "codex"], Ok("/usr/local/bin/codex\n".to_string()))
+                .on_run("sh", &["-c", "command -v \"$1\"", "flotilla-binary-discovery", "codex"], Ok("/usr/local/bin/codex\n".to_string()))
                 .on_run(
                     "sh",
-                    &["-lc", "command -v \"$1\"", "flotilla-binary-discovery", "claude"],
+                    &["-c", "command -v \"$1\"", "flotilla-binary-discovery", "claude"],
                     Ok("/usr/local/bin/claude\n".to_string()),
                 )
                 .build(),

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -5375,6 +5375,12 @@ mod tests {
             DiscoveryMockRunner::builder()
                 .on_run("codex", &["--version"], Ok("codex-cli 1.2.3".to_string()))
                 .on_run("claude", &["--version"], Ok("1.0.0 (Claude Code)".to_string()))
+                .on_run("sh", &["-lc", "command -v \"$1\"", "flotilla-binary-discovery", "codex"], Ok("/usr/local/bin/codex\n".to_string()))
+                .on_run(
+                    "sh",
+                    &["-lc", "command -v \"$1\"", "flotilla-binary-discovery", "claude"],
+                    Ok("/usr/local/bin/claude\n".to_string()),
+                )
                 .build(),
         );
         let handle: EnvironmentHandle = Arc::new(TestInteriorEnvironment {


### PR DESCRIPTION
Closes #1415

## What changed

- resolve PATH-discovered Claude Code and Codex executables to absolute paths inside the target execution environment
- retain those resolved paths in discovery assertions so adapter launch plans cross the cleat-daemon boundary without relying on its ambient PATH
- reject non-absolute resolution results instead of recording a bare command that cannot uphold placement admission
- add a launch-plan regression test and update host/provisioned-environment discovery fixtures

## Root cause

The version probes established that an adapter binary existed in the Flotilla runner environment, but recorded the bare command name. Cleat later evaluated that command in its daemon environment, whose PATH can differ or be stale.

The existing terminal and vessel reconciliation tests also verify the second reported failure mode: a reaped running session is marked stopped on the next observation, interrupts active work, and requests a restart.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`