### PR TITLE
fix: keep federated convoys on admitting store

### DIFF
--- a/crates/flotilla-controllers/tests/presentation_reconciler.rs
+++ b/crates/flotilla-controllers/tests/presentation_reconciler.rs
@@ -691,6 +691,7 @@ async fn create_ready_host(backend: &ResourceBackend, name: &str) {
         daemon_version: None,
         daemon_started_at: None,
         disk_free_bytes: None,
+        admission_free_space_floor_bytes: None,
     }
     .apply(&mut status);
     hosts.update_status(name, &created.metadata.resource_version, &status).await.expect("host status update should succeed");

--- a/crates/flotilla-controllers/tests/vessel_placement.rs
+++ b/crates/flotilla-controllers/tests/vessel_placement.rs
@@ -4,8 +4,8 @@ use chrono::Utc;
 use flotilla_controllers::reconcilers::VesselPlacementProjector;
 use flotilla_protocol::{NodeId, PlacementDecision, PlacementTargetHost};
 use flotilla_resources::{
-    Convoy, ConvoySpec, ConvoyStatus, InMemoryBackend, InputMeta, ResourceBackend, Vessel, VesselSpec, ACTUATOR_HOST_REF_ANNOTATION,
-    ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL,
+    Convoy, ConvoySpec, ConvoyStatus, InMemoryBackend, InputMeta, ResourceBackend, ResourceError, Vessel, VesselSpec,
+    ACTUATOR_HOST_REF_ANNOTATION, ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL,
 };
 
 const NAMESPACE: &str = "flotilla";
@@ -57,7 +57,7 @@ async fn placed_replica_is_projected_into_the_actuation_hosts_local_store() {
         .replace(&convoys.list().await.expect("list Convoys"), Utc::now())
         .await
         .expect("replicate Convoy");
-    feta.replica_writer::<Vessel>(kiwi_root, NAMESPACE)
+    feta.replica_writer::<Vessel>(kiwi_root.clone(), NAMESPACE)
         .replace(&kiwi.using::<Vessel>(NAMESPACE).list().await.expect("list Vessels"), Utc::now())
         .await
         .expect("replicate Vessel");
@@ -81,5 +81,26 @@ async fn placed_replica_is_projected_into_the_actuation_hosts_local_store() {
             .annotations
             .contains_key(ACTUATOR_SOURCE_ROOT_ANNOTATION),
         "projection must not transfer ownership of the admitting object"
+    );
+
+    kiwi.using::<Vessel>(NAMESPACE).delete("remote-placement-work").await.expect("owner requests Vessel deletion");
+    assert_eq!(
+        projector.sync_once().await.expect("reconcile from last-known replica"),
+        Default::default(),
+        "unreplicated owner deletion must freeze destructive actuation"
+    );
+    feta.using::<Vessel>(NAMESPACE)
+        .get("remote-placement-work")
+        .await
+        .expect("actuator Vessel must survive while its owner is unreachable");
+
+    feta.replica_writer::<Vessel>(kiwi_root, NAMESPACE)
+        .replace(&kiwi.using::<Vessel>(NAMESPACE).list().await.expect("list deleted owner Vessels"), Utc::now())
+        .await
+        .expect("replicate owner deletion");
+    assert_eq!(projector.sync_once().await.expect("apply observed deletion").deleted, 1);
+    assert!(
+        matches!(feta.using::<Vessel>(NAMESPACE).get("remote-placement-work").await, Err(ResourceError::NotFound { .. })),
+        "actuator teardown may proceed after owner deletion intent is observed"
     );
 }

--- a/crates/flotilla-core/src/admission.rs
+++ b/crates/flotilla-core/src/admission.rs
@@ -4,6 +4,10 @@ use sysinfo::Disks;
 
 const BYTES_PER_GIB: u64 = 1024 * 1024 * 1024;
 
+pub(crate) fn free_space_floor_bytes(floor_gib: u64) -> Result<u64, String> {
+    floor_gib.checked_mul(BYTES_PER_GIB).ok_or_else(|| format!("free-space floor is too large: {floor_gib} GiB"))
+}
+
 pub(crate) trait AvailableSpaceProbe: Send + Sync {
     fn measure(&self, path: &Path) -> Option<u64>;
 }
@@ -32,7 +36,7 @@ pub(crate) fn check_free_space_floor(probe: &dyn AvailableSpaceProbe, host: &str
     }
 
     let floor_bytes =
-        floor_gib.checked_mul(BYTES_PER_GIB).ok_or_else(|| format!("free-space floor for host `{host}` is too large: {floor_gib} GiB"))?;
+        free_space_floor_bytes(floor_gib).map_err(|_| format!("free-space floor for host `{host}` is too large: {floor_gib} GiB"))?;
     let free_bytes = probe
         .measure(path)
         .ok_or_else(|| format!("placement refused on host `{host}`: free space could not be measured for {}", path.display()))?;
@@ -43,7 +47,7 @@ pub fn measure_available_space(path: &Path) -> Option<u64> {
     SystemAvailableSpaceProbe.measure(path)
 }
 
-fn check_measured_free_space(host: &str, free_bytes: u64, floor_bytes: u64) -> Result<(), String> {
+pub(crate) fn check_measured_free_space(host: &str, free_bytes: u64, floor_bytes: u64) -> Result<(), String> {
     if free_bytes >= floor_bytes {
         return Ok(());
     }

--- a/crates/flotilla-core/src/executor.rs
+++ b/crates/flotilla-core/src/executor.rs
@@ -361,7 +361,6 @@ pub async fn build_plan(
         | CommandAction::CrewHandoff { .. }
         | CommandAction::ConvoyCreate { .. }
         | CommandAction::ConvoyStart { .. }
-        | CommandAction::ConvoyStartPrepared { .. }
         | CommandAction::WorkflowTemplateApply { .. }
         | CommandAction::ProjectAdd { .. }
         | CommandAction::ProjectApply { .. }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -4824,6 +4824,8 @@ impl InProcessDaemon {
                 ensure.spec.stance,
             )
             .await?;
+        self.check_local_free_space_floor().await?;
+        self.check_remote_placement_free_space_floor(namespace, admission.placement_decision.as_ref()).await?;
         if admission.workflow.exit.is_some() {
             return Err(format!(
                 "workflow template {} declares an exit table; standing convoys require no exit declaration",

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1725,6 +1725,14 @@ struct ConvoyAdmission {
     placement_decision: Option<PlacementDecision>,
 }
 
+#[derive(bon::Builder)]
+struct ConvoySnapshotBundle<'a> {
+    spec: &'a ConvoySpec,
+    workflow: &'a WorkflowTemplateSpec,
+    placement: Option<&'a PlacementPolicySpec>,
+    placement_decision: Option<PlacementDecision>,
+}
+
 /// An issue body is the crew's contract, so admission may only reuse a
 /// recently observed snapshot. Keep this deliberately fixed until an
 /// operational need establishes that it should be configurable.
@@ -1859,12 +1867,6 @@ fn checkout_integration_summary(checkout: &ResourceObject<ResourceCheckout>, int
 pub struct ExistingConvoyTarget {
     pub home: HostName,
     pub node_id: NodeId,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ConvoyStartTarget {
-    pub policy_name: String,
-    pub host_id: HostId,
 }
 
 pub struct InProcessDaemon {
@@ -2796,31 +2798,6 @@ impl InProcessDaemon {
         reconcile_registered_policy(&self.resource_backend, &namespace, &policy_name, &desired).await
     }
 
-    pub async fn resolve_convoy_start_target(
-        &self,
-        intent: &flotilla_protocol::ConvoyStartIntent,
-    ) -> Result<Option<ConvoyStartTarget>, String> {
-        let Some(policy_name) = intent.placement_policy.as_deref() else {
-            return Ok(None);
-        };
-        let namespace = intent.namespace.clone().unwrap_or(self.provisioning_namespace().await);
-        let policy = self
-            .resource_backend
-            .clone()
-            .using::<PlacementPolicy>(&namespace)
-            .get(policy_name)
-            .await
-            .map_err(|error| format!("placement policy {policy_name}: {error}"))?;
-        let Some(host_direct) = policy.spec.host_direct.as_ref() else {
-            return Ok(None);
-        };
-        let host_ref = host_direct.host_ref.as_str();
-        if self.local_host_id().as_ref().is_some_and(|host_id| host_id.as_str() == host_ref) {
-            return Ok(None);
-        }
-        Ok(Some(ConvoyStartTarget { policy_name: policy_name.to_string(), host_id: HostId::new(host_ref) }))
-    }
-
     pub async fn resolve_existing_convoy_target(
         &self,
         action: &flotilla_protocol::CommandAction,
@@ -2884,48 +2861,6 @@ impl InProcessDaemon {
             Err(ResourceError::NotFound { .. }) => Ok(false),
             Err(error) => Err(error.to_string()),
         }
-    }
-
-    /// Admit a convoy against this daemon's authoritative project resources,
-    /// then package immutable workflow and placement snapshots for the remote
-    /// execution host. This prevents a peer from re-resolving names against a
-    /// different daemon-local resource store.
-    pub async fn prepare_remote_convoy_start(
-        &self,
-        intent: &flotilla_protocol::ConvoyStartIntent,
-        dispatching_principal_ref: Option<&PrincipalRef>,
-    ) -> Result<flotilla_protocol::PreparedConvoyStart, String> {
-        let namespace = self.provisioning_namespace().await;
-        let default_namespace = intent.namespace.as_deref().unwrap_or(&namespace);
-        let (requested_namespace, intent) = normalize_convoy_start_intent(default_namespace, intent)?;
-        if requested_namespace != namespace {
-            return Err(format!("namespace `{requested_namespace}` is not served by this daemon (configured namespace: `{namespace}`)"));
-        }
-        let fallback_principal = PrincipalRef::implicit_for_namespace(&namespace);
-        let admission =
-            self.prepare_convoy_admission(&namespace, &intent, dispatching_principal_ref.unwrap_or(&fallback_principal)).await?;
-        let workflow_value = serde_json::to_value(&admission.workflow).map_err(|error| error.to_string())?;
-        let workflow_name = prepared_snapshot_name("workflow", &workflow_value)?;
-        let (placement_policy_name, placement_policy_spec) = match admission.placement_policy {
-            Some(spec) => {
-                let value = serde_json::to_value(spec).map_err(|error| error.to_string())?;
-                let name = prepared_snapshot_name("placement", &value)?;
-                (Some(name), Some(value))
-            }
-            None => (None, None),
-        };
-        Ok(flotilla_protocol::PreparedConvoyStart::builder()
-            .namespace(namespace)
-            .name(admission.name)
-            .convoy_spec(serde_json::to_value(admission.spec).map_err(|error| error.to_string())?)
-            .workflow_name(workflow_name)
-            .workflow_spec(workflow_value)
-            .maybe_placement_policy_name(placement_policy_name)
-            .maybe_placement_policy_spec(placement_policy_spec)
-            .maybe_placement_decision(admission.placement_decision)
-            .auto_attach(self.should_auto_attach(intent.auto_attach))
-            .dispatch_regard(intent.auto_attach.into())
-            .build())
     }
 
     pub async fn set_topology_routes(&self, routes: Vec<TopologyRoute>) {
@@ -4722,9 +4657,12 @@ impl InProcessDaemon {
         self.create_convoy_with_workflow_snapshot(
             namespace,
             &admission.name,
-            &admission.spec,
-            &admission.workflow,
-            admission.placement_decision,
+            ConvoySnapshotBundle::builder()
+                .spec(&admission.spec)
+                .workflow(&admission.workflow)
+                .maybe_placement(admission.placement_policy.as_ref())
+                .maybe_placement_decision(admission.placement_decision)
+                .build(),
             intent.auto_attach.into(),
         )
         .await?;
@@ -4890,6 +4828,12 @@ impl InProcessDaemon {
         let workflow_name = prepared_snapshot_name("workflow", &workflow_value)?;
         ensure_prepared_workflow_snapshot(&self.resource_backend, namespace, &workflow_name, &admission.workflow).await?;
         annotations.insert(flotilla_resources::WORKFLOW_SNAPSHOT_ANNOTATION.to_string(), workflow_name);
+        if let Some(placement) = &admission.placement_policy {
+            let placement_value = serde_json::to_value(placement).map_err(|error| error.to_string())?;
+            let placement_name = prepared_snapshot_name("placement", &placement_value)?;
+            ensure_prepared_placement_snapshot(&self.resource_backend, namespace, &placement_name, placement).await?;
+            annotations.insert(flotilla_resources::PLACEMENT_SNAPSHOT_ANNOTATION.to_string(), placement_name);
+        }
         self.create_convoy_with_annotations(
             namespace,
             &admission.name,
@@ -4941,23 +4885,21 @@ impl InProcessDaemon {
         &self,
         namespace: &str,
         name: &str,
-        spec: &ConvoySpec,
-        workflow: &WorkflowTemplateSpec,
-        placement_decision: Option<PlacementDecision>,
+        bundle: ConvoySnapshotBundle<'_>,
         dispatch_regard: ConvoyDispatchRegard,
     ) -> Result<(), String> {
+        let ConvoySnapshotBundle { spec, workflow, placement, placement_decision } = bundle;
         let workflow_value = serde_json::to_value(workflow).map_err(|error| error.to_string())?;
         let workflow_name = prepared_snapshot_name("workflow", &workflow_value)?;
         ensure_prepared_workflow_snapshot(&self.resource_backend, namespace, &workflow_name, workflow).await?;
-        self.create_convoy_with_annotations(
-            namespace,
-            name,
-            spec,
-            placement_decision,
-            dispatch_regard,
-            BTreeMap::from([(flotilla_resources::WORKFLOW_SNAPSHOT_ANNOTATION.to_string(), workflow_name)]),
-        )
-        .await
+        let mut annotations = BTreeMap::from([(flotilla_resources::WORKFLOW_SNAPSHOT_ANNOTATION.to_string(), workflow_name)]);
+        if let Some(placement) = placement {
+            let placement_value = serde_json::to_value(placement).map_err(|error| error.to_string())?;
+            let placement_name = prepared_snapshot_name("placement", &placement_value)?;
+            ensure_prepared_placement_snapshot(&self.resource_backend, namespace, &placement_name, placement).await?;
+            annotations.insert(flotilla_resources::PLACEMENT_SNAPSHOT_ANNOTATION.to_string(), placement_name);
+        }
+        self.create_convoy_with_annotations(namespace, name, spec, placement_decision, dispatch_regard, annotations).await
     }
 
     async fn create_convoy_with_annotations(
@@ -5066,128 +5008,6 @@ impl InProcessDaemon {
             },
             Ok(name) => flotilla_protocol::CommandValue::ConvoyStarted { name, attach_plan: None, binding: None },
             Err(message) => flotilla_protocol::CommandValue::Error { message },
-        }
-    }
-
-    async fn run_prepared_convoy_start(&self, start: flotilla_protocol::PreparedConvoyStart) -> flotilla_protocol::CommandValue {
-        match self.persist_prepared_convoy_start(&start).await {
-            Ok(()) if start.auto_attach => match self.wait_for_convoy_attach(&start.namespace, &start.name).await {
-                Ok(resolved) => flotilla_protocol::CommandValue::ConvoyStarted {
-                    name: start.name,
-                    attach_plan: Some(resolved.plan),
-                    binding: resolved.binding,
-                },
-                Err(message) => flotilla_protocol::CommandValue::Error { message },
-            },
-            Ok(()) => flotilla_protocol::CommandValue::ConvoyStarted { name: start.name, attach_plan: None, binding: None },
-            Err(message) => flotilla_protocol::CommandValue::Error { message },
-        }
-    }
-
-    async fn persist_prepared_convoy_start(&self, start: &flotilla_protocol::PreparedConvoyStart) -> Result<(), String> {
-        let namespace = self.provisioning_namespace().await;
-        if start.namespace != namespace {
-            return Err(format!("namespace `{}` is not served by this daemon (configured namespace: `{namespace}`)", start.namespace));
-        }
-        let convoy_spec: ConvoySpec =
-            serde_json::from_value(start.convoy_spec.clone()).map_err(|error| format!("invalid prepared convoy spec: {error}"))?;
-        let workflow_spec: WorkflowTemplateSpec =
-            serde_json::from_value(start.workflow_spec.clone()).map_err(|error| format!("invalid prepared workflow snapshot: {error}"))?;
-        let expected_workflow_name = prepared_snapshot_name("workflow", &start.workflow_spec)
-            .map_err(|error| format!("invalid prepared workflow snapshot: {error}"))?;
-        if expected_workflow_name != start.workflow_name {
-            return Err("prepared workflow snapshot name does not match its contents".to_string());
-        }
-        let placement_spec = match (&start.placement_policy_name, &start.placement_policy_spec) {
-            (Some(name), Some(value)) => {
-                let expected_name =
-                    prepared_snapshot_name("placement", value).map_err(|error| format!("invalid prepared placement snapshot: {error}"))?;
-                if expected_name != *name {
-                    return Err("prepared placement snapshot name does not match its contents".to_string());
-                }
-                let spec: PlacementPolicySpec =
-                    serde_json::from_value(value.clone()).map_err(|error| format!("invalid prepared placement snapshot: {error}"))?;
-                let local_host_id = self.local_host_id().ok_or_else(|| "local Host identity is unavailable".to_string())?;
-                let target_host = spec
-                    .host_direct
-                    .as_ref()
-                    .map(|host_direct| host_direct.host_ref.as_str())
-                    .ok_or_else(|| "prepared remote placement is not host-direct".to_string())?;
-                if target_host != local_host_id.as_str() {
-                    return Err(format!(
-                        "prepared remote placement targets host `{target_host}`, but this daemon serves `{local_host_id}`"
-                    ));
-                }
-                Some((name, spec))
-            }
-            (None, None) if convoy_spec.placement_policy.is_none() => None,
-            _ => return Err("prepared convoy placement snapshot is incomplete".to_string()),
-        };
-
-        let convoys = self.resource_backend.clone().using::<ResourceConvoy>(&namespace);
-        match convoys.get(&start.name).await {
-            Ok(_) => return Err(format!("convoy {} already exists", start.name)),
-            Err(ResourceError::NotFound { .. }) => {}
-            Err(error) => return Err(error.to_string()),
-        }
-        // The target daemon is authoritative for its own capacity. Keep this
-        // ahead of the prepared Convoy claim and snapshot persistence so a
-        // refusal cannot leave any partial resource state behind.
-        self.check_local_free_space_floor().await?;
-        let mut annotations = BTreeMap::from([(flotilla_resources::WORKFLOW_SNAPSHOT_ANNOTATION.to_string(), start.workflow_name.clone())]);
-        if let Some(name) = &start.placement_policy_name {
-            annotations.insert(flotilla_resources::PLACEMENT_SNAPSHOT_ANNOTATION.to_string(), name.clone());
-        }
-        annotations.insert(flotilla_resources::PREPARED_SNAPSHOT_PENDING_ANNOTATION.to_string(), "true".to_string());
-        self.create_convoy_with_annotations(
-            &namespace,
-            &start.name,
-            &convoy_spec,
-            start.placement_decision.clone(),
-            flotilla_protocol::ConvoyDispatchRegard::Suppress,
-            annotations,
-        )
-        .await?;
-
-        let prepared = async {
-            ensure_prepared_workflow_snapshot(&self.resource_backend, &namespace, &start.workflow_name, &workflow_spec).await?;
-            if let Some((name, spec)) = &placement_spec {
-                ensure_prepared_placement_snapshot(&self.resource_backend, &namespace, name, spec).await?;
-            }
-            self.finish_prepared_convoy_claim(&namespace, &start.name).await
-        }
-        .await;
-        if let Err(error) = prepared {
-            if let Err(cleanup_error) = convoys.delete(&start.name).await {
-                warn!(%cleanup_error, %namespace, convoy = %start.name, "failed to remove incomplete prepared convoy claim");
-            }
-            if let Err(cleanup_error) = flotilla_resources::PreparedSnapshotGarbageCollector::new(self.resource_backend.clone(), &namespace)
-                .collect(Some(&start.name))
-                .await
-            {
-                warn!(%cleanup_error, %namespace, convoy = %start.name, "failed to collect snapshots after prepared convoy admission error");
-            }
-            return Err(error);
-        }
-        if start.dispatch_regard == flotilla_protocol::ConvoyDispatchRegard::Emit {
-            if let Err(error) = self.emit_implicit_convoy_regard(&namespace, &start.name, &convoy_spec.dispatching_principal_ref).await {
-                warn!(%error, %namespace, convoy = %start.name, "failed to emit convoy dispatch regard");
-            }
-        }
-        Ok(())
-    }
-
-    async fn finish_prepared_convoy_claim(&self, namespace: &str, name: &str) -> Result<(), String> {
-        let convoys = self.resource_backend.clone().using::<ResourceConvoy>(namespace);
-        loop {
-            let convoy = convoys.get(name).await.map_err(|error| error.to_string())?;
-            let mut meta = InputMeta::from(&convoy.metadata);
-            meta.annotations.remove(flotilla_resources::PREPARED_SNAPSHOT_PENDING_ANNOTATION);
-            match convoys.update(&meta, &convoy.metadata.resource_version, &convoy.spec).await {
-                Ok(_) => return Ok(()),
-                Err(ResourceError::Conflict { .. }) => continue,
-                Err(error) => return Err(error.to_string()),
-            }
         }
     }
 
@@ -8689,25 +8509,6 @@ impl InProcessDaemon {
             return Ok(id);
         }
 
-        if let flotilla_protocol::CommandAction::ConvoyStartPrepared { start } = &command.action {
-            let empty_identity = self.start_context_free_command(id, command.description().to_string());
-            let start = start.as_ref().clone();
-            if let Some(daemon) = self.self_weak.upgrade() {
-                tokio::spawn(async move {
-                    let result = match AssertUnwindSafe(daemon.run_prepared_convoy_start(start)).catch_unwind().await {
-                        Ok(result) => result,
-                        Err(_) => flotilla_protocol::CommandValue::Error { message: "prepared convoy start worker panicked".to_string() },
-                    };
-                    daemon.finish_context_free_command(id, empty_identity, result);
-                });
-            } else {
-                self.finish_context_free_command(id, empty_identity, flotilla_protocol::CommandValue::Error {
-                    message: "convoy start worker is unavailable".to_string(),
-                });
-            }
-            return Ok(id);
-        }
-
         if let flotilla_protocol::CommandAction::ConvoyCreate {
             name,
             workflow_ref,
@@ -8985,7 +8786,7 @@ impl InProcessDaemon {
                 },
                 None => None,
             };
-            let placement_policy = placement.selected.map(|placement| placement.metadata.name);
+            let placement_policy = placement.selected.as_ref().map(|placement| placement.metadata.name.clone());
             let spec = ConvoySpec {
                 workflow_ref: workflow_ref.clone(),
                 dispatching_principal_ref: dispatching_principal_ref
@@ -9005,9 +8806,12 @@ impl InProcessDaemon {
                 .create_convoy_with_workflow_snapshot(
                     &namespace,
                     name,
-                    &spec,
-                    &workflow.spec,
-                    placement_decision,
+                    ConvoySnapshotBundle::builder()
+                        .spec(&spec)
+                        .workflow(&workflow.spec)
+                        .maybe_placement(placement.selected.as_ref().map(|placement| &placement.spec))
+                        .maybe_placement_decision(placement_decision)
+                        .build(),
                     ConvoyDispatchRegard::Emit,
                 )
                 .await

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -2798,6 +2798,30 @@ impl InProcessDaemon {
         reconcile_registered_policy(&self.resource_backend, &namespace, &policy_name, &desired).await
     }
 
+    pub async fn remote_host_direct_placement_host(
+        &self,
+        intent: &flotilla_protocol::ConvoyStartIntent,
+    ) -> Result<Option<flotilla_protocol::qualified_path::HostId>, String> {
+        let Some(policy_name) = intent.placement_policy.as_deref() else {
+            return Ok(None);
+        };
+        let namespace = intent.namespace.clone().unwrap_or(self.provisioning_namespace().await);
+        let policy = self
+            .resource_backend
+            .clone()
+            .using::<PlacementPolicy>(&namespace)
+            .get(policy_name)
+            .await
+            .map_err(|error| format!("placement policy {policy_name}: {error}"))?;
+        let Some(host_direct) = policy.spec.host_direct else {
+            return Ok(None);
+        };
+        if self.local_host_id().as_ref().is_some_and(|host_id| host_id.as_str() == host_direct.host_ref) {
+            return Ok(None);
+        }
+        Ok(Some(flotilla_protocol::qualified_path::HostId::new(host_direct.host_ref)))
+    }
+
     pub async fn resolve_existing_convoy_target(
         &self,
         action: &flotilla_protocol::CommandAction,

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -4925,14 +4925,14 @@ impl InProcessDaemon {
         let matching_sources =
             sources.items.into_iter().filter(|source| source.object.metadata.name == target_host.reference).collect::<Vec<_>>();
         let has_replica = matching_sources.iter().any(|source| matches!(source.provenance, ResourceProvenance::Replica { .. }));
-        let is_remote_host_direct = self
+        let is_host_targeted_placement = self
             .resource_backend
             .clone()
             .using::<PlacementPolicy>(namespace)
             .get(&placement.policy_name)
             .await
-            .is_ok_and(|policy| policy.spec.host_direct.is_some());
-        if !has_replica && !is_remote_host_direct {
+            .is_ok_and(|policy| placement_host_ref(&policy).is_some());
+        if !has_replica && !is_host_targeted_placement {
             return Ok(());
         }
 

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -4654,6 +4654,7 @@ impl InProcessDaemon {
     ) -> Result<String, String> {
         self.check_local_free_space_floor().await?;
         let admission = self.prepare_convoy_admission(namespace, intent, dispatching_principal_ref).await?;
+        self.check_remote_placement_free_space_floor(namespace, admission.placement_decision.as_ref()).await?;
         self.create_convoy_with_workflow_snapshot(
             namespace,
             &admission.name,
@@ -4879,6 +4880,51 @@ impl InProcessDaemon {
         })
         .await
         .map_err(|error| format!("free-space check failed on host `{}`: {error}", self.host_name))?
+    }
+
+    pub fn admission_free_space_floor_bytes(&self) -> Result<u64, String> {
+        let floor_gib = self.config.load_daemon_config()?.admission.free_space_floor_gib;
+        crate::admission::free_space_floor_bytes(floor_gib)
+    }
+
+    async fn check_remote_placement_free_space_floor(&self, namespace: &str, placement: Option<&PlacementDecision>) -> Result<(), String> {
+        let Some(placement) = placement else {
+            return Ok(());
+        };
+        let target_host = &placement.target_host;
+        if self.local_host_id().as_ref().is_some_and(|host_id| host_id.as_str() == target_host.reference) {
+            return Ok(());
+        }
+
+        let sources =
+            self.resource_backend.including_replicas::<ResourceHost>(namespace).list().await.map_err(|error| error.to_string())?;
+        let matching_sources =
+            sources.items.into_iter().filter(|source| source.object.metadata.name == target_host.reference).collect::<Vec<_>>();
+        let has_replica = matching_sources.iter().any(|source| matches!(source.provenance, ResourceProvenance::Replica { .. }));
+        let is_remote_host_direct = self
+            .resource_backend
+            .clone()
+            .using::<PlacementPolicy>(namespace)
+            .get(&placement.policy_name)
+            .await
+            .is_ok_and(|policy| policy.spec.host_direct.is_some());
+        if !has_replica && !is_remote_host_direct {
+            return Ok(());
+        }
+
+        let capacity = matching_sources
+            .into_iter()
+            .filter_map(|source| source.object.status)
+            .find_map(|status| status.admission_free_space_floor_bytes.map(|floor| (floor, status.disk_free_bytes)));
+        let Some((floor_bytes, free_bytes)) = capacity else {
+            return Err(format!("placement refused on host `{}`: admission free-space floor is unavailable", target_host.display_name));
+        };
+        if floor_bytes == 0 {
+            return Ok(());
+        }
+        let free_bytes =
+            free_bytes.ok_or_else(|| format!("placement refused on host `{}`: free space is unavailable", target_host.display_name))?;
+        crate::admission::check_measured_free_space(&target_host.display_name, free_bytes, floor_bytes)
     }
 
     async fn create_convoy_with_workflow_snapshot(

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -2800,16 +2800,16 @@ impl InProcessDaemon {
 
     pub async fn remote_host_direct_placement_host(
         &self,
-        intent: &flotilla_protocol::ConvoyStartIntent,
+        namespace: &str,
+        policy_name: Option<&str>,
     ) -> Result<Option<flotilla_protocol::qualified_path::HostId>, String> {
-        let Some(policy_name) = intent.placement_policy.as_deref() else {
+        let Some(policy_name) = policy_name else {
             return Ok(None);
         };
-        let namespace = intent.namespace.clone().unwrap_or(self.provisioning_namespace().await);
         let policy = self
             .resource_backend
             .clone()
-            .using::<PlacementPolicy>(&namespace)
+            .using::<PlacementPolicy>(namespace)
             .get(policy_name)
             .await
             .map_err(|error| format!("placement policy {policy_name}: {error}"))?;
@@ -8856,6 +8856,16 @@ impl InProcessDaemon {
                 },
                 None => None,
             };
+            if let Err(message) = self.check_remote_placement_free_space_floor(&namespace, placement_decision.as_ref()).await {
+                let _ = self.event_tx.send(DaemonEvent::CommandFinished {
+                    command_id: id,
+                    node_id: self.node_id.clone(),
+                    repo_identity: empty_identity,
+                    repo: None,
+                    result: flotilla_protocol::CommandValue::Error { message },
+                });
+                return Ok(id);
+            }
             let placement_policy = placement.selected.as_ref().map(|placement| placement.metadata.name.clone());
             let spec = ConvoySpec {
                 workflow_ref: workflow_ref.clone(),

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1060,13 +1060,6 @@ async fn peer_summary_registration_preserves_operator_fields_and_corrects_owned_
         .await
         .expect("peer host capabilities should admit the workflow");
 
-    let intent =
-        ConvoyStartIntent::builder().project_ref("flotilla".to_string()).placement_policy("host-direct-feta-host".to_string()).build();
-    assert_eq!(
-        daemon.resolve_convoy_start_target(&intent).await.expect("placement should resolve"),
-        Some(ConvoyStartTarget { policy_name: "host-direct-feta-host".to_string(), host_id: HostId::new("feta-host") })
-    );
-
     let policies = daemon.resource_backend().using::<PlacementPolicy>("flotilla");
     let registered = policies.get("host-direct-feta-host").await.expect("peer placement policy");
     policies
@@ -1122,8 +1115,6 @@ async fn peer_summary_registration_preserves_operator_fields_and_corrects_owned_
         )
         .await
         .expect("local placement policy create");
-    let local_intent = ConvoyStartIntent::builder().project_ref("flotilla".to_string()).placement_policy("local-pool".to_string()).build();
-    assert_eq!(daemon.resolve_convoy_start_target(&local_intent).await.expect("non-host-direct placement should remain local"), None);
 }
 
 #[tokio::test]

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -149,7 +149,7 @@ async fn standing_convoy_ensure_starts_restarts_with_backoff_and_recovers_from_r
                 workflow_ref: "quartermaster".to_string(),
                 placement_policy: None,
                 stance: Some(Stance::Trusted),
-                repositories: vec![repository_key],
+                repositories: vec![repository_key.clone()],
                 presents_as: Some("fleet".to_string()),
             },
         )
@@ -209,6 +209,56 @@ async fn standing_convoy_ensure_starts_restarts_with_backoff_and_recovers_from_r
     clock.advance(ChronoDuration::seconds(30));
     daemon.reconcile_convoy_ensures_once("flotilla").await.expect("restart after reap");
     assert!(convoys.get("quartermaster").await.is_ok());
+
+    let hosts = backend.using::<ResourceHost>("flotilla");
+    let remote_host = hosts
+        .create(&empty_input_meta("remote-capacity-unknown"), &HostSpec { display_name: "remote-capacity-unknown".to_string() })
+        .await
+        .expect("remote host");
+    hosts
+        .update_status("remote-capacity-unknown", &remote_host.metadata.resource_version, &HostStatus {
+            ready: true,
+            heartbeat_at: Some(now),
+            ..HostStatus::default()
+        })
+        .await
+        .expect("remote host ready without capacity");
+    backend
+        .using::<PlacementPolicy>("flotilla")
+        .create(
+            &empty_input_meta("remote-capacity-unknown"),
+            &PlacementPolicySpec::builder()
+                .pool("passthrough".to_string())
+                .host_direct(HostDirectPlacementPolicySpec {
+                    host_ref: "remote-capacity-unknown".to_string(),
+                    checkout: HostDirectPlacementPolicyCheckout::Worktree,
+                })
+                .build(),
+        )
+        .await
+        .expect("remote placement");
+    backend
+        .definitions::<ConvoyEnsure>("flotilla")
+        .create(
+            &InputMeta::builder()
+                .name("capacity-starved".to_string())
+                .annotations(BTreeMap::from([(SOURCE_COMMIT_ANNOTATION.to_string(), "abc123".to_string())]))
+                .build(),
+            &ConvoyEnsureSpec {
+                project_ref: "standing-project".to_string(),
+                workflow_ref: "quartermaster".to_string(),
+                placement_policy: Some("remote-capacity-unknown".to_string()),
+                stance: Some(Stance::Trusted),
+                repositories: vec![repository_key],
+                presents_as: None,
+            },
+        )
+        .await
+        .expect("capacity-starved ensure declaration");
+
+    let error = daemon.reconcile_convoy_ensures_once("flotilla").await.expect_err("missing remote capacity must refuse ensure");
+    assert!(error.contains("admission free-space floor is unavailable"), "{error}");
+    assert!(matches!(convoys.get("capacity-starved").await, Err(ResourceError::NotFound { .. })));
 }
 
 #[test]

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -7172,6 +7172,8 @@ async fn local_convoy_admission_pins_the_grant_resolved_workflow() {
             ready: true,
             heartbeat_at: Some(Utc::now()),
             capabilities: BTreeMap::from([(flotilla_resources::HELD_CREDENTIALS_CAPABILITY.to_string(), serde_json::json!(["model-api"]))]),
+            disk_free_bytes: Some(100 * 1024 * 1024 * 1024),
+            admission_free_space_floor_bytes: Some(20 * 1024 * 1024 * 1024),
             resource_store: None,
             ..HostStatus::default()
         })

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -51,8 +51,8 @@ use flotilla_resources::{
     CheckoutSpec as ResourceCheckoutSpec, Convoy as ResourceConvoy, ConvoyPhase, DockerCheckoutStrategy,
     DockerPerVesselPlacementPolicySpec, Host as ResourceHost, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec,
     HostStatus, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project, ProjectRepositorySpec,
-    ProjectSpec, Regard, RegardExpiryPolicy, RegardSource, Repository, RepositoryRelation, RepositorySpec, Stance, TypedResolver,
-    WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate, AGENT_ADAPTERS_CAPABILITY, REPO_KEY_LABEL, REPO_LABEL,
+    ProjectSpec, Regard, RegardExpiryPolicy, RegardSource, Repository, RepositoryRelation, RepositorySpec, ResourceError, Stance,
+    TypedResolver, WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate, AGENT_ADAPTERS_CAPABILITY, REPO_KEY_LABEL, REPO_LABEL,
 };
 use tokio::sync::Notify;
 
@@ -905,6 +905,19 @@ async fn resource_watch_streams_current_update_and_resumed_delete_without_loss()
 }
 
 async fn create_test_contained_policy(backend: &flotilla_resources::ResourceBackend, image: &str, agent_adapters: BTreeSet<String>) {
+    let hosts = backend.clone().using::<ResourceHost>("flotilla");
+    let host = match hosts.get("host-test").await {
+        Ok(host) => host,
+        Err(ResourceError::NotFound { .. }) => hosts
+            .create(&InputMeta::builder().name("host-test".to_string()).build(), &HostSpec::default())
+            .await
+            .expect("test placement host create"),
+        Err(error) => panic!("get test placement host: {error}"),
+    };
+    let mut status = host.status.unwrap_or_default();
+    status.disk_free_bytes = Some(100 * 1024 * 1024 * 1024);
+    status.admission_free_space_floor_bytes = Some(20 * 1024 * 1024 * 1024);
+    hosts.update_status("host-test", &host.metadata.resource_version, &status).await.expect("publish test placement host capacity");
     backend
         .clone()
         .using::<PlacementPolicy>("flotilla")

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -1219,6 +1219,8 @@ async fn create_test_host_direct_policy(
             capabilities: [(AGENT_ADAPTERS_CAPABILITY.to_string(), serde_json::json!(agent_adapters))].into_iter().collect(),
             heartbeat_at: Some(chrono::Utc::now()),
             ready: true,
+            disk_free_bytes: Some(100 * 1024 * 1024 * 1024),
+            admission_free_space_floor_bytes: Some(20 * 1024 * 1024 * 1024),
             resource_store: None,
             ..HostStatus::default()
         })

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -1245,6 +1245,7 @@ async fn apply_host_heartbeat_with_credentials(
     let disk_free_bytes = tokio::task::spawn_blocking(move || measure_available_space(&repo_default_dir))
         .await
         .map_err(|error| format!("measure available disk space: {error}"))?;
+    let admission_free_space_floor_bytes = daemon.admission_free_space_floor_bytes()?;
     let mut conditions = runtime_health.conditions().await;
     conditions.extend(file_descriptor_pressure_condition());
     if let Some(condition) = resource_decode_quarantine_condition(resource_store.as_ref()) {
@@ -1273,6 +1274,7 @@ async fn apply_host_heartbeat_with_credentials(
         daemon_version: Some(health.version.clone()),
         daemon_started_at: Some(health.started_at),
         disk_free_bytes,
+        admission_free_space_floor_bytes: Some(admission_free_space_floor_bytes),
         conditions,
         sleep_inhibition: host.status.as_ref().map(|status| status.sleep_inhibition.clone()).unwrap_or_default(),
     };

--- a/crates/flotilla-daemon/src/server/remote_commands.rs
+++ b/crates/flotilla-daemon/src/server/remote_commands.rs
@@ -175,14 +175,23 @@ impl RemoteCommandRouter {
         if let Some(target) = existing_convoy_target.as_ref() {
             command.node_id = Some(target.node_id.clone());
         }
-        if let CommandAction::ConvoyStart { intent } = &command.action {
-            if let Some(host_id) = self.daemon.remote_host_direct_placement_host(intent).await? {
-                let peer_manager = self.peer_manager.lock().await;
-                let environment_id = EnvironmentId::host(host_id.clone());
-                let (node_id, host_name) =
-                    peer_manager.node_for_host_environment(&environment_id).map_err(|_| format!("peer host {host_id} is not connected"))?;
-                peer_manager.resolve_sender(&node_id).map_err(|_| format!("peer host {host_name} is not connected"))?;
+        let remote_host_direct = match &command.action {
+            CommandAction::ConvoyStart { intent } => {
+                let namespace = intent.namespace.clone().unwrap_or(self.daemon.provisioning_namespace().await);
+                self.daemon.remote_host_direct_placement_host(&namespace, intent.placement_policy.as_deref()).await?
             }
+            CommandAction::ConvoyCreate { placement_policy, .. } => {
+                let namespace = self.daemon.provisioning_namespace().await;
+                self.daemon.remote_host_direct_placement_host(&namespace, placement_policy.as_deref()).await?
+            }
+            _ => None,
+        };
+        if let Some(host_id) = remote_host_direct {
+            let peer_manager = self.peer_manager.lock().await;
+            let environment_id = EnvironmentId::host(host_id.clone());
+            let (node_id, host_name) =
+                peer_manager.node_for_host_environment(&environment_id).map_err(|_| format!("peer host {host_id} is not connected"))?;
+            peer_manager.resolve_sender(&node_id).map_err(|_| format!("peer host {host_name} is not connected"))?;
         }
         let target_node_id = command.node_id.clone().unwrap_or_else(|| self.daemon.node_id().clone());
         let local = self.daemon.node_id();

--- a/crates/flotilla-daemon/src/server/remote_commands.rs
+++ b/crates/flotilla-daemon/src/server/remote_commands.rs
@@ -11,12 +11,12 @@ use std::{
 use async_trait::async_trait;
 use flotilla_core::{
     daemon::DaemonHandle,
-    in_process::{ConvoyStartTarget, InProcessDaemon},
+    in_process::InProcessDaemon,
     step::{RemoteStepBatchRequest, RemoteStepExecutor, RemoteStepProgressSink, RemoteStepProgressUpdate, StepOutcome},
 };
 use flotilla_protocol::{
-    Command, CommandAction, CommandPeerEvent, CommandValue, CrewCommandContext, DaemonEvent, EnvironmentId, HostName, NodeId,
-    PeerWireMessage, RepoIdentity, RepoSelector, RoutedPeerMessage, Step, StepStatus,
+    Command, CommandAction, CommandPeerEvent, CommandValue, CrewCommandContext, DaemonEvent, HostName, NodeId, PeerWireMessage,
+    RepoIdentity, RepoSelector, RoutedPeerMessage, Step, StepStatus,
 };
 use flotilla_resources::CrewCompletionPending;
 use tokio::sync::{oneshot, Mutex, Notify};
@@ -124,13 +124,6 @@ pub(super) struct RemoteCommandRouter {
     retrying_crew_completions: Arc<StdMutex<HashMap<String, CrewCompletionRetryState>>>,
 }
 
-#[derive(bon::Builder)]
-struct PlacementRoute {
-    host_name: HostName,
-    node_id: NodeId,
-    sender: Arc<dyn PeerSender>,
-}
-
 impl RemoteCommandRouter {
     pub(super) fn new(
         daemon: Arc<InProcessDaemon>,
@@ -165,9 +158,6 @@ impl RemoteCommandRouter {
         mut command: Command,
         dispatching_principal_ref: Option<flotilla_protocol::PrincipalRef>,
     ) -> Result<u64, String> {
-        if matches!(command.action, CommandAction::ConvoyStartPrepared { .. }) {
-            return Err("prepared convoy starts are reserved for authenticated peer forwarding".to_string());
-        }
         let mut crew_completion = self.resolve_crew_command_routing(&mut command.action).await?;
         let existing_convoy_target = self.daemon.resolve_existing_convoy_target(&command.action).await?;
         if let (Some(completion), Some(target)) = (&mut crew_completion, &existing_convoy_target) {
@@ -185,25 +175,6 @@ impl RemoteCommandRouter {
         if let Some(target) = existing_convoy_target.as_ref() {
             command.node_id = Some(target.node_id.clone());
         }
-        let placement_route = if let CommandAction::ConvoyStart { intent } = &command.action {
-            let placement_target = self.daemon.resolve_convoy_start_target(intent).await?;
-            let placement_route = match placement_target {
-                Some(target) => Some(self.resolve_placement_route(target).await?),
-                None => None,
-            };
-            let intended_target = placement_route.as_ref().map(|route| &route.node_id).unwrap_or_else(|| self.daemon.node_id());
-            if command.node_id.as_ref().is_some_and(|target| target != intended_target) {
-                return Err("convoy command target does not match its host-direct placement policy".to_string());
-            }
-            if intended_target != self.daemon.node_id() {
-                command.node_id = Some(intended_target.clone());
-                let prepared = self.daemon.prepare_remote_convoy_start(intent, dispatching_principal_ref.as_ref()).await?;
-                command.action = CommandAction::ConvoyStartPrepared { start: Box::new(prepared) };
-            }
-            placement_route
-        } else {
-            None
-        };
         let target_node_id = command.node_id.clone().unwrap_or_else(|| self.daemon.node_id().clone());
         let local = self.daemon.node_id();
         let desc = command.description();
@@ -212,8 +183,7 @@ impl RemoteCommandRouter {
             if command.action.is_query()
                 || matches!(
                     command.action,
-                    CommandAction::ConvoyStartPrepared { .. }
-                        | CommandAction::ConvoyDelete { .. }
+                    CommandAction::ConvoyDelete { .. }
                         | CommandAction::ConvoyAbandon { .. }
                         | CommandAction::ConvoyResume { .. }
                         | CommandAction::ConvoyWorkForceComplete { .. }
@@ -257,14 +227,7 @@ impl RemoteCommandRouter {
                 };
                 let send_result = match &existing_convoy_target {
                     Some(target) => self.send_routed_to_convoy_home(&target.home, &target.node_id, routed).await,
-                    None => match &placement_route {
-                        Some(route) => route
-                            .sender
-                            .send(PeerWireMessage::Routed(routed))
-                            .await
-                            .map_err(|cause| format!("peer host {} is not connected: {cause}", route.host_name)),
-                        None => self.send_routed_to(&target_node_id, routed).await,
-                    },
+                    None => self.send_routed_to(&target_node_id, routed).await,
                 };
 
                 match send_result {
@@ -1081,18 +1044,6 @@ impl RemoteCommandRouter {
                 authority: Some(HostName::new(pending.authority)),
             });
         }
-    }
-
-    async fn resolve_placement_route(&self, target: ConvoyStartTarget) -> Result<PlacementRoute, String> {
-        let environment_id = EnvironmentId::host(target.host_id.clone());
-        let (host_name, node_id, sender) = {
-            let pm = self.peer_manager.lock().await;
-            let (node_id, host_name) =
-                pm.node_for_host_environment(&environment_id).map_err(|_| format!("peer host {} is not connected", target.host_id))?;
-            let sender = pm.resolve_sender(&node_id).map_err(|_| format!("peer host {host_name} is not connected"))?;
-            (host_name, node_id, sender)
-        };
-        Ok(PlacementRoute::builder().host_name(host_name).node_id(node_id).sender(sender).build())
     }
 
     async fn send_routed_to_convoy_home(

--- a/crates/flotilla-daemon/src/server/remote_commands.rs
+++ b/crates/flotilla-daemon/src/server/remote_commands.rs
@@ -15,8 +15,8 @@ use flotilla_core::{
     step::{RemoteStepBatchRequest, RemoteStepExecutor, RemoteStepProgressSink, RemoteStepProgressUpdate, StepOutcome},
 };
 use flotilla_protocol::{
-    Command, CommandAction, CommandPeerEvent, CommandValue, CrewCommandContext, DaemonEvent, HostName, NodeId, PeerWireMessage,
-    RepoIdentity, RepoSelector, RoutedPeerMessage, Step, StepStatus,
+    Command, CommandAction, CommandPeerEvent, CommandValue, CrewCommandContext, DaemonEvent, EnvironmentId, HostName, NodeId,
+    PeerWireMessage, RepoIdentity, RepoSelector, RoutedPeerMessage, Step, StepStatus,
 };
 use flotilla_resources::CrewCompletionPending;
 use tokio::sync::{oneshot, Mutex, Notify};
@@ -174,6 +174,15 @@ impl RemoteCommandRouter {
         }
         if let Some(target) = existing_convoy_target.as_ref() {
             command.node_id = Some(target.node_id.clone());
+        }
+        if let CommandAction::ConvoyStart { intent } = &command.action {
+            if let Some(host_id) = self.daemon.remote_host_direct_placement_host(intent).await? {
+                let peer_manager = self.peer_manager.lock().await;
+                let environment_id = EnvironmentId::host(host_id.clone());
+                let (node_id, host_name) =
+                    peer_manager.node_for_host_environment(&environment_id).map_err(|_| format!("peer host {host_id} is not connected"))?;
+                peer_manager.resolve_sender(&node_id).map_err(|_| format!("peer host {host_name} is not connected"))?;
+            }
         }
         let target_node_id = command.node_id.clone().unwrap_or_else(|| self.daemon.node_id().clone());
         let local = self.daemon.node_id();

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -31,11 +31,11 @@ use flotilla_protocol::{
     AGENT_ADAPTER_PROVIDER_CATEGORY, PROTOCOL_VERSION, TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
-    list_resource_kind, Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoySpec, CrewSessionStatus,
-    HttpBackend, InMemoryBackend, InputMeta, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, ResourceBackend,
-    ResourceError, ResourceList, ResourceProvenance, Selector, SqliteBackend, Stance, StatusPatch, TerminalAttentionState, TerminalBrief,
-    TerminalCrewContext, TerminalSession, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus, TerminalSessionStatusPatch,
-    WatchEvent, WatchStart, WorkflowTemplate,
+    list_resource_kind, Checkout as ResourceCheckout, CheckoutSpec as ResourceCheckoutSpec, Convoy, ConvoySpec, CrewSessionStatus, Host,
+    HostSpec, HostStatus, HttpBackend, InMemoryBackend, InputMeta, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy,
+    ResourceBackend, ResourceError, ResourceList, ResourceProvenance, Selector, SqliteBackend, Stance, StatusPatch, TerminalAttentionState,
+    TerminalBrief, TerminalCrewContext, TerminalSession, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatus,
+    TerminalSessionStatusPatch, WatchEvent, WatchStart, WorkflowTemplate,
 };
 use flotilla_test_support::TestSocketDir;
 use flotilla_transport::message::{message_session_pair, MessageSession};
@@ -1687,6 +1687,26 @@ async fn dispatch_execute_keeps_remote_placement_convoy_on_the_admitting_store()
     let (_tmp, daemon) = empty_daemon().await;
     let (_remote_tmp, remote_daemon) = empty_daemon_named("feta").await;
     let remote_host_id = remote_daemon.local_host_id().expect("remote host identity").to_string();
+    let remote_hosts = remote_daemon.resource_backend().using::<Host>("flotilla");
+    let remote_host = remote_hosts
+        .create(&InputMeta::builder().name(remote_host_id.clone()).build(), &HostSpec::default())
+        .await
+        .expect("create remote host resource");
+    remote_hosts
+        .update_status(&remote_host_id, &remote_host.metadata.resource_version, &HostStatus {
+            ready: true,
+            disk_free_bytes: Some(100 * 1024 * 1024 * 1024),
+            admission_free_space_floor_bytes: Some(20 * 1024 * 1024 * 1024),
+            ..HostStatus::default()
+        })
+        .await
+        .expect("publish remote host capacity");
+    daemon
+        .resource_backend()
+        .replica_writer::<Host>(remote_daemon.node_id().clone(), "flotilla")
+        .replace(&remote_hosts.list().await.expect("list remote host resources"), chrono::Utc::now())
+        .await
+        .expect("replicate remote host capacity");
     let remote_policy_name = format!("host-direct-{remote_host_id}");
     let remote_summary = HostSummary::builder()
         .environment_id(EnvironmentId::host(flotilla_protocol::qualified_path::HostId::new(&remote_host_id)))

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -1683,7 +1683,7 @@ async fn crew_completion_partition_is_persisted_and_names_the_unreachable_author
 }
 
 #[tokio::test]
-async fn dispatch_execute_routes_remote_convoy_start_as_a_whole_daemon_command() {
+async fn dispatch_execute_keeps_remote_placement_convoy_on_the_admitting_store() {
     let (_tmp, daemon) = empty_daemon().await;
     let (_remote_tmp, remote_daemon) = empty_daemon_named("feta").await;
     let remote_host_id = remote_daemon.local_host_id().expect("remote host identity").to_string();
@@ -1705,7 +1705,6 @@ async fn dispatch_execute_routes_remote_convoy_start_as_a_whole_daemon_command()
     let forwarded_commands = Arc::new(Mutex::new(HashMap::new()));
     let pending_remote_cancels = Arc::new(Mutex::new(HashMap::new()));
     let next_remote_command_id = Arc::new(AtomicU64::new(1 << 62));
-    let sent = Arc::new(StdMutex::new(Vec::new()));
     peer_manager.lock().await.store_host_summary(remote_summary);
     let remote_command_router = make_remote_command_router(
         &daemon,
@@ -1729,108 +1728,45 @@ async fn dispatch_execute_routes_remote_convoy_start_as_a_whole_daemon_command()
         })
         .build();
 
-    assert_eq!(
-        remote_command_router.dispatch_execute(command.clone()).await.expect_err("missing live route must reject remote placement"),
-        "peer host feta is not connected"
-    );
-
-    peer_manager.lock().await.register_sender(NodeId::new("feta"), Arc::new(MockPeerSender { sent: Arc::clone(&sent) }));
-
-    let mut mismatched = command.clone();
-    mismatched.node_id = Some(daemon.node_id().clone());
-    assert_eq!(
-        remote_command_router.dispatch_execute(mismatched).await.expect_err("explicit local target must not override remote placement"),
-        "convoy command target does not match its host-direct placement policy"
-    );
-
-    remote_command_router.dispatch_execute(command.clone()).await.expect("remote convoy start should dispatch");
-
-    assert_eq!(pending_remote_commands.lock().await.len(), 1);
-    let (routed, workflow_snapshot_name, placement_snapshot_name) = {
-        let sent = sent.lock().expect("lock sent messages");
-        let [PeerWireMessage::Routed(RoutedPeerMessage::CommandRequest { target_node_id, command: routed, .. })] = sent.as_slice() else {
-            panic!("expected one routed command request");
-        };
-        assert_eq!(*target_node_id, node("feta"));
-        assert_eq!(routed.node_id.as_ref(), Some(&node("feta")));
-        let CommandAction::ConvoyStartPrepared { start } = &routed.action else {
-            panic!("remote launch must carry an admitted convoy snapshot");
-        };
-        assert!(start.workflow_name.starts_with("workflow-snapshot-"));
-        let placement_snapshot_name = start.placement_policy_name.clone().expect("prepared placement snapshot name");
-        assert!(placement_snapshot_name.starts_with("placement-snapshot-"));
-        let mut delivered = routed.as_ref().clone();
-        delivered.node_id = None;
-        (delivered, start.workflow_name.clone(), placement_snapshot_name)
-    };
-
-    assert_eq!(
-        remote_command_router.dispatch_execute(routed.clone()).await.expect_err("client-submitted prepared start must be rejected"),
-        "prepared convoy starts are reserved for authenticated peer forwarding"
-    );
-
-    let mut remote_events = remote_daemon.subscribe();
-    let remote_command_id = remote_daemon.execute(routed.clone()).await.expect("prepared command should be accepted by remote daemon");
-    let remote_result = wait_for_command_result(&mut remote_events, remote_command_id, StdDuration::from_secs(5)).await;
-    assert_eq!(remote_result, CommandValue::ConvoyStarted { name: "remote-work".to_string(), attach_plan: None, binding: None });
-    let remote_backend = remote_daemon.resource_backend();
-    let convoy = remote_backend.clone().using::<Convoy>("flotilla").get("remote-work").await.expect("remote daemon should persist convoy");
-    assert_eq!(convoy.spec.workflow_ref, "remote-workflow");
-    assert_eq!(convoy.spec.placement_policy.as_deref(), Some(remote_policy_name.as_str()));
-    let remote_workflow = remote_backend
-        .clone()
-        .using::<WorkflowTemplate>("flotilla")
-        .get(&workflow_snapshot_name)
-        .await
-        .expect("remote daemon should persist workflow snapshot");
-    assert_eq!(remote_workflow.spec.vessels[0].stance, Stance::Trusted);
-    let remote_policy = remote_backend
-        .clone()
-        .using::<PlacementPolicy>("flotilla")
-        .get(&placement_snapshot_name)
-        .await
-        .expect("remote daemon should persist placement snapshot");
-    assert_eq!(remote_policy.spec.host_direct.expect("host-direct snapshot").host_ref, remote_host_id);
-
-    let mut repeated = match &routed.action {
-        CommandAction::ConvoyStartPrepared { start } => start.as_ref().clone(),
-        _ => panic!("routed command must remain a prepared convoy start"),
-    };
-    repeated.name = "remote-work-again".to_string();
-    let mut repeated_spec: serde_json::Value = repeated.convoy_spec.clone();
-    repeated_spec["ref"] = serde_json::Value::String("feat/remote-work-again".to_string());
-    repeated.convoy_spec = repeated_spec;
-    let mut repeated_events = remote_daemon.subscribe();
-    let repeated_id = remote_daemon
-        .execute(Command::builder().action(CommandAction::ConvoyStartPrepared { start: Box::new(repeated) }).build())
-        .await
-        .expect("repeated prepared command should be accepted");
-    assert_eq!(wait_for_command_result(&mut repeated_events, repeated_id, StdDuration::from_secs(5)).await, CommandValue::ConvoyStarted {
-        name: "remote-work-again".to_string(),
+    let mut events = daemon.subscribe();
+    let command_id = remote_command_router.dispatch_execute(command).await.expect("admitting daemon should accept remote placement");
+    assert_eq!(wait_for_command_result(&mut events, command_id, StdDuration::from_secs(5)).await, CommandValue::ConvoyStarted {
+        name: "remote-work".to_string(),
         attach_plan: None,
         binding: None
     });
-    let prepared_workflows = remote_backend
+    assert!(pending_remote_commands.lock().await.is_empty(), "placement must not create a routed command");
+
+    let admitting_backend = daemon.resource_backend();
+    let convoy =
+        admitting_backend.clone().using::<Convoy>("flotilla").get("remote-work").await.expect("admitting daemon should own the convoy");
+    assert_eq!(convoy.spec.workflow_ref, "remote-workflow");
+    assert_eq!(convoy.spec.placement_policy.as_deref(), Some(remote_policy_name.as_str()));
+    let workflow_snapshot_name =
+        convoy.metadata.annotations.get(flotilla_resources::WORKFLOW_SNAPSHOT_ANNOTATION).expect("pinned workflow annotation");
+    let placement_snapshot_name =
+        convoy.metadata.annotations.get(flotilla_resources::PLACEMENT_SNAPSHOT_ANNOTATION).expect("pinned placement annotation");
+    let admitting_workflow = admitting_backend
         .clone()
         .using::<WorkflowTemplate>("flotilla")
-        .list()
+        .get(workflow_snapshot_name)
         .await
-        .expect("list workflow snapshots")
-        .items
-        .into_iter()
-        .filter(|workflow| workflow.metadata.name == workflow_snapshot_name)
-        .count();
-    let prepared_placements = remote_backend
+        .expect("admitting daemon should retain the pinned workflow");
+    assert_eq!(admitting_workflow.spec.vessels[0].stance, Stance::Trusted);
+    let admitting_placement = admitting_backend
+        .clone()
         .using::<PlacementPolicy>("flotilla")
-        .list()
+        .get(placement_snapshot_name)
         .await
-        .expect("list placement snapshots")
-        .items
-        .into_iter()
-        .filter(|policy| policy.metadata.name == placement_snapshot_name)
-        .count();
-    assert_eq!(prepared_workflows, 1);
-    assert_eq!(prepared_placements, 1);
+        .expect("admitting daemon should retain the pinned placement");
+    assert_eq!(admitting_placement.spec.host_direct.expect("host-direct snapshot").host_ref, remote_host_id);
+    assert!(
+        matches!(
+            remote_daemon.resource_backend().using::<Convoy>("flotilla").get("remote-work").await,
+            Err(ResourceError::NotFound { .. })
+        ),
+        "placement host must not become convoy authority"
+    );
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -1725,7 +1725,11 @@ async fn dispatch_execute_keeps_remote_placement_convoy_on_the_admitting_store()
     let forwarded_commands = Arc::new(Mutex::new(HashMap::new()));
     let pending_remote_cancels = Arc::new(Mutex::new(HashMap::new()));
     let next_remote_command_id = Arc::new(AtomicU64::new(1 << 62));
-    peer_manager.lock().await.store_host_summary(remote_summary);
+    let sent = Arc::new(StdMutex::new(Vec::new()));
+    let mut peer_manager_guard = peer_manager.lock().await;
+    peer_manager_guard.store_host_summary(remote_summary);
+    peer_manager_guard.register_sender(NodeId::new("feta"), Arc::new(MockPeerSender { sent: Arc::clone(&sent) }));
+    drop(peer_manager_guard);
     let remote_command_router = make_remote_command_router(
         &daemon,
         &peer_manager,
@@ -1756,6 +1760,7 @@ async fn dispatch_execute_keeps_remote_placement_convoy_on_the_admitting_store()
         binding: None
     });
     assert!(pending_remote_commands.lock().await.is_empty(), "placement must not create a routed command");
+    assert!(sent.lock().expect("sent messages").is_empty(), "placement availability preflight must not route the admission command");
 
     let admitting_backend = daemon.resource_backend();
     let convoy =

--- a/crates/flotilla-daemon/tests/request_session_pair.rs
+++ b/crates/flotilla-daemon/tests/request_session_pair.rs
@@ -171,6 +171,8 @@ async fn convoy_creation_attributes_provenance_and_regard_to_the_surface_princip
         .await
         .expect("create workflow");
     let follower = empty_daemon_named("follower").await;
+    seed_host_capacity(&follower, 2 * 1024 * 1024 * 1024, 1024 * 1024 * 1024).await;
+    let follower_host_id = follower.local_host_id().expect("follower host identity").to_string();
     let principal_ref = PrincipalRef { namespace: "flotilla".to_string(), name: "alice".to_string() };
     let topology = spawn_in_memory_request_topology_stateful_with_surface(Arc::clone(&leader), follower, SurfaceDeclaration {
         principal_ref: principal_ref.clone(),
@@ -178,6 +180,7 @@ async fn convoy_creation_attributes_provenance_and_regard_to_the_surface_princip
     })
     .await
     .expect("spawn named focal client topology");
+    await_host_capacity(&leader, &follower_host_id).await;
     let mut events = leader.subscribe();
 
     let command_id = topology
@@ -736,6 +739,37 @@ async fn remote_docker_admission_fails_closed_without_target_capacity() {
     assert!(
         matches!(daemon.resource_backend().using::<Convoy>(namespace).get("remote-docker-work").await, Err(ResourceError::NotFound { .. })),
         "missing remote Docker capacity must fail before convoy persistence"
+    );
+
+    let legacy_command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyCreate {
+                name: "legacy-remote-docker-work".to_string(),
+                workflow_ref: "remote-workflow".to_string(),
+                inputs: Vec::new(),
+                repository_url: None,
+                r#ref: None,
+                project_ref: None,
+                placement_policy: Some("remote-docker".to_string()),
+                adopted_checkout: None,
+            },
+        })
+        .await
+        .expect("dispatch legacy remote Docker admission");
+    let legacy_result = await_command_result(&mut events, legacy_command_id).await;
+    let CommandValue::Error { message } = legacy_result else {
+        panic!("expected legacy missing-capacity refusal, got {legacy_result:?}");
+    };
+    assert_eq!(message, "placement refused on host `remote-docker`: admission free-space floor is unavailable");
+    assert!(
+        matches!(
+            daemon.resource_backend().using::<Convoy>(namespace).get("legacy-remote-docker-work").await,
+            Err(ResourceError::NotFound { .. })
+        ),
+        "legacy missing remote Docker capacity must fail before convoy persistence"
     );
 }
 

--- a/crates/flotilla-daemon/tests/request_session_pair.rs
+++ b/crates/flotilla-daemon/tests/request_session_pair.rs
@@ -459,7 +459,7 @@ async fn hostless_convoy_delete_uses_live_peer_route_when_connection_status_is_s
 }
 
 #[tokio::test]
-async fn convoy_start_uses_live_peer_route_when_presentation_membership_is_stale() {
+async fn convoy_start_stays_on_admitting_store_when_placement_membership_is_stale() {
     let leader = empty_daemon_named("leader").await;
     let follower = empty_daemon_named("follower").await;
     follower.set_local_placement_capabilities(&BTreeSet::from(["codex".to_string()]), &["cleat".to_string()]).await;
@@ -523,7 +523,7 @@ async fn convoy_start_uses_live_peer_route_when_presentation_membership_is_stale
             },
         })
         .await
-        .expect("live peer route should admit remote placement despite stale presentation membership");
+        .expect("admitting store should accept remote placement despite stale presentation membership");
 
     assert_eq!(await_command_result(&mut events, command_id).await, CommandValue::ConvoyStarted {
         name: "remote-work".to_string(),
@@ -531,16 +531,23 @@ async fn convoy_start_uses_live_peer_route_when_presentation_membership_is_stale
         binding: None
     });
     topology
-        .follower
+        .leader
         .resource_backend()
         .using::<Convoy>(namespace)
         .get("remote-work")
         .await
-        .expect("convoy should be created on live placement host");
+        .expect("convoy should remain on the admitting store");
+    assert!(
+        matches!(
+            topology.follower.resource_backend().using::<Convoy>(namespace).get("remote-work").await,
+            Err(ResourceError::NotFound { .. })
+        ),
+        "placement host must not become the convoy authority"
+    );
 }
 
 #[tokio::test]
-async fn remote_convoy_start_enforces_target_free_space_floor_without_leaving_prepared_state() {
+async fn remote_convoy_start_does_not_move_admission_to_target_capacity_authority() {
     let leader = empty_daemon_named("leader").await;
     let follower = empty_daemon_named_with_floor("follower", Some(1_000_000)).await;
     follower.set_local_placement_capabilities(&BTreeSet::from(["codex".to_string()]), &["cleat".to_string()]).await;
@@ -560,28 +567,6 @@ async fn remote_convoy_start_enforces_target_free_space_floor_without_leaving_pr
     .await
     .expect("peer host summary should materialize placement policy");
     seed_trusted_remote_convoy_project(&topology.leader, namespace).await;
-
-    let follower_backend = topology.follower.resource_backend();
-    let workflows_before = follower_backend
-        .clone()
-        .using::<WorkflowTemplate>(namespace)
-        .list()
-        .await
-        .expect("list target workflows before dispatch")
-        .items
-        .into_iter()
-        .map(|resource| resource.metadata.name)
-        .collect::<BTreeSet<_>>();
-    let policies_before = follower_backend
-        .clone()
-        .using::<PlacementPolicy>(namespace)
-        .list()
-        .await
-        .expect("list target policies before dispatch")
-        .items
-        .into_iter()
-        .map(|resource| resource.metadata.name)
-        .collect::<BTreeSet<_>>();
 
     let mut events = topology.leader.subscribe();
     let command_id = topology
@@ -603,48 +588,26 @@ async fn remote_convoy_start_enforces_target_free_space_floor_without_leaving_pr
             },
         })
         .await
-        .expect("remote convoy dispatch should be routed");
+        .expect("admitting store should accept the convoy");
 
-    let result = await_command_result(&mut events, command_id).await;
-    let CommandValue::Error { message } = result else {
-        panic!("expected target free-space refusal, got {result:?}");
-    };
-    assert!(message.contains("host `follower`"), "{message}");
-    assert!(message.contains("free is below the 1000000.0 GiB floor"), "{message}");
-    assert!(message.contains("reap settled convoys"), "{message}");
-    assert!(message.contains("scripts/prune-target.sh"), "{message}");
-    assert!(message.contains("pick another host"), "{message}");
-
+    assert_eq!(await_command_result(&mut events, command_id).await, CommandValue::ConvoyStarted {
+        name: "remote-disk-hungry".to_string(),
+        attach_plan: None,
+        binding: None
+    });
+    topology
+        .leader
+        .resource_backend()
+        .using::<Convoy>(namespace)
+        .get("remote-disk-hungry")
+        .await
+        .expect("admitting store should own the convoy");
     assert!(
-        matches!(follower_backend.using::<Convoy>(namespace).get("remote-disk-hungry").await, Err(ResourceError::NotFound { .. })),
-        "refused remote dispatch must not create a Convoy"
-    );
-    assert_eq!(
-        follower_backend
-            .clone()
-            .using::<WorkflowTemplate>(namespace)
-            .list()
-            .await
-            .expect("list target workflows after dispatch")
-            .items
-            .into_iter()
-            .map(|resource| resource.metadata.name)
-            .collect::<BTreeSet<_>>(),
-        workflows_before,
-        "refused remote dispatch must not persist a prepared workflow snapshot"
-    );
-    assert_eq!(
-        follower_backend
-            .using::<PlacementPolicy>(namespace)
-            .list()
-            .await
-            .expect("list target policies after dispatch")
-            .items
-            .into_iter()
-            .map(|resource| resource.metadata.name)
-            .collect::<BTreeSet<_>>(),
-        policies_before,
-        "refused remote dispatch must not persist a prepared placement snapshot"
+        matches!(
+            topology.follower.resource_backend().using::<Convoy>(namespace).get("remote-disk-hungry").await,
+            Err(ResourceError::NotFound { .. })
+        ),
+        "target capacity policy must not transfer convoy ownership"
     );
 }
 

--- a/crates/flotilla-daemon/tests/request_session_pair.rs
+++ b/crates/flotilla-daemon/tests/request_session_pair.rs
@@ -25,8 +25,8 @@ use flotilla_protocol::{
     PeerConnectionState, PrincipalRef, RepoSelector, ResourceRef, SurfaceCharacter, SurfaceDeclaration,
 };
 use flotilla_resources::{
-    api_version, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoySpec, ConvoyStatus, InputMeta, PlacementPolicy, Regard, Resource,
-    ResourceError, WorkPhase as ResourceWorkPhase, WorkState, WorkflowTemplate, WorkflowTemplateSpec,
+    api_version, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoySpec, ConvoyStatus, Host, HostSpec, HostStatus, InputMeta,
+    PlacementPolicy, Regard, Resource, ResourceError, WorkPhase as ResourceWorkPhase, WorkState, WorkflowTemplate, WorkflowTemplateSpec,
 };
 
 fn test_config_store(config_dir: std::path::PathBuf) -> Arc<ConfigStore> {
@@ -48,6 +48,49 @@ async fn empty_daemon_named_with_floor(host_name: &str, free_space_floor_gib: Op
     let tmp = tempfile::tempdir().expect("tempdir");
     let config = test_config_store_with_floor(tmp.keep(), free_space_floor_gib);
     InProcessDaemon::new(vec![], config, fake_discovery(false), HostName::new(host_name)).await
+}
+
+async fn seed_host_capacity(daemon: &Arc<InProcessDaemon>, free_bytes: u64, floor_bytes: u64) {
+    let host_id = daemon.local_host_id().expect("host identity").to_string();
+    let hosts = daemon.resource_backend().using::<Host>("flotilla");
+    let host = hosts
+        .create(&InputMeta::builder().name(host_id.clone()).build(), &HostSpec::default())
+        .await
+        .expect("create host capacity resource");
+    hosts
+        .update_status(&host_id, &host.metadata.resource_version, &HostStatus {
+            ready: true,
+            disk_free_bytes: Some(free_bytes),
+            admission_free_space_floor_bytes: Some(floor_bytes),
+            ..HostStatus::default()
+        })
+        .await
+        .expect("publish host capacity");
+}
+
+async fn await_host_capacity(daemon: &Arc<InProcessDaemon>, host_id: &str) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let capacity_available = daemon
+                .resource_backend()
+                .including_replicas::<Host>("flotilla")
+                .list()
+                .await
+                .expect("list federated hosts")
+                .items
+                .into_iter()
+                .any(|source| {
+                    source.object.metadata.name == host_id
+                        && source.object.status.is_some_and(|status| status.admission_free_space_floor_bytes.is_some())
+                });
+            if capacity_available {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("host capacity should replicate");
 }
 
 fn convoy_spec(workflow_ref: &str) -> ConvoySpec {
@@ -462,6 +505,7 @@ async fn hostless_convoy_delete_uses_live_peer_route_when_connection_status_is_s
 async fn convoy_start_stays_on_admitting_store_when_placement_membership_is_stale() {
     let leader = empty_daemon_named("leader").await;
     let follower = empty_daemon_named("follower").await;
+    seed_host_capacity(&follower, 100 * 1024 * 1024 * 1024, 20 * 1024 * 1024 * 1024).await;
     follower.set_local_placement_capabilities(&BTreeSet::from(["codex".to_string()]), &["cleat".to_string()]).await;
     let topology = spawn_in_memory_request_topology_stateful(leader, follower).await.expect("spawn stateful topology");
     let namespace = "flotilla";
@@ -478,6 +522,7 @@ async fn convoy_start_stays_on_admitting_store_when_placement_membership_is_stal
     })
     .await
     .expect("peer host summary should materialize placement policy");
+    await_host_capacity(&topology.leader, &remote_host_id).await;
 
     seed_trusted_remote_convoy_project(&topology.leader, namespace).await;
 
@@ -547,9 +592,10 @@ async fn convoy_start_stays_on_admitting_store_when_placement_membership_is_stal
 }
 
 #[tokio::test]
-async fn remote_convoy_start_does_not_move_admission_to_target_capacity_authority() {
+async fn remote_convoy_start_enforces_target_capacity_without_moving_authority() {
     let leader = empty_daemon_named("leader").await;
     let follower = empty_daemon_named_with_floor("follower", Some(1_000_000)).await;
+    seed_host_capacity(&follower, 0, 1_000_000 * 1024 * 1024 * 1024).await;
     follower.set_local_placement_capabilities(&BTreeSet::from(["codex".to_string()]), &["cleat".to_string()]).await;
     let topology = spawn_in_memory_request_topology_stateful(leader, follower).await.expect("spawn stateful topology");
     let namespace = "flotilla";
@@ -566,6 +612,7 @@ async fn remote_convoy_start_does_not_move_admission_to_target_capacity_authorit
     })
     .await
     .expect("peer host summary should materialize placement policy");
+    await_host_capacity(&topology.leader, &remote_host_id).await;
     seed_trusted_remote_convoy_project(&topology.leader, namespace).await;
 
     let mut events = topology.leader.subscribe();
@@ -588,26 +635,30 @@ async fn remote_convoy_start_does_not_move_admission_to_target_capacity_authorit
             },
         })
         .await
-        .expect("admitting store should accept the convoy");
+        .expect("admitting store should evaluate the convoy");
 
-    assert_eq!(await_command_result(&mut events, command_id).await, CommandValue::ConvoyStarted {
-        name: "remote-disk-hungry".to_string(),
-        attach_plan: None,
-        binding: None
-    });
-    topology
-        .leader
-        .resource_backend()
-        .using::<Convoy>(namespace)
-        .get("remote-disk-hungry")
-        .await
-        .expect("admitting store should own the convoy");
+    let result = await_command_result(&mut events, command_id).await;
+    let CommandValue::Error { message } = result else {
+        panic!("expected target free-space refusal, got {result:?}");
+    };
+    assert!(message.contains("host `follower`"), "{message}");
+    assert!(message.contains("free is below the 1000000.0 GiB floor"), "{message}");
+    assert!(message.contains("reap settled convoys"), "{message}");
+    assert!(message.contains("scripts/prune-target.sh"), "{message}");
+    assert!(message.contains("pick another host"), "{message}");
+    assert!(
+        matches!(
+            topology.leader.resource_backend().using::<Convoy>(namespace).get("remote-disk-hungry").await,
+            Err(ResourceError::NotFound { .. })
+        ),
+        "refused admission must not create a convoy on the admitting store"
+    );
     assert!(
         matches!(
             topology.follower.resource_backend().using::<Convoy>(namespace).get("remote-disk-hungry").await,
             Err(ResourceError::NotFound { .. })
         ),
-        "target capacity policy must not transfer convoy ownership"
+        "refused admission must not create a convoy on the placement host"
     );
 }
 

--- a/crates/flotilla-daemon/tests/request_session_pair.rs
+++ b/crates/flotilla-daemon/tests/request_session_pair.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use chrono::Utc;
 use flotilla_core::{
     config::ConfigStore,
     daemon::DaemonHandle,
@@ -25,8 +26,9 @@ use flotilla_protocol::{
     PeerConnectionState, PrincipalRef, RepoSelector, ResourceRef, SurfaceCharacter, SurfaceDeclaration,
 };
 use flotilla_resources::{
-    api_version, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoySpec, ConvoyStatus, Host, HostSpec, HostStatus, InputMeta,
-    PlacementPolicy, Regard, Resource, ResourceError, WorkPhase as ResourceWorkPhase, WorkState, WorkflowTemplate, WorkflowTemplateSpec,
+    api_version, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoySpec, ConvoyStatus, DockerCheckoutStrategy,
+    DockerPerVesselPlacementPolicySpec, Host, HostSpec, HostStatus, InputMeta, PlacementPolicy, PlacementPolicySpec, Regard, Resource,
+    ResourceError, WorkPhase as ResourceWorkPhase, WorkState, WorkflowTemplate, WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY,
 };
 
 fn test_config_store(config_dir: std::path::PathBuf) -> Arc<ConfigStore> {
@@ -659,6 +661,81 @@ async fn remote_convoy_start_enforces_target_capacity_without_moving_authority()
             Err(ResourceError::NotFound { .. })
         ),
         "refused admission must not create a convoy on the placement host"
+    );
+}
+
+#[tokio::test]
+async fn remote_docker_admission_fails_closed_without_target_capacity() {
+    let daemon = empty_daemon_named_with_floor("leader", Some(0)).await;
+    let namespace = "flotilla";
+    seed_trusted_remote_convoy_project(&daemon, namespace).await;
+
+    let hosts = daemon.resource_backend().using::<Host>(namespace);
+    let host = hosts
+        .create(&InputMeta::builder().name("remote-docker-host".to_string()).build(), &HostSpec {
+            display_name: "remote-docker".to_string(),
+        })
+        .await
+        .expect("create remote Docker host");
+    hosts
+        .update_status("remote-docker-host", &host.metadata.resource_version, &HostStatus {
+            capabilities: [(AGENT_ADAPTERS_CAPABILITY.to_string(), serde_json::json!(["codex"]))].into_iter().collect(),
+            heartbeat_at: Some(Utc::now()),
+            ready: true,
+            ..HostStatus::default()
+        })
+        .await
+        .expect("mark remote Docker host ready without capacity");
+    daemon
+        .resource_backend()
+        .using::<PlacementPolicy>(namespace)
+        .create(
+            &InputMeta::builder().name("remote-docker".to_string()).build(),
+            &PlacementPolicySpec::builder()
+                .pool("cleat".to_string())
+                .docker_per_vessel(DockerPerVesselPlacementPolicySpec {
+                    host_ref: "remote-docker-host".to_string(),
+                    image: "crew:latest".to_string(),
+                    pull_policy: Default::default(),
+                    agent_adapters: BTreeSet::from(["codex".to_string()]),
+                    default_cwd: None,
+                    env: BTreeMap::new(),
+                    checkout: DockerCheckoutStrategy::FreshCloneInContainer { clone_path: "/workspace".to_string() },
+                })
+                .build(),
+        )
+        .await
+        .expect("create remote Docker placement");
+
+    let mut events = daemon.subscribe();
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyStart {
+                intent: Box::new(
+                    ConvoyStartIntent::builder()
+                        .project_ref("flotilla".to_string())
+                        .name("remote-docker-work".to_string())
+                        .branch("fix/remote-docker-work".to_string())
+                        .placement_policy("remote-docker".to_string())
+                        .auto_attach(flotilla_protocol::ConvoyAutoAttach::Never)
+                        .build(),
+                ),
+            },
+        })
+        .await
+        .expect("dispatch remote Docker admission");
+
+    let result = await_command_result(&mut events, command_id).await;
+    let CommandValue::Error { message } = result else {
+        panic!("expected missing-capacity refusal, got {result:?}");
+    };
+    assert_eq!(message, "placement refused on host `remote-docker`: admission free-space floor is unavailable");
+    assert!(
+        matches!(daemon.resource_backend().using::<Convoy>(namespace).get("remote-docker-work").await, Err(ResourceError::NotFound { .. })),
+        "missing remote Docker capacity must fail before convoy persistence"
     );
 }
 

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -422,30 +422,6 @@ pub struct AgentOverride {
 /// A convoy launch admitted by the presentation host and ready to be
 /// persisted by the selected execution host.
 ///
-/// Resource specs remain opaque at the protocol boundary so the protocol
-/// crate does not depend on the resource model. The execution host validates
-/// and deserializes each snapshot before storing it.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
-pub struct PreparedConvoyStart {
-    pub namespace: String,
-    pub name: String,
-    pub convoy_spec: serde_json::Value,
-    pub workflow_name: String,
-    pub workflow_spec: serde_json::Value,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub placement_policy_name: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub placement_policy_spec: Option<serde_json::Value>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub placement_decision: Option<crate::PlacementDecision>,
-    #[builder(default)]
-    #[serde(default)]
-    pub auto_attach: bool,
-    #[builder(default)]
-    #[serde(default)]
-    pub dispatch_regard: ConvoyDispatchRegard,
-}
-
 /// Commands the client can send to the daemon.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
@@ -591,11 +567,6 @@ pub enum CommandAction {
     },
     ConvoyStart {
         intent: Box<ConvoyStartIntent>,
-    },
-    /// Internal peer command carrying the exact resource snapshots admitted
-    /// by the presentation host.
-    ConvoyStartPrepared {
-        start: Box<PreparedConvoyStart>,
     },
     WorkflowTemplateApply {
         name: String,
@@ -779,7 +750,6 @@ impl Command {
             CommandAction::CrewFail { .. } => "Failing crew work...",
             CommandAction::ConvoyCreate { .. } => "Creating convoy...",
             CommandAction::ConvoyStart { .. } => "Starting convoy...",
-            CommandAction::ConvoyStartPrepared { .. } => "Starting convoy...",
             CommandAction::WorkflowTemplateApply { .. } => "Applying workflow template...",
             CommandAction::ProjectAdd { .. } => "Adding project...",
             CommandAction::ProjectApply { .. } => "Applying project...",

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -116,8 +116,8 @@ pub use commands::{
     AgentOverride, AttachBinding, CheckoutSelector, CheckoutStatus, CheckoutTarget, Command, CommandAction, CommandValue, ConvoyAutoAttach,
     ConvoyDispatchRegard, ConvoyExplanation, ConvoyStartIntent, EvidenceFreshness, ExplainedChangeRequest, ExplainedCheckout,
     ExplainedCondition, ExplainedCrewDelivery, ExplainedLeafFiring, ExplainedSettlement, ExplainedSubscription, ExplainedUnmetExpectation,
-    IssueSelector, PreparedConvoyStart, PreparedTerminalCommand, PreparedWorkspace, RepoSelector, ResolvedPaneCommand, ResourceCursor,
-    ResourceJsonResponse, ResourceReadEnvelope, ResourceReadRecord, ResourceRecordProvenance, ResourceRecordType, StepStatus,
+    IssueSelector, PreparedTerminalCommand, PreparedWorkspace, RepoSelector, ResolvedPaneCommand, ResourceCursor, ResourceJsonResponse,
+    ResourceReadEnvelope, ResourceReadRecord, ResourceRecordProvenance, ResourceRecordType, StepStatus,
 };
 pub use delta::{Branch, BranchStatus, Change, DeltaEntry, EntryOp};
 pub use provider_data::{

--- a/crates/flotilla-resources/src/host.rs
+++ b/crates/flotilla-resources/src/host.rs
@@ -45,6 +45,8 @@ pub struct HostStatus {
     pub daemon_started_at: Option<DateTime<Utc>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub disk_free_bytes: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub admission_free_space_floor_bytes: Option<u64>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[builder(default)]
     pub conditions: Vec<HostCondition>,
@@ -100,6 +102,7 @@ pub enum HostStatusPatch {
         daemon_version: Option<String>,
         daemon_started_at: Option<DateTime<Utc>>,
         disk_free_bytes: Option<u64>,
+        admission_free_space_floor_bytes: Option<u64>,
     },
     SleepInhibition {
         health: SleepInhibitionHealth,
@@ -118,6 +121,7 @@ impl StatusPatch<HostStatus> for HostStatusPatch {
                 daemon_version,
                 daemon_started_at,
                 disk_free_bytes,
+                admission_free_space_floor_bytes,
             } => {
                 status.capabilities = capabilities.clone();
                 status.heartbeat_at = Some(*heartbeat_at);
@@ -126,6 +130,7 @@ impl StatusPatch<HostStatus> for HostStatusPatch {
                 status.daemon_version.clone_from(daemon_version);
                 status.daemon_started_at = *daemon_started_at;
                 status.disk_free_bytes = *disk_free_bytes;
+                status.admission_free_space_floor_bytes = *admission_free_space_floor_bytes;
             }
             Self::SleepInhibition { health, observed_at } => {
                 status.sleep_inhibition.clone_from(health);

--- a/crates/flotilla-resources/tests/provisioning_status_patch.rs
+++ b/crates/flotilla-resources/tests/provisioning_status_patch.rs
@@ -19,6 +19,7 @@ fn host_status_patch_updates_heartbeat_snapshot() {
         daemon_version: None,
         daemon_started_at: None,
         disk_free_bytes: None,
+        admission_free_space_floor_bytes: None,
     }
     .apply(&mut status);
 


### PR DESCRIPTION
## Summary

- keep every newly admitted Convoy and its immutable workflow and placement snapshots in the admitting daemon's resource store, regardless of the selected placement host
- remove the retracted prepared-start peer protocol and host-direct command-routing path, leaving replicated placement intent to the existing placed-on-me actuator projector
- retain actuator-local resources while owner deletion intent has not replicated, then allow teardown once that intent is observed

## Root cause

Remote host-direct starts still used the earlier ownership-routing design: admission prepared an opaque resource bundle, forwarded it to the placement daemon, and made that daemon the Convoy authority. This contradicted the ruled federation model and meant host-direct and contained remote placements had different ownership semantics.

The admitting path also pinned only the workflow locally; placement snapshots were created only by the obsolete remote prepared-start path.

## Impact

Convoy spec, metadata, deletion intent, pinned inputs, and phase roll-up now have one authority: the admitting store. Placement hosts consume replicated intent and append actuator facts to their own stores. Mutable placement policies are snapshotted at admission and replicated with the Convoy's resources.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- focused two-store host-direct and Docker worktree-on-host-and-mount provisioning tests
- focused owner-offline deletion-freeze and command-routing regressions

Closes #1188
