### PR TITLE
fix: collect orphaned resource replicas

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -8435,9 +8435,20 @@ impl InProcessDaemon {
             return Ok(id);
         }
 
-        if let flotilla_protocol::CommandAction::ResourceDelete { namespace, kind, name } = &command.action {
+        if let flotilla_protocol::CommandAction::ResourceDelete { namespace, kind, name, replica_origin } = &command.action {
             let empty_identity = self.start_context_free_command(id, command.description().to_string());
-            let result = match flotilla_resources::delete_resource_kind(&self.resource_backend, namespace, kind, name).await {
+            let deleted = if let Some(origin_root) = replica_origin {
+                if self.peer_connection_status(origin_root).await == PeerConnectionState::Connected {
+                    Err(ResourceError::invalid(format!(
+                        "replica origin {origin_root} is connected; delete the authoritative resource instead"
+                    )))
+                } else {
+                    flotilla_resources::collect_resource_replica_kind(&self.resource_backend, namespace, kind, name, origin_root).await
+                }
+            } else {
+                flotilla_resources::delete_resource_kind(&self.resource_backend, namespace, kind, name).await
+            };
+            let result = match deleted {
                 Ok(deleted) => flotilla_protocol::CommandValue::ResourceDeleted(Box::new(ResourceJsonResponse {
                     kind: deleted.kind,
                     plural: deleted.plural,

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -8428,6 +8428,7 @@ impl InProcessDaemon {
                     plural: applied.plural,
                     namespace: applied.namespace,
                     value: applied.value,
+                    replica_origin: None,
                 })),
                 Err(error) => flotilla_protocol::CommandValue::Error { message: error.to_string() },
             };
@@ -8454,6 +8455,7 @@ impl InProcessDaemon {
                     plural: deleted.plural,
                     namespace: deleted.namespace,
                     value: deleted.value,
+                    replica_origin: replica_origin.clone(),
                 })),
                 Err(error) => flotilla_protocol::CommandValue::Error { message: error.to_string() },
             };

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -773,6 +773,85 @@ async fn resource_list_and_get_queries_return_wire_json() {
 }
 
 #[tokio::test]
+async fn orphaned_authority_record_can_be_collected_from_the_replica_store() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let daemon =
+        InProcessDaemon::new(vec![], test_config_store(temp.path().join("config")), fake_discovery(false), HostName::local()).await;
+    let authority_node = test_node("retired-authority");
+    let origin = authority_node.node_id.clone();
+    daemon.set_configured_peers(vec![authority_node.clone()]).await;
+
+    let local = daemon.resource_backend().using::<ResourceConvoy>("flotilla");
+    local
+        .create(
+            &InputMeta::builder().name("orphaned-convoy".to_string()).build(),
+            &flotilla_resources::ConvoySpec::builder().workflow_ref("wf".to_string()).build(),
+        )
+        .await
+        .expect("create authority record");
+    let authority_snapshot = local.list().await.expect("list authority record");
+    local.delete("orphaned-convoy").await.expect("authority store vanishes");
+    daemon
+        .resource_backend()
+        .replica_writer::<ResourceConvoy>(origin.clone(), "flotilla")
+        .replace(&authority_snapshot, chrono::Utc::now())
+        .await
+        .expect("retain stale replica after authority disappears");
+
+    let mut events = daemon.subscribe();
+    InProcessDaemon::publish_peer_connection_status(daemon.as_ref(), &authority_node, PeerConnectionState::Connected).await;
+    let refused_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ResourceDelete {
+                namespace: "flotilla".to_string(),
+                kind: "convoys".to_string(),
+                name: "orphaned-convoy".to_string(),
+                replica_origin: Some(origin.clone()),
+            },
+        })
+        .await
+        .expect("request collection while authority is connected");
+    let refused = recv_command_finished(&mut events, refused_id).await;
+    assert!(
+        matches!(refused, CommandValue::Error { ref message } if message.contains("is connected")),
+        "live authorities must retain their deletion authority: {refused:?}"
+    );
+
+    InProcessDaemon::publish_peer_connection_status(daemon.as_ref(), &authority_node, PeerConnectionState::Disconnected).await;
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ResourceDelete {
+                namespace: "flotilla".to_string(),
+                kind: "convoys".to_string(),
+                name: "orphaned-convoy".to_string(),
+                replica_origin: Some(origin),
+            },
+        })
+        .await
+        .expect("collect orphaned replica");
+
+    let result = recv_command_finished(&mut events, command_id).await;
+    assert!(matches!(result, CommandValue::ResourceDeleted(_)), "unexpected collection result: {result:?}");
+    assert!(
+        daemon
+            .resource_backend()
+            .including_replicas::<ResourceConvoy>("flotilla")
+            .list()
+            .await
+            .expect("list after collection")
+            .items
+            .is_empty(),
+        "the stale authority projection must be collectable"
+    );
+}
+
+#[tokio::test]
 async fn resource_watch_streams_current_update_and_resumed_delete_without_loss() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let daemon =

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -703,6 +703,8 @@ pub enum CommandAction {
         namespace: String,
         kind: String,
         name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        replica_origin: Option<crate::NodeId>,
     },
     ResourceWatch {
         namespace: String,

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -53,6 +53,8 @@ pub struct ResourceJsonResponse {
     pub plural: String,
     pub namespace: String,
     pub value: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "replicaOrigin")]
+    pub replica_origin: Option<crate::NodeId>,
 }
 
 /// Opaque position in one resource kind's ordered mutation stream.
@@ -1617,6 +1619,7 @@ mod tests {
                     "metadata": { "name": "demo" },
                     "spec": {}
                 }),
+                replica_origin: None,
             })),
             CommandValue::ResourceWatchEvent(Box::new(ResourceReadEnvelope {
                 api_version: "flotilla.work/v1".into(),

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -117,8 +117,8 @@ pub use project::{
 };
 pub use provisioning_identity::{canonicalize_repo_url, clone_key, descriptive_repo_slug, repo_key};
 pub use registry::{
-    apply_manifest_resource_document, apply_resource_document, delete_resource_kind, get_resource_kind, list_resource_kind,
-    list_resource_kind_including_replicas, list_resource_kind_replica_sources, quarantine_undecodable_stored_objects,
+    apply_manifest_resource_document, apply_resource_document, collect_resource_replica_kind, delete_resource_kind, get_resource_kind,
+    list_resource_kind, list_resource_kind_including_replicas, list_resource_kind_replica_sources, quarantine_undecodable_stored_objects,
     replica_cursor_for_resource_kind, resource_document_spec_hash, resource_list_api_version, watch_resource_kind,
     watch_resource_kind_from, watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, DynamicResourceList,
     DynamicResourceObject, DynamicResourceWatch, RegisteredResourceKind, REGISTERED_RESOURCE_KINDS,

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use chrono::Utc;
 use flotilla_protocol::NodeId;
 use futures::{stream::BoxStream, StreamExt};
 use serde::Deserialize;
@@ -324,6 +325,26 @@ pub async fn delete_resource_kind(
     dispatch_resource_kind!(lookup_resource_kind(requested_kind)?.resource, delete_typed(backend, namespace, name).await)
 }
 
+/// Deliberately collect one cached replica while preserving its read-only
+/// authority boundary.
+///
+/// The stored delete is timestamped and relayed like an ordinary replica
+/// tombstone, so stale copies from other peers cannot immediately resurrect
+/// the object. A later update from the original authority remains newer and
+/// can recreate it.
+pub async fn collect_resource_replica_kind(
+    backend: &ResourceBackend,
+    namespace: &str,
+    requested_kind: &str,
+    name: &str,
+    origin_root: &NodeId,
+) -> Result<DynamicResourceObject, ResourceError> {
+    dispatch_resource_kind!(
+        lookup_resource_kind(requested_kind)?.resource,
+        collect_replica_typed(backend, namespace, name, origin_root).await
+    )
+}
+
 pub async fn watch_resource_kind(
     backend: &ResourceBackend,
     namespace: &str,
@@ -547,6 +568,33 @@ async fn delete_typed<T: Resource>(backend: &ResourceBackend, namespace: &str, n
         plural: T::API_PATHS.plural.to_string(),
         namespace: namespace.to_string(),
         value: object_value(&object)?,
+    })
+}
+
+async fn collect_replica_typed<T: Resource>(
+    backend: &ResourceBackend,
+    namespace: &str,
+    name: &str,
+    origin_root: &NodeId,
+) -> Result<DynamicResourceObject, ResourceError> {
+    let replica = backend
+        .including_replicas::<T>(namespace)
+        .list_sources()
+        .await?
+        .items
+        .into_iter()
+        .find(|source| {
+            source.object.metadata.name == name
+                && matches!(&source.provenance, ResourceProvenance::Replica { origin_root: source_origin, .. } if source_origin == origin_root)
+        })
+        .ok_or_else(|| ResourceError::not_found(name))?;
+    let value = read_object_value(&replica)?;
+    backend.replica_writer::<T>(origin_root.clone(), namespace).apply(WatchEvent::Deleted(replica.object), Utc::now()).await?;
+    Ok(DynamicResourceObject {
+        kind: T::API_PATHS.kind.to_string(),
+        plural: T::API_PATHS.plural.to_string(),
+        namespace: namespace.to_string(),
+        value,
     })
 }
 

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -728,7 +728,17 @@ fn format_command_result(result: &flotilla_protocol::commands::CommandValue) -> 
         CommandValue::ResourceDeleted(response) => {
             let name = response.value["metadata"]["name"].as_str().unwrap_or("<unknown>");
             let api_version = response.value["apiVersion"].as_str().unwrap_or("<unknown>");
-            format!("deleted {api_version}/{}/{}/{name}\nControllers may recreate code-owned objects.", response.kind, response.namespace,)
+            if let Some(origin_root) = response.value["metadata"]["annotations"]["flotilla.work/origin-root"].as_str() {
+                format!(
+                    "collected replica {api_version}/{}/{}/{name} from {origin_root}\nA newer update from the authority may recreate it.",
+                    response.kind, response.namespace,
+                )
+            } else {
+                format!(
+                    "deleted {api_version}/{}/{}/{name}\nControllers may recreate code-owned objects.",
+                    response.kind, response.namespace,
+                )
+            }
         }
         CommandValue::ResourceWatchEvent(response) => flotilla_protocol::output::json_pretty(response),
         CommandValue::EnvironmentSpecRead { .. } => "environment spec read".to_string(),

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -728,7 +728,7 @@ fn format_command_result(result: &flotilla_protocol::commands::CommandValue) -> 
         CommandValue::ResourceDeleted(response) => {
             let name = response.value["metadata"]["name"].as_str().unwrap_or("<unknown>");
             let api_version = response.value["apiVersion"].as_str().unwrap_or("<unknown>");
-            if let Some(origin_root) = response.value["metadata"]["annotations"]["flotilla.work/origin-root"].as_str() {
+            if let Some(origin_root) = &response.replica_origin {
                 format!(
                     "collected replica {api_version}/{}/{}/{name} from {origin_root}\nA newer update from the authority may recreate it.",
                     response.kind, response.namespace,

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -530,7 +530,7 @@ mod command_result_human {
 
     use chrono::{Duration, Utc};
     use flotilla_protocol::{
-        commands::{CheckoutStatus, CommandValue, RepositoryIdentityChange},
+        commands::{CheckoutStatus, CommandValue, RepositoryIdentityChange, ResourceJsonResponse},
         qualified_path::{HostId, QualifiedPath},
         CrewListMember, CrewListResponse, FleetHealthResponse, FleetHostRow, FleetHostStaleness, FleetListResponse, FleetListRow,
         FleetObservationAgreement, FleetReplicaStatus, FleetStaleness, HostName, NodeId, PeerConnectionState, PreparedWorkspace,
@@ -674,6 +674,45 @@ mod command_result_human {
     #[test]
     fn cancelled() {
         assert_eq!(format_command_result(&CommandValue::Cancelled), "cancelled");
+    }
+
+    #[test]
+    fn resource_deleted_distinguishes_replica_collection() {
+        let response = ResourceJsonResponse {
+            kind: "Convoy".to_string(),
+            plural: "convoys".to_string(),
+            namespace: "flotilla".to_string(),
+            value: serde_json::json!({
+                "apiVersion": "flotilla.work/v1",
+                "metadata": {
+                    "name": "orphaned-convoy",
+                    "annotations": {"flotilla.work/origin-root": "retired-root"}
+                }
+            }),
+        };
+
+        assert_eq!(
+            format_command_result(&CommandValue::ResourceDeleted(Box::new(response))),
+            "collected replica flotilla.work/v1/Convoy/flotilla/orphaned-convoy from retired-root\nA newer update from the authority may recreate it."
+        );
+    }
+
+    #[test]
+    fn resource_deleted_preserves_authoritative_deletion_wording() {
+        let response = ResourceJsonResponse {
+            kind: "Convoy".to_string(),
+            plural: "convoys".to_string(),
+            namespace: "flotilla".to_string(),
+            value: serde_json::json!({
+                "apiVersion": "flotilla.work/v1",
+                "metadata": {"name": "local-convoy", "annotations": {}}
+            }),
+        };
+
+        assert_eq!(
+            format_command_result(&CommandValue::ResourceDeleted(Box::new(response))),
+            "deleted flotilla.work/v1/Convoy/flotilla/local-convoy\nControllers may recreate code-owned objects."
+        );
     }
 
     #[test]

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -686,9 +686,10 @@ mod command_result_human {
                 "apiVersion": "flotilla.work/v1",
                 "metadata": {
                     "name": "orphaned-convoy",
-                    "annotations": {"flotilla.work/origin-root": "retired-root"}
+                    "annotations": {}
                 }
             }),
+            replica_origin: Some(NodeId::new("retired-root")),
         };
 
         assert_eq!(
@@ -705,8 +706,12 @@ mod command_result_human {
             namespace: "flotilla".to_string(),
             value: serde_json::json!({
                 "apiVersion": "flotilla.work/v1",
-                "metadata": {"name": "local-convoy", "annotations": {}}
+                "metadata": {
+                    "name": "local-convoy",
+                    "annotations": {"flotilla.work/origin-root": "spoofed-root"}
+                }
             }),
+            replica_origin: None,
         };
 
         assert_eq!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -348,6 +348,12 @@ struct ResourceDeleteArgs {
     /// Resource namespace
     #[arg(long, default_value = "flotilla")]
     namespace: String,
+    /// Collect a read-only replica from this origin root
+    #[arg(long, value_name = "ORIGIN_ROOT")]
+    replica: Option<String>,
+    /// Route the deletion to a peer host
+    #[arg(long)]
+    host: Option<String>,
 }
 
 #[derive(clap::Args)]
@@ -1147,13 +1153,19 @@ async fn run_resource_command(cli: &Cli, command: ResourceSubCommand, format: Ou
             .await
         }
         ResourceSubCommand::Delete(args) => {
+            let node_id = resolve_optional_host_node(cli, args.host.as_deref()).await?;
             run_control_command(
                 cli,
                 Command {
-                    node_id: None,
+                    node_id,
                     provisioning_target: None,
                     context_repo: None,
-                    action: CommandAction::ResourceDelete { namespace: args.namespace, kind: args.kind, name: args.name },
+                    action: CommandAction::ResourceDelete {
+                        namespace: args.namespace,
+                        kind: args.kind,
+                        name: args.name,
+                        replica_origin: args.replica.map(flotilla_protocol::NodeId::new),
+                    },
                 },
                 format,
             )
@@ -2153,8 +2165,22 @@ mod tests {
         assert!(matches!(
             delete.command,
             Some(SubCommand::Resource {
-                command: ResourceSubCommand::Delete(ResourceDeleteArgs { kind, name, namespace })
+                command: ResourceSubCommand::Delete(ResourceDeleteArgs { kind, name, namespace, replica: None, host: None })
             }) if kind == "workflowtemplates" && name == "scratch" && namespace == "ops"
+        ));
+
+        let collect =
+            Cli::try_parse_from(["flotilla", "resource", "delete", "convoys", "orphan", "--replica", "retired-root", "--host", "feta"])
+                .expect("replica collection should parse");
+        assert!(matches!(
+            collect.command,
+            Some(SubCommand::Resource {
+                command: ResourceSubCommand::Delete(ResourceDeleteArgs {
+                    replica: Some(origin),
+                    host: Some(host),
+                    ..
+                })
+            }) if origin == "retired-root" && host == "feta"
         ));
 
         let apply = Cli::try_parse_from(["flotilla", "resource", "apply", "-f", "demand.yaml", "--namespace", "ops"])


### PR DESCRIPTION
Closes #1422.

## Summary

- add an explicit `resource delete --replica <origin-root>` escape hatch for authority-less replica records
- persist the collection as a replica tombstone so peer relay converges and stale copies cannot immediately resurrect the record
- refuse replica collection while its authority root is connected, preserving the authoritative deletion boundary
- support `--host` on resource deletion for targeted fleet maintenance
- cover authority disappearance and replica collection at the InProcessDaemon level

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
