### PR TITLE
fix: key usage by provider and account

### DIFF
--- a/crates/flotilla-core/src/leaf_engine.rs
+++ b/crates/flotilla-core/src/leaf_engine.rs
@@ -733,8 +733,8 @@ fn evaluate_row(
                 });
                 evaluate_leaf(leaf, subject.as_ref().map(|subject| subject as &dyn flotilla_resources::LeafSubject), row.freshness_demand)?
             }
-            LeafAddress::Usage { account } => {
-                let name = flotilla_resources::usage_record_name(account);
+            LeafAddress::Usage { provider, account } => {
+                let name = flotilla_resources::usage_record_name(provider, account);
                 let subject = usages.get(&name).map(UsageLeafSubject);
                 evaluate_leaf(leaf, subject.as_ref().map(|subject| subject as &dyn flotilla_resources::LeafSubject), row.freshness_demand)?
             }
@@ -994,12 +994,14 @@ mod tests {
     #[tokio::test]
     async fn usage_leaf_fires_from_the_named_window_in_the_replicated_resource_path() {
         let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+        let provider = "codex";
         let account = "user@example.com";
         let records = backend.using::<Usage>("flotilla");
         let created = records
-            .create(&InputMeta::builder().name(flotilla_resources::usage_record_name(account)).build(), &flotilla_resources::UsageSpec {
-                account: account.to_string(),
-            })
+            .create(
+                &InputMeta::builder().name(flotilla_resources::usage_record_name(provider, account)).build(),
+                &flotilla_resources::UsageSpec { provider: provider.to_string(), account: account.to_string() },
+            )
             .await
             .expect("create usage record");
         records
@@ -1007,7 +1009,6 @@ mod tests {
                 &created.metadata.name,
                 &created.metadata.resource_version,
                 &flotilla_resources::UsageStatus::builder()
-                    .provider("codex")
                     .windows(vec![
                         flotilla_resources::UsageWindow::builder().name("session").used_percent(8.0).build(),
                         flotilla_resources::UsageWindow::builder().name("weekly").used_percent(100.0).build(),
@@ -1027,7 +1028,8 @@ mod tests {
         );
         let table = LeafSubscriptionTable::new(backend, event_tx.clone(), refresher);
         let mut events = event_tx.subscribe();
-        let mut usage_leaf = leaf(LeafAddress::Usage { account: account.to_string() }, ".windows.weekly.used-percent", "90");
+        let mut usage_leaf =
+            leaf(LeafAddress::Usage { provider: provider.to_string(), account: account.to_string() }, ".windows.weekly.used-percent", "90");
         usage_leaf.operator = LeafOperator::GreaterThan;
         let subscription_id = table
             .subscribe_wait(uuid::Uuid::new_v4(), WaitSubscriptionRequest {

--- a/crates/flotilla-core/src/ops_entry.rs
+++ b/crates/flotilla-core/src/ops_entry.rs
@@ -193,14 +193,18 @@ mod tests {
     #[test]
     fn checked_in_usage_observer_script_preserves_translation_and_coalescing_rules() {
         let script = concat!(env!("CARGO_MANIFEST_DIR"), "/../../scripts/usage-observer");
-        let expected_name = flotilla_resources::usage_record_name("Ada@Example.com");
+        let expected_codex_name = flotilla_resources::usage_record_name("codex", "Ada@Example.com");
+        let expected_claude_name = flotilla_resources::usage_record_name("claude", "Ada@Example.com");
         let program = r#"
 import copy
 import runpy
 import sys
+from types import SimpleNamespace
 
 observer = runpy.run_path(sys.argv[1], run_name="usage_observer_test")
-assert observer["record_name"](" Ada@Example.com ") == sys.argv[2]
+assert observer["record_name"](" CODEX ", " Ada@Example.com ") == sys.argv[2]
+assert observer["record_name"]("claude", "Ada@Example.com") == sys.argv[3]
+assert sys.argv[2] != sys.argv[3]
 
 payload = {
     "provider": "codex",
@@ -226,6 +230,18 @@ assert [(window["name"], window["used_percent"]) for window in current["windows"
 ]
 assert current["provider_cost"]["balance"] == 37.5
 assert current["reset_credits_available"] == 2
+assert "provider" not in current
+
+runtime = observer["ensure_usage"].__globals__
+documents = []
+runtime["flotilla_command"] = lambda arguments: SimpleNamespace(returncode=1, stdout="", stderr="not found")
+runtime["command_with_document"] = lambda arguments, document: documents.append(document) or SimpleNamespace(returncode=0, stdout="", stderr="")
+observer["ensure_usage"](sys.argv[2], "codex", account)
+assert documents == [{
+    "kind": "Usage",
+    "metadata": {"name": sys.argv[2]},
+    "spec": {"provider": "codex", "account": "Ada@Example.com"},
+}]
 
 sub_threshold = copy.deepcopy(current)
 sub_threshold["windows"][0]["used_percent"] = 8.999
@@ -247,7 +263,7 @@ assert observer["material_change"](current, heartbeat)
 patches = []
 runtime = observer["run_cycle"].__globals__
 runtime["poll"] = lambda provider: [(account, current)] if provider == "codex" else []
-runtime["ensure_usage"] = lambda name, account: None
+runtime["ensure_usage"] = lambda name, provider, account: None
 runtime["patch_status"] = lambda name, status: patches.append((name, status))
 last_written = {}
 observer["run_cycle"](last_written)
@@ -255,7 +271,7 @@ observer["run_cycle"](last_written)
 assert len(patches) == 1
 "#;
         let output = Command::new("python3")
-            .args(["-c", program, script, &expected_name])
+            .args(["-c", program, script, &expected_codex_name, &expected_claude_name])
             .output()
             .expect("run usage observer Python contract test");
         assert!(output.status.success(), "usage observer Python contract failed: {}", String::from_utf8_lossy(&output.stderr));

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -857,7 +857,7 @@ async fn generic_resource_commands_create_usage_and_patch_its_typed_status() {
     let daemon =
         InProcessDaemon::new(vec![], test_config_store(temp.path().join("config")), fake_discovery(false), HostName::local()).await;
     let mut events = daemon.subscribe();
-    let name = flotilla_resources::usage_record_name("ada@example.com");
+    let name = flotilla_resources::usage_record_name("codex", "ada@example.com");
     let create_id = daemon
         .execute(Command {
             node_id: None,
@@ -868,7 +868,7 @@ async fn generic_resource_commands_create_usage_and_patch_its_typed_status() {
                 document: serde_json::json!({
                     "kind": "Usage",
                     "metadata": {"name": name},
-                    "spec": {"account": "Ada@Example.com"},
+                    "spec": {"provider": "codex", "account": "Ada@Example.com"},
                 }),
             },
         })
@@ -879,7 +879,6 @@ async fn generic_resource_commands_create_usage_and_patch_its_typed_status() {
 
     let observed_at = "2026-08-08T18:00:00Z".parse().expect("timestamp");
     let status = flotilla_resources::UsageStatus::builder()
-        .provider("codex")
         .windows(vec![flotilla_resources::UsageWindow::builder().name("weekly").used_percent(100.0).build()])
         .observed_at(observed_at)
         .build();
@@ -911,7 +910,7 @@ async fn generic_resource_commands_create_usage_and_patch_its_typed_status() {
                 namespace: "flotilla".to_string(),
                 kind: "usages".to_string(),
                 name: name.clone(),
-                status: serde_json::json!({"provider": "codex"}),
+                status: serde_json::json!({"windows": []}),
             },
         })
         .await
@@ -920,6 +919,7 @@ async fn generic_resource_commands_create_usage_and_patch_its_typed_status() {
     assert!(matches!(malformed_result, CommandValue::Error { message } if message.contains("decode Usage status")));
 
     let stored = daemon.resource_backend().using::<flotilla_resources::Usage>("flotilla").get(&name).await.expect("stored usage");
+    assert_eq!(stored.spec.provider, "codex");
     assert_eq!(stored.spec.account, "Ada@Example.com");
     assert_eq!(stored.status, Some(status));
 }

--- a/crates/flotilla-protocol/src/leaf.rs
+++ b/crates/flotilla-protocol/src/leaf.rs
@@ -49,7 +49,7 @@ pub enum LeafAddress {
     Vessel { name: String },
     Work { convoy: String, work: String },
     ChangeRequest { service: String, scope: String, number: u64 },
-    Usage { account: String },
+    Usage { provider: String, account: String },
 }
 
 impl LeafAddress {
@@ -79,9 +79,11 @@ impl FromStr for LeafAddress {
                 let number = number.parse().map_err(|_| format!("invalid change request number `{number}` in leaf address `{value}`"))?;
                 Ok(Self::ChangeRequest { service: (*service).to_string(), scope: scope.join("/"), number })
             }
-            ["usage", account] if !account.is_empty() => Ok(Self::Usage { account: (*account).to_string() }),
+            ["usage", provider, account] if !provider.is_empty() && !account.is_empty() => {
+                Ok(Self::Usage { provider: (*provider).to_string(), account: (*account).to_string() })
+            }
             _ => Err(format!(
-                "invalid leaf address `{value}`; expected convoy/<name>, vessel/<name>, work/<convoy>/<work>, cr/<service>/<scope>/<number>, or usage/<account>"
+                "invalid leaf address `{value}`; expected convoy/<name>, vessel/<name>, work/<convoy>/<work>, cr/<service>/<scope>/<number>, or usage/<provider>/<account>"
             )),
         }
     }
@@ -94,7 +96,7 @@ impl fmt::Display for LeafAddress {
             Self::Vessel { name } => write!(f, "vessel/{name}"),
             Self::Work { convoy, work } => write!(f, "work/{convoy}/{work}"),
             Self::ChangeRequest { service, scope, number } => write!(f, "cr/{service}/{scope}/{number}"),
-            Self::Usage { account } => write!(f, "usage/{account}"),
+            Self::Usage { provider, account } => write!(f, "usage/{provider}/{account}"),
         }
     }
 }
@@ -229,8 +231,8 @@ mod tests {
 
     #[test]
     fn parses_subject_keyed_usage_address() {
-        let leaf: Leaf = "usage/user@example.com .windows.weekly.used-percent > 90".parse().expect("parse usage leaf");
-        assert_eq!(leaf.address, LeafAddress::Usage { account: "user@example.com".to_string() });
-        assert_eq!(leaf.to_string(), "usage/user@example.com .windows.weekly.used-percent > 90");
+        let leaf: Leaf = "usage/codex/user@example.com .windows.weekly.used-percent > 90".parse().expect("parse usage leaf");
+        assert_eq!(leaf.address, LeafAddress::Usage { provider: "codex".to_string(), account: "user@example.com".to_string() });
+        assert_eq!(leaf.to_string(), "usage/codex/user@example.com .windows.weekly.used-percent > 90");
     }
 }

--- a/crates/flotilla-resources/src/leaf.rs
+++ b/crates/flotilla-resources/src/leaf.rs
@@ -234,9 +234,11 @@ impl LeafSubject for UsageLeafSubject<'_> {
     }
 
     fn value(&self, field_path: &str) -> Option<LeafValue> {
+        if field_path == ".provider" {
+            return Some(LeafValue::Text(self.0.spec.provider.clone()));
+        }
         let status = self.0.status.as_ref()?;
         match field_path {
-            ".provider" => Some(LeafValue::Text(status.provider.clone())),
             ".plan" => status.plan.clone().map(LeafValue::Text),
             ".organization" => status.organization.clone().map(LeafValue::Text),
             path => {
@@ -447,10 +449,9 @@ mod tests {
                 creation_timestamp: observed_at,
                 merge: None,
             },
-            spec: crate::UsageSpec { account: "user@example.com".to_string() },
+            spec: crate::UsageSpec { provider: "codex".to_string(), account: "user@example.com".to_string() },
             status: Some(
                 crate::UsageStatus::builder()
-                    .provider("codex")
                     .windows(vec![
                         crate::UsageWindow::builder().name("session").used_percent(8.0).build(),
                         crate::UsageWindow::builder().name("weekly").used_percent(100.0).build(),
@@ -461,7 +462,7 @@ mod tests {
         };
         let subject = UsageLeafSubject(&object);
         let leaf = Leaf {
-            address: LeafAddress::Usage { account: "user@example.com".to_string() },
+            address: LeafAddress::Usage { provider: "codex".to_string(), account: "user@example.com".to_string() },
             field_path: ".windows.weekly.used-percent".to_string(),
             operator: LeafOperator::GreaterThan,
             literal: "90".to_string(),

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -945,6 +945,7 @@ mod tests {
         backend
             .using::<Usage>("flotilla")
             .create(&InputMeta::builder().name("usage-account".to_string()).build(), &crate::UsageSpec {
+                provider: "codex".to_string(),
                 account: "ada@example.com".to_string(),
             })
             .await
@@ -956,7 +957,6 @@ mod tests {
             "usages",
             "usage-account",
             serde_json::json!({
-                "provider": "codex",
                 "windows": [{"name": "weekly", "used_percent": 42.0}],
                 "observed_at": "2026-08-10T10:00:00Z",
             }),
@@ -967,7 +967,7 @@ mod tests {
         assert_eq!(patched.kind, "Usage");
         assert_eq!(patched.value["status"]["windows"][0]["used_percent"], 42.0);
 
-        let error = patch_resource_status(&backend, "flotilla", "usages", "usage-account", serde_json::json!({"provider": "codex"}))
+        let error = patch_resource_status(&backend, "flotilla", "usages", "usage-account", serde_json::json!({"windows": []}))
             .await
             .expect_err("malformed status should fail typed decoding");
         assert!(error.to_string().contains("decode Usage status"));

--- a/crates/flotilla-resources/src/usage.rs
+++ b/crates/flotilla-resources/src/usage.rs
@@ -19,15 +19,16 @@ impl Resource for Usage {
         if current == requested {
             Ok(())
         } else {
-            Err(ResourceError::invalid("Usage account subject is immutable"))
+            Err(ResourceError::invalid("Usage subject is immutable"))
         }
     }
 }
 
-/// The account is the stable subject. Provider, plan, organization, and quota
-/// data are observations because each can change independently over time.
+/// An account at a provider is the stable subject. Plan, organization, and
+/// quota data are observations because each can change independently over time.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UsageSpec {
+    pub provider: String,
     pub account: String,
 }
 
@@ -78,7 +79,6 @@ pub struct UsageProviderCost {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, bon::Builder)]
 #[builder(on(String, into))]
 pub struct UsageStatus {
-    pub provider: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plan: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -111,12 +111,15 @@ impl StatusPatch<UsageStatus> for UsageStatusPatch {
     }
 }
 
-/// Produce a DNS-safe, fixed-size resource name for a raw account subject.
-pub fn usage_record_name(account: &str) -> String {
-    let normalized = account.trim().to_lowercase();
+/// Produce a DNS-safe, fixed-size resource name for a provider/account subject.
+pub fn usage_record_name(provider: &str, account: &str) -> String {
+    let normalized_provider = provider.trim().to_lowercase();
+    let normalized_account = account.trim().to_lowercase();
     let mut hash = Sha256::new();
-    hash.update(b"usage-account-v1\0");
-    hash.update(normalized.as_bytes());
+    hash.update(b"usage-account-v2\0");
+    hash.update(normalized_provider.as_bytes());
+    hash.update(b"\0");
+    hash.update(normalized_account.as_bytes());
     let digest = format!("{:x}", hash.finalize());
     format!("usage-{}", &digest[..54])
 }
@@ -128,7 +131,6 @@ mod tests {
 
     fn status(used_percent: f64, observed_at: DateTime<Utc>) -> UsageStatus {
         UsageStatus::builder()
-            .provider("codex")
             .windows(vec![UsageWindow::builder().name("weekly").used_percent(used_percent).build()])
             .observed_at(observed_at)
             .build()
@@ -137,7 +139,10 @@ mod tests {
     async fn assert_observation_history_is_thin(backend: ResourceBackend) {
         let records = backend.using::<Usage>("flotilla");
         let created = records
-            .create(&InputMeta::builder().name("usage-account".to_string()).build(), &UsageSpec { account: "user@example.com".to_string() })
+            .create(&InputMeta::builder().name("usage-account".to_string()).build(), &UsageSpec {
+                provider: "codex".to_string(),
+                account: "user@example.com".to_string(),
+            })
             .await
             .expect("create usage observation");
         let first = records
@@ -154,11 +159,24 @@ mod tests {
     }
 
     #[test]
-    fn account_record_names_are_stable_case_insensitive_and_bounded() {
-        let lower = usage_record_name("user@example.com");
-        assert_eq!(lower, usage_record_name(" User@Example.COM "));
+    fn provider_account_record_names_are_stable_case_insensitive_and_bounded() {
+        let lower = usage_record_name("codex", "user@example.com");
+        assert_eq!(lower, usage_record_name(" CODEX ", " User@Example.COM "));
         assert!(lower.starts_with("usage-"));
         assert_eq!(lower.len(), 60);
+    }
+
+    #[test]
+    fn same_account_at_different_providers_has_distinct_record_names() {
+        assert_ne!(usage_record_name("codex", "user@example.com"), usage_record_name("claude", "user@example.com"));
+    }
+
+    #[test]
+    fn provider_and_account_are_one_immutable_subject() {
+        let current = UsageSpec { provider: "codex".to_string(), account: "user@example.com".to_string() };
+        assert!(Usage::validate_spec_update(&current, &current).is_ok());
+        assert!(Usage::validate_spec_update(&current, &UsageSpec { provider: "claude".to_string(), ..current.clone() }).is_err());
+        assert!(Usage::validate_spec_update(&current, &UsageSpec { account: "other@example.com".to_string(), ..current.clone() }).is_err());
     }
 
     #[tokio::test]

--- a/crates/flotilla-resources/tests/resource_projection.rs
+++ b/crates/flotilla-resources/tests/resource_projection.rs
@@ -117,13 +117,12 @@ fn dispatch_observation_crd_parses_with_immutable_record_fields() {
 }
 
 #[test]
-fn usage_resource_roundtrips_account_subject_and_window_set() {
+fn usage_resource_roundtrips_provider_account_subject_and_window_set() {
     let observed_at = "2026-08-06T10:39:55Z".parse().expect("valid timestamp");
     let object = ResourceObject::<Usage> {
         metadata: common::object_meta("usage-example", "flotilla", "3"),
-        spec: UsageSpec { account: "user@example.com".to_string() },
+        spec: UsageSpec { provider: "codex".to_string(), account: "user@example.com".to_string() },
         status: Some(UsageStatus {
-            provider: "codex".to_string(),
             plan: Some("plus".to_string()),
             organization: Some("example-org".to_string()),
             windows: vec![
@@ -138,6 +137,7 @@ fn usage_resource_roundtrips_account_subject_and_window_set() {
     };
 
     let json = serde_json::to_value(object.to_k8s_object()).expect("usage projection should serialize");
+    assert_eq!(json["spec"]["provider"], "codex");
     assert_eq!(json["spec"]["account"], "user@example.com");
     assert_eq!(json["status"]["windows"][0]["name"], "session");
     assert_eq!(json["status"]["windows"][1]["used_percent"], 100.0);

--- a/scripts/usage-observer
+++ b/scripts/usage-observer
@@ -18,10 +18,11 @@ POLL_SECONDS = 300
 PROVIDERS = ("codex", "claude")
 
 
-def record_name(account):
+def record_name(provider, account):
     """Keep this byte-for-byte aligned with usage_record_name in usage.rs."""
-    normalized = account.strip().lower()
-    digest = hashlib.sha256(b"usage-account-v1\0" + normalized.encode()).hexdigest()
+    normalized_provider = provider.strip().lower()
+    normalized_account = account.strip().lower()
+    digest = hashlib.sha256(b"usage-account-v2\0" + normalized_provider.encode() + b"\0" + normalized_account.encode()).hexdigest()
     return "usage-" + digest[:54]
 
 
@@ -115,7 +116,6 @@ def translate_payload(expected_provider, payload):
 
     reset_credits = usage.get("codexResetCredits")
     status = {
-        "provider": expected_provider,
         "plan": first_nonempty(identity.get("loginMethod"), usage.get("loginMethod")),
         "organization": first_nonempty(identity.get("accountOrganization"), usage.get("accountOrganization")),
         "windows": windows,
@@ -168,14 +168,14 @@ def command_with_document(arguments, document):
             os.unlink(path)
 
 
-def ensure_usage(name, account):
+def ensure_usage(name, provider, account):
     result = flotilla_command(["resource", "get", "usages", name, "--namespace", NAMESPACE])
     if result.returncode == 0:
         envelope = json.loads(result.stdout)
         records = envelope.get("records") or []
         return (records[0].get("object") or {}).get("status") if records else None
 
-    document = {"kind": "Usage", "metadata": {"name": name}, "spec": {"account": account}}
+    document = {"kind": "Usage", "metadata": {"name": name}, "spec": {"provider": provider, "account": account}}
     result = command_with_document(["resource", "apply", "--namespace", NAMESPACE], document)
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "resource apply failed")
@@ -213,10 +213,10 @@ def run_cycle(last_written):
             print(f"usage observer: {error}", file=sys.stderr)
             continue
         for account, status in observations:
-            name = record_name(account)
+            name = record_name(provider, account)
             try:
                 if name not in last_written:
-                    last_written[name] = ensure_usage(name, account)
+                    last_written[name] = ensure_usage(name, provider, account)
                 if material_change(last_written[name], status):
                     patch_status(name, status)
                     last_written[name] = status


### PR DESCRIPTION
Follow-up to #1431 for the Usage keying amendment recorded on #1412.

An account identity is provider-scoped. This moves `provider` into the immutable `UsageSpec`, derives record names from the normalized provider/account pair under `usage-account-v2`, keeps the Python poller byte-aligned, and updates Usage leaf addressing and contract coverage.

Tests include the same account under two providers producing distinct resource names.

Local gates:
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1444.
