### PR TITLE
fix: log agent adapter path resolution failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,6 +1177,7 @@ dependencies = [
  "toml",
  "toml_edit 0.22.27",
  "tracing",
+ "tracing-subscriber",
  "urlencoding",
  "uuid",
 ]

--- a/crates/flotilla-core/Cargo.toml
+++ b/crates/flotilla-core/Cargo.toml
@@ -49,6 +49,7 @@ flotilla-protocol = { path = "../flotilla-protocol", features = ["test-support"]
 flotilla-resources = { path = "../flotilla-resources", features = ["test-support"] }
 tempfile = "3"
 insta = "1"
+tracing-subscriber = { version = "0.3", features = ["fmt"] }
 
 [[test]]
 name = "in_process_daemon"

--- a/crates/flotilla-core/src/providers/discovery/detectors/generic.rs
+++ b/crates/flotilla-core/src/providers/discovery/detectors/generic.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
+use tracing::warn;
 
 use crate::providers::{
     discovery::{EnvVars, EnvironmentAssertion, HostDetector},
@@ -74,7 +75,7 @@ impl HostDetector for CommandDetector {
 pub(super) async fn resolve_binary_path(runner: &dyn CommandRunner, command: &str) -> Option<PathBuf> {
     // Resolve inside the runner's environment: provisioned and remote runners
     // intentionally do not share the daemon process's PATH.
-    let output = runner
+    let output = match runner
         .run(
             "sh",
             &["-c", "command -v \"$1\"", "flotilla-binary-discovery", command],
@@ -82,9 +83,20 @@ pub(super) async fn resolve_binary_path(runner: &dyn CommandRunner, command: &st
             &crate::providers::ChannelLabel::Noop,
         )
         .await
-        .ok()?;
+    {
+        Ok(output) => output,
+        Err(error) => {
+            warn!(binary = command, %error, "agent adapter binary path resolution failed after successful version probe");
+            return None;
+        }
+    };
     let path = PathBuf::from(output.trim());
-    path.is_absolute().then_some(path)
+    if path.is_absolute() {
+        Some(path)
+    } else {
+        warn!(binary = command, resolved_path = %path.display(), "agent adapter binary path resolution returned a relative path after successful version probe");
+        None
+    }
 }
 
 pub fn parse_first_dotted_version(output: &str) -> Option<String> {
@@ -133,11 +145,48 @@ pub fn parse_first_dotted_version(output: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        future::Future,
+        io::{self, Write},
+        sync::{Arc, Mutex},
+    };
+
+    use tracing::instrument::WithSubscriber;
+
     use super::*;
     use crate::{
         path_context::ExecutionEnvironmentPath,
         providers::discovery::test_support::{DiscoveryMockRunner, TestEnvVars},
     };
+
+    #[derive(Clone)]
+    struct LogWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for LogWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().expect("log capture lock should be healthy").write(buf)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    async fn capture_warn_logs<F: Future>(future: F) -> (F::Output, String) {
+        let log_output = Arc::new(Mutex::new(Vec::new()));
+        let writer = LogWriter(Arc::clone(&log_output));
+        let subscriber = tracing_subscriber::fmt()
+            .without_time()
+            .with_ansi(false)
+            .with_target(false)
+            .with_max_level(tracing::Level::WARN)
+            .with_writer(move || writer.clone())
+            .finish();
+
+        let output = future.with_subscriber(subscriber).await;
+        let logs = String::from_utf8(log_output.lock().expect("log capture lock should be healthy").clone()).expect("logs should be utf-8");
+        (output, logs)
+    }
 
     #[test]
     fn parse_first_dotted_version_handles_supported_outputs() {
@@ -184,5 +233,43 @@ mod tests {
                 && *path == ExecutionEnvironmentPath::new("gh")
                 && version.as_deref() == Some("2.49.0")
         ));
+    }
+
+    #[tokio::test]
+    async fn resolved_path_detector_warns_when_lookup_fails_after_successful_probe() {
+        let detector = CommandDetector::new("codex", &["--version"], parse_first_dotted_version).with_resolved_path();
+        let runner = DiscoveryMockRunner::builder()
+            .on_run("codex", &["--version"], Ok("codex-cli 0.5.0\n".into()))
+            .on_run("sh", &["-c", "command -v \"$1\"", "flotilla-binary-discovery", "codex"], Err("sh is unavailable".into()))
+            .build();
+        let (assertions, logs) = capture_warn_logs(detector.detect(&runner, &TestEnvVars::default())).await;
+
+        assert!(assertions.is_empty());
+        assert!(logs.contains("codex"), "warning should name the rejected binary: {logs}");
+        assert!(logs.contains("sh is unavailable"), "warning should explain the resolution failure: {logs}");
+    }
+
+    #[tokio::test]
+    async fn resolved_path_detector_warns_when_lookup_returns_relative_path() {
+        let detector = CommandDetector::new("codex", &["--version"], parse_first_dotted_version).with_resolved_path();
+        let runner = DiscoveryMockRunner::builder()
+            .on_run("codex", &["--version"], Ok("codex-cli 0.5.0\n".into()))
+            .on_run("sh", &["-c", "command -v \"$1\"", "flotilla-binary-discovery", "codex"], Ok("bin/codex\n".into()))
+            .build();
+        let (assertions, logs) = capture_warn_logs(detector.detect(&runner, &TestEnvVars::default())).await;
+
+        assert!(assertions.is_empty());
+        assert!(logs.contains("codex"), "warning should name the rejected binary: {logs}");
+        assert!(logs.contains("bin/codex"), "warning should include the rejected relative path: {logs}");
+    }
+
+    #[tokio::test]
+    async fn resolved_path_detector_keeps_missing_binary_quiet() {
+        let detector = CommandDetector::new("codex", &["--version"], parse_first_dotted_version).with_resolved_path();
+        let runner = DiscoveryMockRunner::builder().on_run("codex", &["--version"], Err("command not found".into())).build();
+        let (assertions, logs) = capture_warn_logs(detector.detect(&runner, &TestEnvVars::default())).await;
+
+        assert!(assertions.is_empty());
+        assert!(logs.is_empty(), "ordinary missing-binary detection should remain quiet: {logs}");
     }
 }


### PR DESCRIPTION
Closes #1430.

## What changed

- warn when an agent adapter's version probe succeeds but absolute-path resolution fails
- warn when path resolution returns a relative path, including the rejected path
- keep ordinary missing-binary detection quiet
- add focused tracing tests for all three transitions

## Why

Agent adapters must launch through an absolute executable path. Discovery already rejected failed or relative resolutions, but did so silently, making an otherwise successful probe followed by adapter omission difficult to diagnose.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
