### PR TITLE
fix: tombstone missing authoritative resources

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/vessel_placement.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel_placement.rs
@@ -181,8 +181,9 @@ impl VesselPlacementProjector {
 
 fn replica_changed<T: Resource>(event: Option<Result<ReadWatchEvent<T>, ResourceError>>, kind: &str) -> Result<bool, ResourceError> {
     let event = event.ok_or_else(|| ResourceError::invalid(format!("{kind} replica watch ended")))?;
-    let source = match event? {
-        ReadWatchEvent::Added(source) | ReadWatchEvent::Modified(source) | ReadWatchEvent::Deleted(source) => source,
+    let provenance = match event? {
+        ReadWatchEvent::Added(source) | ReadWatchEvent::Modified(source) | ReadWatchEvent::Deleted(source) => source.provenance,
+        ReadWatchEvent::DeletedByName { provenance, .. } => provenance,
     };
-    Ok(matches!(source.provenance, ResourceProvenance::Replica { .. }))
+    Ok(matches!(provenance, ResourceProvenance::Replica { .. }))
 }

--- a/crates/flotilla-core/src/leaf_engine.rs
+++ b/crates/flotilla-core/src/leaf_engine.rs
@@ -528,6 +528,9 @@ impl ReconcilerWake {
                         WatchEvent::Deleted(convoy) => {
                             convoy_objects.remove(&convoy.metadata.name);
                         }
+                        WatchEvent::DeletedByName(tombstone) => {
+                            convoy_objects.remove(&tombstone.name);
+                        }
                     }
                     self.sync_rows(&namespace, &convoy_objects).await?;
                 }
@@ -694,6 +697,9 @@ fn apply_read_event<T: flotilla_resources::Resource>(
         }
         flotilla_resources::ReadWatchEvent::Deleted(item) => {
             objects.remove(&item.object.metadata.name);
+        }
+        flotilla_resources::ReadWatchEvent::DeletedByName { tombstone, .. } => {
+            objects.remove(&tombstone.name);
         }
     }
 }

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -52,8 +52,10 @@ use flotilla_resources::{
     DockerPerVesselPlacementPolicySpec, Host as ResourceHost, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec,
     HostStatus, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project, ProjectRepositorySpec,
     ProjectSpec, Regard, RegardExpiryPolicy, RegardSource, Repository, RepositoryRelation, RepositorySpec, ResourceError, Stance,
-    TypedResolver, WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate, AGENT_ADAPTERS_CAPABILITY, REPO_KEY_LABEL, REPO_LABEL,
+    TypedResolver, WatchEvent, WatchStart, WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate, AGENT_ADAPTERS_CAPABILITY,
+    REPO_KEY_LABEL, REPO_LABEL,
 };
+use futures::StreamExt;
 use tokio::sync::Notify;
 
 struct FixedRemoteHostDetector {
@@ -849,6 +851,118 @@ async fn orphaned_authority_record_can_be_collected_from_the_replica_store() {
             .is_empty(),
         "the stale authority projection must be collectable"
     );
+}
+
+#[tokio::test]
+async fn deleting_a_missing_authoritative_resource_tombstones_connected_peer_replicas() {
+    let authority_temp = tempfile::tempdir().expect("create authority tempdir");
+    let authority = InProcessDaemon::new(
+        vec![],
+        test_config_store(authority_temp.path().join("config")),
+        fake_discovery(false),
+        HostName::new("authority"),
+    )
+    .await;
+    let peer_temp = tempfile::tempdir().expect("create peer tempdir");
+    let peer =
+        InProcessDaemon::new(vec![], test_config_store(peer_temp.path().join("config")), fake_discovery(false), HostName::new("peer"))
+            .await;
+    let origin = authority.node_id().clone();
+    let authority_node = NodeInfo::new(origin.clone(), "authority");
+    peer.set_configured_peers(vec![authority_node.clone()]).await;
+
+    let peer_local = peer.resource_backend().using::<ResourceConvoy>("flotilla");
+    peer_local
+        .create(
+            &InputMeta::builder().name("lost-at-authority".to_string()).build(),
+            &flotilla_resources::ConvoySpec::builder().workflow_ref("wf".to_string()).build(),
+        )
+        .await
+        .expect("create stale source object");
+    let stale_snapshot = peer_local.list().await.expect("snapshot stale source object");
+    peer_local.delete("lost-at-authority").await.expect("remove local source object");
+    peer.resource_backend()
+        .replica_writer::<ResourceConvoy>(origin.clone(), "flotilla")
+        .replace(&stale_snapshot, chrono::Utc::now())
+        .await
+        .expect("seed stale peer replica");
+
+    let authority_convoys = authority.resource_backend().using::<ResourceConvoy>("flotilla");
+    authority_convoys
+        .create(
+            &InputMeta::builder().name("held-at-authority".to_string()).build(),
+            &flotilla_resources::ConvoySpec::builder().workflow_ref("wf".to_string()).build(),
+        )
+        .await
+        .expect("create held authority object");
+    let authority_snapshot = authority_convoys.list().await.expect("snapshot held authority object");
+    peer.resource_backend()
+        .replica_writer::<ResourceConvoy>(origin.clone(), "flotilla")
+        .apply(WatchEvent::Added(authority_snapshot.items[0].clone()), chrono::Utc::now())
+        .await
+        .expect("seed held peer replica");
+
+    let mut peer_events = peer.subscribe();
+    InProcessDaemon::publish_peer_connection_status(peer.as_ref(), &authority_node, PeerConnectionState::Connected).await;
+    let refused_id = peer
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ResourceDelete {
+                namespace: "flotilla".to_string(),
+                kind: "convoys".to_string(),
+                name: "held-at-authority".to_string(),
+                replica_origin: Some(origin.clone()),
+            },
+        })
+        .await
+        .expect("request collection of held resource");
+    let refused = recv_command_finished(&mut peer_events, refused_id).await;
+    assert!(
+        matches!(refused, CommandValue::Error { ref message } if message.contains("is connected")),
+        "a connected authority that holds the record must retain deletion authority: {refused:?}"
+    );
+
+    let listed = authority_convoys.list().await.expect("list before authority tombstone");
+    let mut authority_watch = authority_convoys.watch(WatchStart::resuming_from(&listed)).await.expect("watch authority tombstones");
+    let mut authority_events = authority.subscribe();
+    let delete_id = authority
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ResourceDelete {
+                namespace: "flotilla".to_string(),
+                kind: "convoys".to_string(),
+                name: "lost-at-authority".to_string(),
+                replica_origin: None,
+            },
+        })
+        .await
+        .expect("delete missing authority resource");
+    let deleted = recv_command_finished(&mut authority_events, delete_id).await;
+    assert!(matches!(deleted, CommandValue::ResourceDeleted(_)), "missing authority delete must succeed: {deleted:?}");
+
+    let tombstone_event = tokio::time::timeout(Duration::from_secs(1), authority_watch.next())
+        .await
+        .expect("authority tombstone watch timeout")
+        .expect("authority tombstone watch ended")
+        .expect("authority tombstone watch failed");
+    assert!(
+        matches!(&tombstone_event, WatchEvent::DeletedByName(tombstone) if tombstone.name == "lost-at-authority"),
+        "missing authority delete must emit a name tombstone: {tombstone_event:?}"
+    );
+    peer.resource_backend()
+        .replica_writer::<ResourceConvoy>(origin, "flotilla")
+        .apply(tombstone_event, chrono::Utc::now())
+        .await
+        .expect("relay authority tombstone to peer");
+
+    let remaining =
+        peer.resource_backend().including_replicas::<ResourceConvoy>("flotilla").list().await.expect("list converged peer replicas");
+    assert_eq!(remaining.items.len(), 1);
+    assert_eq!(remaining.items[0].object.metadata.name, "held-at-authority");
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -834,6 +834,10 @@ impl Aggregator {
                 let reference = self.presentation_ref(&presentation.metadata.namespace, &presentation.metadata.name);
                 self.presentations_by_source.entry(source).or_default().remove(&reference);
             }
+            WatchEvent::DeletedByName(tombstone) => {
+                let reference = self.presentation_ref(&tombstone.namespace, &tombstone.name);
+                self.presentations_by_source.entry(source).or_default().remove(&reference);
+            }
         }
         self.rebuild_local_projection().await;
     }
@@ -848,6 +852,10 @@ impl Aggregator {
                 let reference = self.demand_ref(&demand.metadata.namespace, &demand.metadata.name);
                 self.demands.remove(&reference);
             }
+            WatchEvent::DeletedByName(tombstone) => {
+                let reference = self.demand_ref(&tombstone.namespace, &tombstone.name);
+                self.demands.remove(&reference);
+            }
         }
         self.rebuild_local_projection().await;
     }
@@ -860,6 +868,10 @@ impl Aggregator {
             }
             WatchEvent::Deleted(regard) => {
                 let reference = self.regard_ref(&regard.metadata.namespace, &regard.metadata.name);
+                self.regards.remove(&reference);
+            }
+            WatchEvent::DeletedByName(tombstone) => {
+                let reference = self.regard_ref(&tombstone.namespace, &tombstone.name);
                 self.regards.remove(&reference);
             }
         }
@@ -877,16 +889,16 @@ impl Aggregator {
     }
 
     async fn apply_convoy_read_event_from(&mut self, source: LocalSource, event: ReadWatchEvent<Convoy>) {
-        let convoy = match &event {
-            ReadWatchEvent::Added(convoy) | ReadWatchEvent::Modified(convoy) | ReadWatchEvent::Deleted(convoy) => convoy,
+        let key = match &event {
+            ReadWatchEvent::Added(convoy) | ReadWatchEvent::Modified(convoy) | ReadWatchEvent::Deleted(convoy) => convoy_key(convoy),
+            ReadWatchEvent::DeletedByName { tombstone, provenance } => tombstone_key(tombstone, provenance),
         };
-        let key = convoy_key(convoy);
         let previous = self.effective_convoys();
         match event {
             ReadWatchEvent::Added(convoy) | ReadWatchEvent::Modified(convoy) => {
                 self.convoys_by_source.entry(source).or_default().insert(key, convoy);
             }
-            ReadWatchEvent::Deleted(_) => {
+            ReadWatchEvent::Deleted(_) | ReadWatchEvent::DeletedByName { .. } => {
                 self.convoys_by_source.entry(source).or_default().remove(&key);
             }
         }
@@ -1255,6 +1267,9 @@ impl Aggregator {
             ReadWatchEvent::Deleted(session) => {
                 self.sessions_by_source.entry(source).or_default().remove(&session_key(&session));
             }
+            ReadWatchEvent::DeletedByName { tombstone, provenance } => {
+                self.sessions_by_source.entry(source).or_default().remove(&tombstone_key(&tombstone, &provenance));
+            }
         }
         self.rebuild_independents_projection().await;
         self.rebuild_local_projection().await;
@@ -1275,6 +1290,9 @@ impl Aggregator {
                 let project = project.object;
                 self.projects.remove(&(project.metadata.namespace, project.metadata.name));
             }
+            ReadWatchEvent::DeletedByName { tombstone, .. } => {
+                self.projects.remove(&(tombstone.namespace, tombstone.name));
+            }
         }
         self.rebuild_store_catalog().await;
     }
@@ -1286,6 +1304,9 @@ impl Aggregator {
             }
             WatchEvent::Deleted(repository) => {
                 self.repositories.remove(&repository.spec.key());
+            }
+            WatchEvent::DeletedByName(tombstone) => {
+                self.repositories.retain(|_, repository| repository.metadata.name != tombstone.name);
             }
         }
         self.rebuild_store_catalog().await;
@@ -1299,6 +1320,10 @@ impl Aggregator {
             }
             WatchEvent::Deleted(checkout) => {
                 let reference = self.checkout_ref(&checkout.metadata.namespace, &checkout.metadata.name);
+                self.observed_checkouts.remove(&reference);
+            }
+            WatchEvent::DeletedByName(tombstone) => {
+                let reference = self.checkout_ref(&tombstone.namespace, &tombstone.name);
                 self.observed_checkouts.remove(&reference);
             }
         }
@@ -1924,6 +1949,7 @@ fn local_read_event<T: Resource>(event: WatchEvent<T>) -> ReadWatchEvent<T> {
         WatchEvent::Added(object) => ReadWatchEvent::Added(local(object)),
         WatchEvent::Modified(object) => ReadWatchEvent::Modified(local(object)),
         WatchEvent::Deleted(object) => ReadWatchEvent::Deleted(local(object)),
+        WatchEvent::DeletedByName(tombstone) => ReadWatchEvent::DeletedByName { tombstone, provenance: ResourceProvenance::Local },
     }
 }
 
@@ -1933,6 +1959,17 @@ fn convoy_key(convoy: &ReadResourceObject<Convoy>) -> ConvoyKey {
         ResourceProvenance::Replica { origin_root, .. } => Some(origin_root.clone()),
     };
     (convoy.object.metadata.namespace.clone(), convoy.object.metadata.name.clone(), origin)
+}
+
+fn tombstone_key(
+    tombstone: &flotilla_resources::ResourceTombstone,
+    provenance: &ResourceProvenance,
+) -> (String, String, Option<flotilla_protocol::NodeId>) {
+    let origin = match provenance {
+        ResourceProvenance::Local => None,
+        ResourceProvenance::Replica { origin_root, .. } => Some(origin_root.clone()),
+    };
+    (tombstone.namespace.clone(), tombstone.name.clone(), origin)
 }
 
 fn session_key(session: &ReadResourceObject<TerminalSession>) -> SessionKey {

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -7614,7 +7614,7 @@ mod tests {
                 .expect("convoy watch event");
             let convoy = match event {
                 flotilla_resources::WatchEvent::Added(convoy) | flotilla_resources::WatchEvent::Modified(convoy) => convoy,
-                flotilla_resources::WatchEvent::Deleted(_) => continue,
+                flotilla_resources::WatchEvent::Deleted(_) | flotilla_resources::WatchEvent::DeletedByName(_) => continue,
             };
             let Some(status) = convoy.status else { continue };
             saw_interrupted_work |= status.work.get("implement").is_some_and(|work| work.phase == WorkPhase::Interrupted);

--- a/crates/flotilla-daemon/src/server/replicator.rs
+++ b/crates/flotilla-daemon/src/server/replicator.rs
@@ -301,10 +301,28 @@ async fn replicate_relay_over_http<T: Resource>(http: HttpBackend, daemon: &Arc<
     let mut watch = http.watch_replica_sources_typed::<T>(REPLICATION_NAMESPACE).await.map_err(|error| error.to_string())?;
     while let Some(event) = watch.next().await {
         let event = event.map_err(|error| error.to_string())?;
+        if let ReadWatchEvent::DeletedByName { mut tombstone, provenance } = event {
+            let ResourceProvenance::Replica { origin_root, last_synced_at } = provenance else {
+                continue;
+            };
+            if &origin_root == daemon.node_id() || &origin_root == peer {
+                continue;
+            }
+            tombstone.annotations.remove("flotilla.work/origin-root");
+            tombstone.annotations.remove("flotilla.work/last-synced-at");
+            daemon
+                .resource_backend()
+                .replica_writer::<T>(origin_root, REPLICATION_NAMESPACE)
+                .apply(WatchEvent::DeletedByName(tombstone), last_synced_at)
+                .await
+                .map_err(|error| error.to_string())?;
+            continue;
+        }
         let (kind, mut source) = match event {
             ReadWatchEvent::Added(source) => (StoredRelayEventKind::Added, source),
             ReadWatchEvent::Modified(source) => (StoredRelayEventKind::Modified, source),
             ReadWatchEvent::Deleted(source) => (StoredRelayEventKind::Deleted, source),
+            ReadWatchEvent::DeletedByName { .. } => unreachable!("handled above"),
         };
         let ResourceProvenance::Replica { origin_root, last_synced_at } = source.provenance else {
             continue;
@@ -589,8 +607,34 @@ async fn apply_relay_response<T: Resource>(
         let Some(event) = record_watch_event::<T>(record)? else {
             continue;
         };
+        if let WatchEvent::DeletedByName(mut tombstone) = event {
+            let Some(origin) = tombstone.annotations.remove("flotilla.work/origin-root") else {
+                continue;
+            };
+            let origin = NodeId::new(origin);
+            if &origin == daemon.node_id() || &origin == peer {
+                continue;
+            }
+            let synced_at = tombstone
+                .annotations
+                .remove("flotilla.work/last-synced-at")
+                .ok_or_else(|| "relayed tombstone is missing last-synced-at".to_string())
+                .and_then(|value| {
+                    chrono::DateTime::parse_from_rfc3339(&value)
+                        .map(|value| value.with_timezone(&Utc))
+                        .map_err(|error| format!("decode relayed tombstone sync timestamp: {error}"))
+                })?;
+            daemon
+                .resource_backend()
+                .replica_writer::<T>(origin, REPLICATION_NAMESPACE)
+                .apply(WatchEvent::DeletedByName(tombstone), synced_at)
+                .await
+                .map_err(|error| error.to_string())?;
+            continue;
+        }
         let object = match &event {
             WatchEvent::Added(object) | WatchEvent::Modified(object) | WatchEvent::Deleted(object) => object,
+            WatchEvent::DeletedByName(_) => unreachable!("handled above"),
         };
         let Some(origin) = object.metadata.annotations.get("flotilla.work/origin-root") else {
             continue;
@@ -618,6 +662,7 @@ async fn apply_relay_response<T: Resource>(
             WatchEvent::Added(object) => WatchEvent::Added(strip(object)),
             WatchEvent::Modified(object) => WatchEvent::Modified(strip(object)),
             WatchEvent::Deleted(object) => WatchEvent::Deleted(strip(object)),
+            WatchEvent::DeletedByName(_) => unreachable!("handled above"),
         };
         daemon
             .resource_backend()
@@ -677,9 +722,30 @@ fn record_watch_event<T: Resource>(record: ResourceReadRecord) -> Result<Option<
         ResourceRecordType::Bookmark => return Ok(None),
     };
     let object = record.object.ok_or_else(|| format!("{event_type} resource record is missing object"))?;
-    let event: K8sWatchEvent<T> = serde_json::from_value(serde_json::json!({ "type": event_type, "object": object }))
-        .map_err(|error| format!("decode replicated {} event: {error}", T::API_PATHS.kind))?;
-    event.into_watch_event().map(Some).map_err(|error| error.to_string())
+    let encoded = serde_json::json!({ "type": event_type, "object": object.clone() });
+    match serde_json::from_value::<K8sWatchEvent<T>>(encoded) {
+        Ok(event) => event.into_watch_event().map(Some).map_err(|error| error.to_string()),
+        Err(_) if event_type == "DELETED" => {
+            let metadata = &object["metadata"];
+            let name = metadata["name"]
+                .as_str()
+                .ok_or_else(|| format!("decode replicated {} tombstone: missing name", T::API_PATHS.kind))?
+                .to_string();
+            let namespace = metadata["namespace"].as_str().unwrap_or_default().to_string();
+            let resource_version = metadata["resourceVersion"]
+                .as_str()
+                .ok_or_else(|| format!("decode replicated {} tombstone: missing resourceVersion", T::API_PATHS.kind))?
+                .to_string();
+            let annotations = metadata["annotations"]
+                .as_object()
+                .map(|annotations| {
+                    annotations.iter().filter_map(|(key, value)| value.as_str().map(|value| (key.clone(), value.to_string()))).collect()
+                })
+                .unwrap_or_default();
+            Ok(Some(WatchEvent::DeletedByName(flotilla_resources::ResourceTombstone { name, namespace, resource_version, annotations })))
+        }
+        Err(error) => Err(format!("decode replicated {} event: {error}", T::API_PATHS.kind)),
+    }
 }
 
 #[cfg(test)]
@@ -693,6 +759,37 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn routed_replication_decodes_name_tombstones() {
+        let event = record_watch_event::<Convoy>(ResourceReadRecord {
+            record_type: ResourceRecordType::Deleted,
+            provenance: flotilla_protocol::ResourceRecordProvenance::Local { node_id: NodeId::new("authority") },
+            object: Some(json!({
+                "apiVersion": "flotilla.work/v1",
+                "kind": "Convoy",
+                "metadata": {
+                    "name": "lost-at-authority",
+                    "namespace": "flotilla",
+                    "resourceVersion": "9",
+                    "annotations": {
+                        "flotilla.work/origin-root": "authority",
+                        "flotilla.work/last-synced-at": "2026-08-11T20:00:00Z",
+                    },
+                },
+            })),
+        })
+        .expect("decode routed tombstone")
+        .expect("deleted record produces an event");
+
+        assert!(matches!(
+            event,
+            WatchEvent::DeletedByName(tombstone)
+                if tombstone.name == "lost-at-authority"
+                    && tombstone.namespace == "flotilla"
+                    && tombstone.annotations["flotilla.work/origin-root"] == "authority"
+        ));
+    }
 
     #[tokio::test(start_paused = true)]
     async fn socket_path_source_changes_are_resolved_between_retries() {

--- a/crates/flotilla-daemon/src/sleep_inhibitor.rs
+++ b/crates/flotilla-daemon/src/sleep_inhibitor.rs
@@ -146,6 +146,9 @@ impl ActiveVessels {
             WatchEvent::Deleted(vessel) => {
                 self.names.remove(&vessel.metadata.name);
             }
+            WatchEvent::DeletedByName(tombstone) => {
+                self.names.remove(&tombstone.name);
+            }
         }
     }
 
@@ -267,6 +270,13 @@ impl ActiveConvoys {
             }
             ReadWatchEvent::Deleted(convoy) => {
                 self.keys.remove(&convoy_key(&convoy));
+            }
+            ReadWatchEvent::DeletedByName { tombstone, provenance } => {
+                let origin = match provenance {
+                    ResourceProvenance::Local => None,
+                    ResourceProvenance::Replica { origin_root, .. } => Some(origin_root),
+                };
+                self.keys.remove(&(origin, tombstone.name));
             }
         }
     }

--- a/crates/flotilla-resources/examples/k8s_crud.rs
+++ b/crates/flotilla-resources/examples/k8s_crud.rs
@@ -143,7 +143,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             WatchEvent::Modified(object) => {
                 println!("watch saw modified resource rv={}", object.metadata.resource_version);
             }
-            WatchEvent::Added(_) | WatchEvent::Deleted(_) => println!("watch saw non-modified event"),
+            WatchEvent::Added(_) | WatchEvent::Deleted(_) | WatchEvent::DeletedByName(_) => {
+                println!("watch saw non-modified event")
+            }
         }
     }
 
@@ -152,6 +154,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Some(event) = watch.next().await {
         match event? {
             WatchEvent::Deleted(object) => println!("watch saw deleted resource rv={}", object.metadata.resource_version),
+            WatchEvent::DeletedByName(tombstone) => println!("watch saw name tombstone for {}", tombstone.name),
             WatchEvent::Added(_) | WatchEvent::Modified(_) => println!("watch saw non-deleted event"),
         }
     }

--- a/crates/flotilla-resources/src/backend.rs
+++ b/crates/flotilla-resources/src/backend.rs
@@ -181,8 +181,18 @@ impl<T: Resource> ReplicaReadResolver<T> {
                 let namespace = namespace.clone();
                 async move {
                     let event = event?;
+                    if let ReadWatchEvent::DeletedByName { tombstone, provenance } = event {
+                        return match backend.definitions::<T>(&namespace).get(&tombstone.name).await {
+                            Ok(object) => {
+                                Ok(ReadWatchEvent::Modified(ReadResourceObject { object, provenance: ResourceProvenance::Local }))
+                            }
+                            Err(ResourceError::NotFound { .. }) => Ok(ReadWatchEvent::DeletedByName { tombstone, provenance }),
+                            Err(error) => Err(error),
+                        };
+                    }
                     let fallback = match event {
                         ReadWatchEvent::Added(object) | ReadWatchEvent::Modified(object) | ReadWatchEvent::Deleted(object) => object,
+                        ReadWatchEvent::DeletedByName { .. } => unreachable!("handled above"),
                     };
                     match backend.definitions::<T>(&namespace).get(&fallback.object.metadata.name).await {
                         Ok(object) => Ok(ReadWatchEvent::Modified(ReadResourceObject { object, provenance: ResourceProvenance::Local })),
@@ -239,6 +249,17 @@ impl<T: Resource> ReplicaWriter<T> {
             crate::WatchEvent::Added(object) => (StoredReplicaEventKind::Added, object),
             crate::WatchEvent::Modified(object) => (StoredReplicaEventKind::Modified, object),
             crate::WatchEvent::Deleted(object) => (StoredReplicaEventKind::Deleted, object),
+            crate::WatchEvent::DeletedByName(tombstone) => {
+                return match &self.backend {
+                    ResourceBackend::InMemory(backend) => {
+                        backend.apply_replica_tombstone_typed::<T>(&self.origin_root, &self.namespace, &tombstone, synced_at).await
+                    }
+                    ResourceBackend::Sqlite(backend) => {
+                        backend.apply_replica_tombstone_typed::<T>(&self.origin_root, &self.namespace, &tombstone, synced_at).await
+                    }
+                    ResourceBackend::Http(_) => Err(ResourceError::invalid("HTTP backends cannot hold replicas")),
+                };
+            }
         };
         match &self.backend {
             ResourceBackend::InMemory(backend) => {
@@ -324,6 +345,11 @@ impl<T: Resource> TypedResolver<T> {
             return self.backend.definitions::<T>(&self.namespace).delete(name).await;
         }
         dispatch_backend!(self, delete_typed, name)
+    }
+
+    pub(crate) async fn tombstone(&self, name: &str) -> Result<crate::ResourceTombstone, ResourceError> {
+        ensure_replication_enabled::<T>()?;
+        dispatch_backend!(self, tombstone_typed, name)
     }
 
     pub async fn watch(&self, start: WatchStart) -> Result<WatchStream<T>, ResourceError> {

--- a/crates/flotilla-resources/src/controller/mod.rs
+++ b/crates/flotilla-resources/src/controller/mod.rs
@@ -226,6 +226,7 @@ impl<W: Resource, P: Resource> SecondaryWatch for LabelMappedWatch<W, P> {
                     WatchEvent::Added(object) | WatchEvent::Modified(object) | WatchEvent::Deleted(object) => {
                         Self::enqueue_from_object(self.label_key, &sender, &object).await?;
                     }
+                    WatchEvent::DeletedByName(_) => {}
                 }
             }
             Ok(())
@@ -264,6 +265,7 @@ impl<W: Resource, P: Resource> SecondaryWatch for ResolverLabelMappedWatch<W, P>
                     WatchEvent::Added(object) | WatchEvent::Modified(object) | WatchEvent::Deleted(object) => {
                         LabelMappedWatch::<W, P>::enqueue_from_object(self.label_key, &sender, &object).await?;
                     }
+                    WatchEvent::DeletedByName(_) => {}
                 }
             }
             Ok(())
@@ -302,6 +304,7 @@ impl<W: Resource, P: Resource> SecondaryWatch for ReplicaLabelMappedWatch<W, P> 
                     crate::ReadWatchEvent::Added(source)
                     | crate::ReadWatchEvent::Modified(source)
                     | crate::ReadWatchEvent::Deleted(source) => source,
+                    crate::ReadWatchEvent::DeletedByName { .. } => continue,
                 };
                 LabelMappedWatch::<W, P>::enqueue_from_object(self.label_key, &sender, &source.object).await?;
             }
@@ -352,6 +355,7 @@ impl SecondaryWatch for ReplicaConvoyCheckoutWatch {
                     crate::ReadWatchEvent::Added(source)
                     | crate::ReadWatchEvent::Modified(source)
                     | crate::ReadWatchEvent::Deleted(source) => source,
+                    crate::ReadWatchEvent::DeletedByName { .. } => continue,
                 };
                 Self::enqueue_checkouts(&sender, &source.object).await?;
             }
@@ -415,6 +419,7 @@ impl<W: Resource, P: Resource> SecondaryWatch for LabelJoinWatch<W, P> {
                     WatchEvent::Added(object) | WatchEvent::Modified(object) | WatchEvent::Deleted(object) => {
                         Self::enqueue_matching_primaries(self.label_key, &sender, &object, &primaries).await?;
                     }
+                    WatchEvent::DeletedByName(_) => {}
                 }
             }
             Ok(())
@@ -562,6 +567,12 @@ impl<R: Reconciler> ControllerLoop<R> {
                                 .send(object.metadata.name)
                                 .await
                                 .map_err(|_| ResourceError::other("controller queue closed while forwarding primary watch event"))?;
+                        }
+                        WatchEvent::DeletedByName(tombstone) => {
+                            sender
+                                .send(tombstone.name)
+                                .await
+                                .map_err(|_| ResourceError::other("controller queue closed while forwarding primary tombstone"))?;
                         }
                     }
                 }

--- a/crates/flotilla-resources/src/http/mod.rs
+++ b/crates/flotilla-resources/src/http/mod.rs
@@ -18,7 +18,7 @@ use crate::{
         ApiPaths, InputMeta, K8sInputResourceObject, K8sResourceList, K8sResourceObject, K8sStatusResourceObject, K8sWatchEvent, Resource,
         ResourceObject,
     },
-    watch::{ResourceList, WatchEvent, WatchStart, WatchStream},
+    watch::{ResourceList, ResourceTombstone, WatchEvent, WatchStart, WatchStream},
 };
 
 #[derive(Debug, Clone)]
@@ -239,6 +239,10 @@ impl HttpBackend {
         Self::expect_success(response, Some(name)).await
     }
 
+    pub(crate) async fn tombstone_typed<T: Resource>(&self, _namespace: &str, _name: &str) -> Result<ResourceTombstone, ResourceError> {
+        Err(ResourceError::invalid(format!("HTTP backends cannot author {} tombstones", T::API_PATHS.kind)))
+    }
+
     pub(crate) async fn watch_typed<T: Resource>(&self, namespace: &str, start: WatchStart) -> Result<WatchStream<T>, ResourceError> {
         let url = self.namespaced_url(T::API_PATHS, namespace, None, false);
         let mut query = vec![("watch", Cow::Borrowed("true"))];
@@ -357,6 +361,21 @@ fn read_watch_event<T: Resource>(event: WatchEvent<T>) -> Result<ReadWatchEvent<
         WatchEvent::Added(object) => read_resource_object(object).map(ReadWatchEvent::Added),
         WatchEvent::Modified(object) => read_resource_object(object).map(ReadWatchEvent::Modified),
         WatchEvent::Deleted(object) => read_resource_object(object).map(ReadWatchEvent::Deleted),
+        WatchEvent::DeletedByName(tombstone) => {
+            let origin = tombstone.annotations.get(ORIGIN_ROOT_ANNOTATION);
+            let synced_at = tombstone.annotations.get(LAST_SYNCED_AT_ANNOTATION);
+            let provenance = match (origin, synced_at) {
+                (None, None) => ResourceProvenance::Local,
+                (Some(origin), Some(synced_at)) => ResourceProvenance::Replica {
+                    origin_root: flotilla_protocol::NodeId::new(origin.clone()),
+                    last_synced_at: chrono::DateTime::parse_from_rfc3339(synced_at)
+                        .map_err(|error| ResourceError::decode(format!("decode replica tombstone sync timestamp: {error}")))?
+                        .with_timezone(&chrono::Utc),
+                },
+                _ => return Err(ResourceError::decode("replica tombstone provenance annotations are incomplete")),
+            };
+            Ok(ReadWatchEvent::DeletedByName { tombstone, provenance })
+        }
     }
 }
 
@@ -393,7 +412,29 @@ fn map_status_error(status: StatusCode, bytes: &[u8], resource_name: Option<&str
 }
 
 fn parse_watch_line<T: Resource>(line: &[u8]) -> Result<WatchEvent<T>, ResourceError> {
-    let event =
-        serde_json::from_slice::<K8sWatchEvent<T>>(line).map_err(|err| ResourceError::decode(format!("decode watch event: {err}")))?;
-    event.into_watch_event()
+    match serde_json::from_slice::<K8sWatchEvent<T>>(line) {
+        Ok(event) => event.into_watch_event(),
+        Err(typed_error) => {
+            let value: serde_json::Value =
+                serde_json::from_slice(line).map_err(|_| ResourceError::decode(format!("decode watch event: {typed_error}")))?;
+            if value["type"].as_str() != Some("DELETED") {
+                return Err(ResourceError::decode(format!("decode watch event: {typed_error}")));
+            }
+            let metadata = &value["object"]["metadata"];
+            let name =
+                metadata["name"].as_str().ok_or_else(|| ResourceError::decode("decode tombstone watch event: missing name"))?.to_string();
+            let resource_version = metadata["resourceVersion"]
+                .as_str()
+                .ok_or_else(|| ResourceError::decode("decode tombstone watch event: missing resourceVersion"))?
+                .to_string();
+            let namespace = metadata["namespace"].as_str().unwrap_or_default().to_string();
+            let annotations = metadata["annotations"]
+                .as_object()
+                .map(|annotations| {
+                    annotations.iter().filter_map(|(key, value)| value.as_str().map(|value| (key.clone(), value.to_string()))).collect()
+                })
+                .unwrap_or_default();
+            Ok(WatchEvent::DeletedByName(ResourceTombstone { name, namespace, resource_version, annotations }))
+        }
+    }
 }

--- a/crates/flotilla-resources/src/http/mod.rs
+++ b/crates/flotilla-resources/src/http/mod.rs
@@ -438,3 +438,47 @@ fn parse_watch_line<T: Resource>(line: &[u8]) -> Result<WatchEvent<T>, ResourceE
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+
+    use super::*;
+    use crate::Usage;
+
+    #[test]
+    fn decodes_replica_name_tombstone_from_http_watch_line() {
+        let line = br#"{
+            "type":"DELETED",
+            "object":{
+                "apiVersion":"flotilla.work/v1",
+                "kind":"Usage",
+                "metadata":{
+                    "name":"lost-account",
+                    "namespace":"default",
+                    "resourceVersion":"42",
+                    "annotations":{
+                        "flotilla.work/origin-root":"origin-a",
+                        "flotilla.work/last-synced-at":"2026-08-11T20:00:00Z"
+                    }
+                }
+            }
+        }"#;
+
+        let event = parse_watch_line::<Usage>(line).expect("decode HTTP tombstone");
+        let event = read_watch_event(event).expect("decode tombstone provenance");
+
+        match event {
+            ReadWatchEvent::DeletedByName { tombstone, provenance } => {
+                assert_eq!(tombstone.name, "lost-account");
+                assert_eq!(tombstone.namespace, "default");
+                assert_eq!(tombstone.resource_version, "42");
+                assert_eq!(provenance, ResourceProvenance::Replica {
+                    origin_root: flotilla_protocol::NodeId::new("origin-a"),
+                    last_synced_at: Utc.with_ymd_and_hms(2026, 8, 11, 20, 0, 0).unwrap(),
+                });
+            }
+            other => panic!("expected name tombstone, got {other:?}"),
+        }
+    }
+}

--- a/crates/flotilla-resources/src/in_memory.rs
+++ b/crates/flotilla-resources/src/in_memory.rs
@@ -259,9 +259,12 @@ impl InMemoryBackend {
             let event = rx.recv().await?;
             let provenance = ResourceProvenance::Replica { origin_root: event.origin_root, last_synced_at: event.synced_at };
             let decoded = if matches!(event.kind, StoredReplicaEventKind::Deleted) {
-                match Self::decode_object::<T>(event.object.clone()) {
-                    Ok(object) => Ok(ReadWatchEvent::Deleted(ReadResourceObject { object, provenance })),
-                    Err(_) => Self::decode_tombstone(event.object).map(|tombstone| ReadWatchEvent::DeletedByName { tombstone, provenance }),
+                // Name-only tombstones deliberately omit `spec`; a present but
+                // malformed spec is a corrupt object and must remain an error.
+                if event.object.get("spec").is_some() {
+                    Self::decode_object::<T>(event.object).map(|object| ReadWatchEvent::Deleted(ReadResourceObject { object, provenance }))
+                } else {
+                    Self::decode_tombstone(event.object).map(|tombstone| ReadWatchEvent::DeletedByName { tombstone, provenance })
                 }
             } else {
                 Self::decode_object::<T>(event.object).map(|object| {
@@ -432,10 +435,12 @@ impl InMemoryBackend {
         match event.kind {
             StoredEventKind::Added => Self::decode_object::<T>(event.object).map(WatchEvent::Added),
             StoredEventKind::Modified => Self::decode_object::<T>(event.object).map(WatchEvent::Modified),
-            StoredEventKind::Deleted => match Self::decode_object::<T>(event.object.clone()) {
-                Ok(object) => Ok(WatchEvent::Deleted(object)),
-                Err(_) => Self::decode_tombstone(event.object).map(WatchEvent::DeletedByName),
-            },
+            // Name-only tombstones deliberately omit `spec`; a present but
+            // malformed spec is a corrupt object and must remain an error.
+            StoredEventKind::Deleted if event.object.get("spec").is_none() => {
+                Self::decode_tombstone(event.object).map(WatchEvent::DeletedByName)
+            }
+            StoredEventKind::Deleted => Self::decode_object::<T>(event.object).map(WatchEvent::Deleted),
         }
     }
 

--- a/crates/flotilla-resources/src/in_memory.rs
+++ b/crates/flotilla-resources/src/in_memory.rs
@@ -15,7 +15,7 @@ use crate::{
     replica::{ReadResourceObject, ReadWatchEvent, ReplicaCursor, ResourceProvenance, StoredReplicaEvent, StoredReplicaEventKind},
     resource::{InputMeta, K8sResourceObject, MergeMetadata, ObjectMeta, Resource, ResourceObject},
     retention::{EventRetention, ResourceStoreDiagnostics, MAX_FIELD_OWNERSHIP_VIOLATIONS},
-    watch::{ResourceList, WatchEvent, WatchStart, WatchStream},
+    watch::{ResourceList, ResourceTombstone, WatchEvent, WatchStart, WatchStream},
 };
 
 type StoreKey = (String, String, String, String);
@@ -257,17 +257,22 @@ impl InMemoryBackend {
         self.replicas.lock().await.watchers.entry(key).or_default().push(tx);
         Ok(stream::unfold(rx, |mut rx| async {
             let event = rx.recv().await?;
-            let decoded = Self::decode_object::<T>(event.object).map(|object| {
-                let object = ReadResourceObject {
-                    object,
-                    provenance: ResourceProvenance::Replica { origin_root: event.origin_root, last_synced_at: event.synced_at },
-                };
-                match event.kind {
-                    StoredReplicaEventKind::Added => ReadWatchEvent::Added(object),
-                    StoredReplicaEventKind::Modified => ReadWatchEvent::Modified(object),
-                    StoredReplicaEventKind::Deleted => ReadWatchEvent::Deleted(object),
+            let provenance = ResourceProvenance::Replica { origin_root: event.origin_root, last_synced_at: event.synced_at };
+            let decoded = if matches!(event.kind, StoredReplicaEventKind::Deleted) {
+                match Self::decode_object::<T>(event.object.clone()) {
+                    Ok(object) => Ok(ReadWatchEvent::Deleted(ReadResourceObject { object, provenance })),
+                    Err(_) => Self::decode_tombstone(event.object).map(|tombstone| ReadWatchEvent::DeletedByName { tombstone, provenance }),
                 }
-            });
+            } else {
+                Self::decode_object::<T>(event.object).map(|object| {
+                    let object = ReadResourceObject { object, provenance };
+                    match event.kind {
+                        StoredReplicaEventKind::Added => ReadWatchEvent::Added(object),
+                        StoredReplicaEventKind::Modified => ReadWatchEvent::Modified(object),
+                        StoredReplicaEventKind::Deleted => unreachable!("deleted replica events handled above"),
+                    }
+                })
+            };
             Some((decoded, rx))
         })
         .boxed())
@@ -379,6 +384,41 @@ impl InMemoryBackend {
         Ok(())
     }
 
+    pub(crate) async fn apply_replica_tombstone_typed<T: Resource>(
+        &self,
+        origin_root: &NodeId,
+        namespace: &str,
+        tombstone: &ResourceTombstone,
+        synced_at: chrono::DateTime<Utc>,
+    ) -> Result<(), ResourceError> {
+        let store_key = Self::store_key::<T>(namespace);
+        let replica_key = (origin_root.clone(), store_key.clone());
+        let encoded = Self::encode_tombstone::<T>(tombstone);
+        let mut state = self.replicas.lock().await;
+        let partition = state.partitions.entry(replica_key).or_default();
+        let unchanged = match partition.synced_at_by_name.get(&tombstone.name) {
+            Some(existing_synced_at) if existing_synced_at > &synced_at => true,
+            Some(existing_synced_at) if existing_synced_at == &synced_at => !partition.objects.contains_key(&tombstone.name),
+            _ => false,
+        };
+        if unchanged {
+            return Ok(());
+        }
+        partition.objects.remove(&tombstone.name);
+        partition.synced_at_by_name.insert(tombstone.name.clone(), synced_at);
+        partition.cursor = Some(ReplicaCursor {
+            resource_version: tombstone.resource_version.clone(),
+            generation: partition.cursor.as_ref().and_then(|cursor| cursor.generation.clone()),
+        });
+        Self::notify_replica_watchers(&mut state, &store_key, StoredReplicaEvent {
+            origin_root: origin_root.clone(),
+            synced_at,
+            kind: StoredReplicaEventKind::Deleted,
+            object: encoded,
+        });
+        Ok(())
+    }
+
     pub(crate) async fn replica_cursor_typed<T: Resource>(
         &self,
         origin_root: &NodeId,
@@ -389,11 +429,49 @@ impl InMemoryBackend {
     }
 
     fn decode_event<T: Resource>(event: StoredEvent) -> Result<WatchEvent<T>, ResourceError> {
-        let object = Self::decode_object::<T>(event.object)?;
-        Ok(match event.kind {
-            StoredEventKind::Added => WatchEvent::Added(object),
-            StoredEventKind::Modified => WatchEvent::Modified(object),
-            StoredEventKind::Deleted => WatchEvent::Deleted(object),
+        match event.kind {
+            StoredEventKind::Added => Self::decode_object::<T>(event.object).map(WatchEvent::Added),
+            StoredEventKind::Modified => Self::decode_object::<T>(event.object).map(WatchEvent::Modified),
+            StoredEventKind::Deleted => match Self::decode_object::<T>(event.object.clone()) {
+                Ok(object) => Ok(WatchEvent::Deleted(object)),
+                Err(_) => Self::decode_tombstone(event.object).map(WatchEvent::DeletedByName),
+            },
+        }
+    }
+
+    fn decode_tombstone(value: Value) -> Result<ResourceTombstone, ResourceError> {
+        let metadata = value.get("metadata").ok_or_else(|| ResourceError::decode("decode tombstone: missing metadata"))?;
+        let name = metadata
+            .get("name")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ResourceError::decode("decode tombstone: missing name"))?
+            .to_string();
+        let resource_version = metadata
+            .get("resourceVersion")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ResourceError::decode("decode tombstone: missing resourceVersion"))?
+            .to_string();
+        let namespace = metadata.get("namespace").and_then(Value::as_str).unwrap_or_default().to_string();
+        let annotations = metadata
+            .get("annotations")
+            .cloned()
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(|error| ResourceError::decode(format!("decode tombstone annotations: {error}")))?
+            .unwrap_or_default();
+        Ok(ResourceTombstone { name, namespace, resource_version, annotations })
+    }
+
+    fn encode_tombstone<T: Resource>(tombstone: &ResourceTombstone) -> Value {
+        serde_json::json!({
+            "apiVersion": format!("{}/{}", T::API_PATHS.group, T::API_PATHS.version),
+            "kind": T::API_PATHS.kind,
+            "metadata": {
+                "name": tombstone.name,
+                "namespace": tombstone.namespace,
+                "resourceVersion": tombstone.resource_version,
+                "annotations": tombstone.annotations,
+            },
         })
     }
 
@@ -636,6 +714,27 @@ impl InMemoryBackend {
                 T::REPLICATION_CLASS.event_retention(self.event_retention.max_events_per_resource_stream()),
             );
             Ok(())
+        })
+        .await
+    }
+
+    pub(crate) async fn tombstone_typed<T: Resource>(&self, namespace: &str, name: &str) -> Result<ResourceTombstone, ResourceError> {
+        self.with_store_mut::<T, _>(namespace, |store| {
+            if store.objects.contains_key(name) {
+                return Err(ResourceError::conflict(name, "cannot tombstone an existing resource by name"));
+            }
+            let version = store.allocate_version();
+            let tombstone = ResourceTombstone {
+                name: name.to_string(),
+                namespace: namespace.to_string(),
+                resource_version: version.to_string(),
+                annotations: BTreeMap::new(),
+            };
+            store.push_event(
+                StoredEvent { version, kind: StoredEventKind::Deleted, object: Self::encode_tombstone::<T>(&tombstone) },
+                T::REPLICATION_CLASS.event_retention(self.event_retention.max_events_per_resource_stream()),
+            );
+            Ok(tombstone)
         })
         .await
     }

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -148,7 +148,7 @@ pub use usage::{usage_record_name, Usage, UsagePace, UsageProviderCost, UsageSpe
 pub use vessel::{
     Vessel, VesselPhase, VesselSpec, VesselStatus, VesselStatusPatch, ACTUATOR_HOST_REF_ANNOTATION, ACTUATOR_SOURCE_ROOT_ANNOTATION,
 };
-pub use watch::{ResourceList, WatchEvent, WatchStart, WatchStream};
+pub use watch::{ResourceList, ResourceTombstone, WatchEvent, WatchStart, WatchStream};
 
 #[doc(hidden)]
 #[macro_export]

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -571,13 +571,22 @@ async fn get_typed<T: Resource>(backend: &ResourceBackend, namespace: &str, name
 
 async fn delete_typed<T: Resource>(backend: &ResourceBackend, namespace: &str, name: &str) -> Result<DynamicResourceObject, ResourceError> {
     let resolver = backend.using::<T>(namespace);
-    let object = resolver.get(name).await?;
-    resolver.delete(name).await?;
+    let value = match resolver.get(name).await {
+        Ok(object) => {
+            resolver.delete(name).await?;
+            object_value(&object)?
+        }
+        Err(ResourceError::NotFound { .. }) if T::REPLICATION_CLASS != crate::ReplicationClass::None => {
+            let tombstone = resolver.tombstone(name).await?;
+            tombstone_value::<T>(&tombstone)
+        }
+        Err(error) => return Err(error),
+    };
     Ok(DynamicResourceObject {
         kind: T::API_PATHS.kind.to_string(),
         plural: T::API_PATHS.plural.to_string(),
         namespace: namespace.to_string(),
-        value: object_value(&object)?,
+        value,
     })
 }
 
@@ -864,6 +873,14 @@ fn read_watch_event_value<T: Resource>(event: &ReadWatchEvent<T>) -> Result<Valu
         ReadWatchEvent::Added(object) => ("ADDED", object),
         ReadWatchEvent::Modified(object) => ("MODIFIED", object),
         ReadWatchEvent::Deleted(object) => ("DELETED", object),
+        ReadWatchEvent::DeletedByName { tombstone, provenance } => {
+            let mut tombstone = tombstone.clone();
+            if let ResourceProvenance::Replica { origin_root, last_synced_at } = provenance {
+                tombstone.annotations.insert(ORIGIN_ROOT_ANNOTATION.to_string(), origin_root.to_string());
+                tombstone.annotations.insert(LAST_SYNCED_AT_ANNOTATION.to_string(), last_synced_at.to_rfc3339());
+            }
+            return Ok(json!({"type": "DELETED", "object": tombstone_value::<T>(&tombstone)}));
+        }
     };
     Ok(json!({"type": event_type, "object": read_object_value(object)?}))
 }
@@ -873,7 +890,21 @@ fn typed_watch_event_value<T: Resource>(event: &WatchEvent<T>) -> Result<Value, 
         WatchEvent::Added(object) => watch_event_value("ADDED", object),
         WatchEvent::Modified(object) => watch_event_value("MODIFIED", object),
         WatchEvent::Deleted(object) => watch_event_value("DELETED", object),
+        WatchEvent::DeletedByName(tombstone) => Ok(json!({"type": "DELETED", "object": tombstone_value::<T>(tombstone)})),
     }
+}
+
+fn tombstone_value<T: Resource>(tombstone: &crate::ResourceTombstone) -> Value {
+    json!({
+        "apiVersion": api_version(T::API_PATHS),
+        "kind": T::API_PATHS.kind,
+        "metadata": {
+            "name": tombstone.name,
+            "namespace": tombstone.namespace,
+            "resourceVersion": tombstone.resource_version,
+            "annotations": tombstone.annotations,
+        },
+    })
 }
 
 fn watch_event_value<T: Resource>(event_type: &str, object: &ResourceObject<T>) -> Result<Value, ResourceError> {

--- a/crates/flotilla-resources/src/replica.rs
+++ b/crates/flotilla-resources/src/replica.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use flotilla_protocol::NodeId;
 use serde::{Deserialize, Serialize};
 
-use crate::{Resource, ResourceObject, WatchEvent};
+use crate::{Resource, ResourceObject, ResourceTombstone, WatchEvent};
 
 pub(crate) const ORIGIN_ROOT_ANNOTATION: &str = "flotilla.work/origin-root";
 pub(crate) const LAST_SYNCED_AT_ANNOTATION: &str = "flotilla.work/last-synced-at";
@@ -54,6 +54,7 @@ pub enum ReadWatchEvent<T: Resource> {
     Added(ReadResourceObject<T>),
     Modified(ReadResourceObject<T>),
     Deleted(ReadResourceObject<T>),
+    DeletedByName { tombstone: ResourceTombstone, provenance: ResourceProvenance },
 }
 
 impl<T: Resource> ReadWatchEvent<T> {
@@ -62,6 +63,7 @@ impl<T: Resource> ReadWatchEvent<T> {
             WatchEvent::Added(object) => Self::Added(ReadResourceObject { object, provenance: ResourceProvenance::Local }),
             WatchEvent::Modified(object) => Self::Modified(ReadResourceObject { object, provenance: ResourceProvenance::Local }),
             WatchEvent::Deleted(object) => Self::Deleted(ReadResourceObject { object, provenance: ResourceProvenance::Local }),
+            WatchEvent::DeletedByName(tombstone) => Self::DeletedByName { tombstone, provenance: ResourceProvenance::Local },
         }
     }
 }

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -20,7 +20,7 @@ use crate::{
     retention::{
         EventRetention, ResourceDecodeQuarantine, ResourceEventDecodeQuarantine, ResourceStoreDiagnostics, MAX_FIELD_OWNERSHIP_VIOLATIONS,
     },
-    watch::{ResourceList, WatchEvent, WatchStart, WatchStream},
+    watch::{ResourceList, ResourceTombstone, WatchEvent, WatchStart, WatchStream},
     FieldOwnershipViolation,
 };
 
@@ -29,6 +29,15 @@ type WatchSender = mpsc::UnboundedSender<StoredEvent>;
 type WatchersByStore = HashMap<StoreKey, Vec<WatchSender>>;
 type ReplicaWatchSender = mpsc::UnboundedSender<StoredReplicaEvent>;
 type ReplicaWatchersByStore = HashMap<StoreKey, Vec<ReplicaWatchSender>>;
+
+#[derive(bon::Builder)]
+struct ReplicaMutation {
+    kind: StoredReplicaEventKind,
+    name: String,
+    resource_version: String,
+    value: Value,
+    synced_at: DateTime<Utc>,
+}
 
 #[derive(Debug, Clone, bon::Builder)]
 #[builder(builder_type(vis = "pub(in crate::sqlite)"))]
@@ -489,13 +498,51 @@ impl SqliteBackend {
         serde_json::to_value(object.to_k8s_object()).map_err(|err| ResourceError::decode(format!("encode object: {err}")))
     }
 
-    fn decode_event<T: Resource>(event: StoredEvent) -> Result<WatchEvent<T>, ResourceError> {
-        let object = Self::decode_object::<T>(event.object)?;
-        Ok(match event.kind {
-            StoredEventKind::Added => WatchEvent::Added(object),
-            StoredEventKind::Modified => WatchEvent::Modified(object),
-            StoredEventKind::Deleted => WatchEvent::Deleted(object),
+    fn encode_tombstone<T: Resource>(tombstone: &ResourceTombstone) -> Value {
+        serde_json::json!({
+            "apiVersion": format!("{}/{}", T::API_PATHS.group, T::API_PATHS.version),
+            "kind": T::API_PATHS.kind,
+            "metadata": {
+                "name": tombstone.name,
+                "namespace": tombstone.namespace,
+                "resourceVersion": tombstone.resource_version,
+                "annotations": tombstone.annotations,
+            },
         })
+    }
+
+    fn decode_tombstone(value: Value) -> Result<ResourceTombstone, ResourceError> {
+        let metadata = value.get("metadata").ok_or_else(|| ResourceError::decode("decode tombstone: missing metadata"))?;
+        let name = metadata
+            .get("name")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ResourceError::decode("decode tombstone: missing name"))?
+            .to_string();
+        let resource_version = metadata
+            .get("resourceVersion")
+            .and_then(Value::as_str)
+            .ok_or_else(|| ResourceError::decode("decode tombstone: missing resourceVersion"))?
+            .to_string();
+        let namespace = metadata.get("namespace").and_then(Value::as_str).unwrap_or_default().to_string();
+        let annotations = metadata
+            .get("annotations")
+            .cloned()
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(|error| ResourceError::decode(format!("decode tombstone annotations: {error}")))?
+            .unwrap_or_default();
+        Ok(ResourceTombstone { name, namespace, resource_version, annotations })
+    }
+
+    fn decode_event<T: Resource>(event: StoredEvent) -> Result<WatchEvent<T>, ResourceError> {
+        match event.kind {
+            StoredEventKind::Added => Self::decode_object::<T>(event.object).map(WatchEvent::Added),
+            StoredEventKind::Modified => Self::decode_object::<T>(event.object).map(WatchEvent::Modified),
+            StoredEventKind::Deleted => match Self::decode_object::<T>(event.object.clone()) {
+                Ok(object) => Ok(WatchEvent::Deleted(object)),
+                Err(_) => Self::decode_tombstone(event.object).map(WatchEvent::DeletedByName),
+            },
+        }
     }
 
     fn map_sqlite(err: rusqlite::Error, action: &str) -> ResourceError {
@@ -733,17 +780,22 @@ impl SqliteBackend {
             .push(tx);
         Ok(stream::unfold(rx, |mut rx| async {
             let event = rx.recv().await?;
-            let decoded = Self::decode_object::<T>(event.object).map(|object| {
-                let object = ReadResourceObject {
-                    object,
-                    provenance: ResourceProvenance::Replica { origin_root: event.origin_root, last_synced_at: event.synced_at },
-                };
-                match event.kind {
-                    StoredReplicaEventKind::Added => ReadWatchEvent::Added(object),
-                    StoredReplicaEventKind::Modified => ReadWatchEvent::Modified(object),
-                    StoredReplicaEventKind::Deleted => ReadWatchEvent::Deleted(object),
+            let provenance = ResourceProvenance::Replica { origin_root: event.origin_root, last_synced_at: event.synced_at };
+            let decoded = if matches!(event.kind, StoredReplicaEventKind::Deleted) {
+                match Self::decode_object::<T>(event.object.clone()) {
+                    Ok(object) => Ok(ReadWatchEvent::Deleted(ReadResourceObject { object, provenance })),
+                    Err(_) => Self::decode_tombstone(event.object).map(|tombstone| ReadWatchEvent::DeletedByName { tombstone, provenance }),
                 }
-            });
+            } else {
+                Self::decode_object::<T>(event.object).map(|object| {
+                    let object = ReadResourceObject { object, provenance };
+                    match event.kind {
+                        StoredReplicaEventKind::Added => ReadWatchEvent::Added(object),
+                        StoredReplicaEventKind::Modified => ReadWatchEvent::Modified(object),
+                        StoredReplicaEventKind::Deleted => unreachable!("deleted replica events handled above"),
+                    }
+                })
+            };
             Some((decoded, rx))
         })
         .boxed())
@@ -876,12 +928,48 @@ impl SqliteBackend {
         object: &ResourceObject<T>,
         synced_at: DateTime<Utc>,
     ) -> Result<(), ResourceError> {
-        let key = Self::store_key::<T>(namespace);
-        let operation_key = key.clone();
-        let origin = origin_root.to_string();
         let name = object.metadata.name.clone();
         let resource_version = object.metadata.resource_version.clone();
         let value = Self::encode_object(object)?;
+        self.apply_replica_value::<T>(
+            origin_root,
+            namespace,
+            ReplicaMutation::builder().kind(kind).name(name).resource_version(resource_version).value(value).synced_at(synced_at).build(),
+        )
+        .await
+    }
+
+    pub(crate) async fn apply_replica_tombstone_typed<T: Resource>(
+        &self,
+        origin_root: &NodeId,
+        namespace: &str,
+        tombstone: &ResourceTombstone,
+        synced_at: DateTime<Utc>,
+    ) -> Result<(), ResourceError> {
+        self.apply_replica_value::<T>(
+            origin_root,
+            namespace,
+            ReplicaMutation::builder()
+                .kind(StoredReplicaEventKind::Deleted)
+                .name(tombstone.name.clone())
+                .resource_version(tombstone.resource_version.clone())
+                .value(Self::encode_tombstone::<T>(tombstone))
+                .synced_at(synced_at)
+                .build(),
+        )
+        .await
+    }
+
+    async fn apply_replica_value<T: Resource>(
+        &self,
+        origin_root: &NodeId,
+        namespace: &str,
+        mutation: ReplicaMutation,
+    ) -> Result<(), ResourceError> {
+        let ReplicaMutation { kind, name, resource_version, value, synced_at } = mutation;
+        let key = Self::store_key::<T>(namespace);
+        let operation_key = key.clone();
+        let origin = origin_root.to_string();
         let body =
             serde_json::to_string(&value).map_err(|err| ResourceError::decode(format!("encode sqlite replica event JSON: {err}")))?;
         let synced = synced_at.to_rfc3339();
@@ -1392,6 +1480,35 @@ impl SqliteBackend {
             tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource delete"))?;
             Self::notify_watchers(&watchers, &key, StoredEvent { kind: event_kind, object: encoded });
             Ok(())
+        })
+        .await
+    }
+
+    pub(crate) async fn tombstone_typed<T: Resource>(&self, namespace: &str, name: &str) -> Result<ResourceTombstone, ResourceError> {
+        let key = Self::store_key::<T>(namespace);
+        let namespace = namespace.to_string();
+        let name = name.to_string();
+        let watchers = Arc::clone(&self.watchers);
+        let event_retention = self.event_retention;
+        self.call(move |connection| {
+            let tx = connection.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite resource tombstone"))?;
+            if Self::select_existing::<T>(&tx, &key, &name)?.is_some() {
+                return Err(ResourceError::conflict(&name, "cannot tombstone an existing resource by name"));
+            }
+            let version = Self::allocate_version(&tx, &key)?;
+            let tombstone = ResourceTombstone {
+                name: name.clone(),
+                namespace: namespace.clone(),
+                resource_version: version.to_string(),
+                annotations: BTreeMap::new(),
+            };
+            let encoded = Self::encode_tombstone::<T>(&tombstone);
+            let body_json =
+                serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode tombstone JSON: {err}")))?;
+            Self::insert_event(&tx, &key, version, StoredEventKind::Deleted, &body_json, event_retention, T::REPLICATION_CLASS)?;
+            tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource tombstone"))?;
+            Self::notify_watchers(&watchers, &key, StoredEvent { kind: StoredEventKind::Deleted, object: encoded });
+            Ok(tombstone)
         })
         .await
     }

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -538,10 +538,12 @@ impl SqliteBackend {
         match event.kind {
             StoredEventKind::Added => Self::decode_object::<T>(event.object).map(WatchEvent::Added),
             StoredEventKind::Modified => Self::decode_object::<T>(event.object).map(WatchEvent::Modified),
-            StoredEventKind::Deleted => match Self::decode_object::<T>(event.object.clone()) {
-                Ok(object) => Ok(WatchEvent::Deleted(object)),
-                Err(_) => Self::decode_tombstone(event.object).map(WatchEvent::DeletedByName),
-            },
+            // Name-only tombstones deliberately omit `spec`; a present but
+            // malformed spec is a corrupt object and must remain an error.
+            StoredEventKind::Deleted if event.object.get("spec").is_none() => {
+                Self::decode_tombstone(event.object).map(WatchEvent::DeletedByName)
+            }
+            StoredEventKind::Deleted => Self::decode_object::<T>(event.object).map(WatchEvent::Deleted),
         }
     }
 
@@ -782,9 +784,12 @@ impl SqliteBackend {
             let event = rx.recv().await?;
             let provenance = ResourceProvenance::Replica { origin_root: event.origin_root, last_synced_at: event.synced_at };
             let decoded = if matches!(event.kind, StoredReplicaEventKind::Deleted) {
-                match Self::decode_object::<T>(event.object.clone()) {
-                    Ok(object) => Ok(ReadWatchEvent::Deleted(ReadResourceObject { object, provenance })),
-                    Err(_) => Self::decode_tombstone(event.object).map(|tombstone| ReadWatchEvent::DeletedByName { tombstone, provenance }),
+                // Name-only tombstones deliberately omit `spec`; a present but
+                // malformed spec is a corrupt object and must remain an error.
+                if event.object.get("spec").is_some() {
+                    Self::decode_object::<T>(event.object).map(|object| ReadWatchEvent::Deleted(ReadResourceObject { object, provenance }))
+                } else {
+                    Self::decode_tombstone(event.object).map(|tombstone| ReadWatchEvent::DeletedByName { tombstone, provenance })
                 }
             } else {
                 Self::decode_object::<T>(event.object).map(|object| {

--- a/crates/flotilla-resources/src/watch.rs
+++ b/crates/flotilla-resources/src/watch.rs
@@ -75,6 +75,16 @@ pub enum WatchEvent<T: Resource> {
     Added(ResourceObject<T>),
     Modified(ResourceObject<T>),
     Deleted(ResourceObject<T>),
+    DeletedByName(ResourceTombstone),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceTombstone {
+    pub name: String,
+    pub namespace: String,
+    pub resource_version: String,
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub annotations: std::collections::BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/flotilla-resources/tests/common/contract.rs
+++ b/crates/flotilla-resources/tests/common/contract.rs
@@ -3,9 +3,10 @@ use std::{collections::BTreeSet, time::Duration};
 use chrono::Utc;
 use flotilla_protocol::ResourceRef;
 use flotilla_resources::{
-    Convoy, Demand, DemandAddressee, DemandKind, DemandPoolRef, DemandSpec, InMemoryBackend, InputMeta, IssueSource, OwnerReference,
-    PrincipalRef, Project, ProjectRepositorySpec, ProjectSpec, Regard, RegardExpiryPolicy, RegardSource, RegardSpec, RepositoryKey,
-    Resource, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance, TypedResolver, WatchEvent, WatchStart, WorkflowTemplate,
+    delete_resource_kind, Convoy, Demand, DemandAddressee, DemandKind, DemandPoolRef, DemandSpec, InMemoryBackend, InputMeta, IssueSource,
+    OwnerReference, PrincipalRef, Project, ProjectRepositorySpec, ProjectSpec, Regard, RegardExpiryPolicy, RegardSource, RegardSpec,
+    RepositoryKey, Resource, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance, TypedResolver, WatchEvent, WatchStart,
+    WorkflowTemplate,
 };
 use futures::StreamExt;
 use tokio::time::timeout;
@@ -305,6 +306,34 @@ pub async fn assert_replica_events_ignore_stale_writes_and_deletes_with_backend(
         backend.including_replicas::<Convoy>("flotilla").list().await.expect("list recreated replica").items.len(),
         1,
         "a write newer than the delete tombstone should recreate the replica"
+    );
+}
+
+pub async fn assert_missing_authority_delete_tombstones_replica_with_backend(backend: ResourceBackend) {
+    let origin = flotilla_protocol::NodeId::new("authority-root");
+    let source = ResourceBackend::InMemory(InMemoryBackend::default());
+    source
+        .using::<Convoy>("flotilla")
+        .create(&convoy_meta("lost-at-authority"), &convoy_spec("template"))
+        .await
+        .expect("create stale source object");
+    let stale = source.using::<Convoy>("flotilla").list().await.expect("list stale source object");
+    backend.replica_writer::<Convoy>(origin.clone(), "flotilla").replace(&stale, Utc::now()).await.expect("seed stale replica");
+
+    let local = backend.using::<Convoy>("flotilla");
+    let listed = local.list().await.expect("list empty authority store");
+    let mut watch = local.watch(WatchStart::resuming_from(&listed)).await.expect("watch authority store");
+    delete_resource_kind(&backend, "flotilla", "convoys", "lost-at-authority").await.expect("delete missing authority object");
+    let event = timeout(Duration::from_secs(1), watch.next())
+        .await
+        .expect("authority tombstone timeout")
+        .expect("authority watch ended")
+        .expect("authority watch failed");
+    assert!(matches!(&event, WatchEvent::DeletedByName(tombstone) if tombstone.name == "lost-at-authority"));
+    backend.replica_writer::<Convoy>(origin, "flotilla").apply(event, Utc::now()).await.expect("apply authority tombstone to replica");
+    assert!(
+        backend.including_replicas::<Convoy>("flotilla").list().await.expect("list converged replica view").items.is_empty(),
+        "the name tombstone must remove the stale replica"
     );
 }
 

--- a/crates/flotilla-resources/tests/in_memory.rs
+++ b/crates/flotilla-resources/tests/in_memory.rs
@@ -6,8 +6,8 @@ use common::{
     contract::{
         assert_consumer_relists_after_expired_watch_and_converges_with_backend, assert_create_get_list_roundtrip,
         assert_delete_emits_event, assert_identical_status_update_is_noop_with_backend, assert_identical_update_is_noop_with_backend,
-        assert_metadata_roundtrip, assert_namespace_isolation, assert_project_definition_causal_merge_with_backend,
-        assert_project_definition_delete_conflicts_with_concurrent_edit_with_backend,
+        assert_metadata_roundtrip, assert_missing_authority_delete_tombstones_replica_with_backend, assert_namespace_isolation,
+        assert_project_definition_causal_merge_with_backend, assert_project_definition_delete_conflicts_with_concurrent_edit_with_backend,
         assert_project_definition_edit_converges_with_backend, assert_project_definition_edit_preserves_unrelated_conflict_with_backend,
         assert_project_definition_metadata_edit_converges_with_backend,
         assert_project_definition_optional_field_can_be_cleared_with_backend,
@@ -129,6 +129,11 @@ async fn replica_read_view_contract() {
 #[tokio::test]
 async fn replica_events_ignore_stale_writes_and_deletes() {
     assert_replica_events_ignore_stale_writes_and_deletes_with_backend(ResourceBackend::InMemory(InMemoryBackend::default())).await;
+}
+
+#[tokio::test]
+async fn missing_authority_delete_tombstones_replica() {
+    assert_missing_authority_delete_tombstones_replica_with_backend(ResourceBackend::InMemory(InMemoryBackend::default())).await;
 }
 
 #[tokio::test]

--- a/crates/flotilla-resources/tests/sqlite.rs
+++ b/crates/flotilla-resources/tests/sqlite.rs
@@ -12,7 +12,8 @@ use common::{
     contract::{
         assert_consumer_relists_after_expired_watch_and_converges_with_backend, assert_create_get_list_roundtrip_with_backend,
         assert_delete_emits_event_with_backend, assert_identical_status_update_is_noop_with_backend,
-        assert_identical_update_is_noop_with_backend, assert_metadata_roundtrip_with_backend, assert_namespace_isolation_with_backend,
+        assert_identical_update_is_noop_with_backend, assert_metadata_roundtrip_with_backend,
+        assert_missing_authority_delete_tombstones_replica_with_backend, assert_namespace_isolation_with_backend,
         assert_project_definition_causal_merge_with_backend, assert_project_definition_delete_conflicts_with_concurrent_edit_with_backend,
         assert_project_definition_edit_converges_with_backend, assert_project_definition_edit_preserves_unrelated_conflict_with_backend,
         assert_project_definition_metadata_edit_converges_with_backend,
@@ -220,6 +221,11 @@ async fn replica_read_view_contract() {
 #[tokio::test]
 async fn replica_events_ignore_stale_writes_and_deletes() {
     assert_replica_events_ignore_stale_writes_and_deletes_with_backend(backend()).await;
+}
+
+#[tokio::test]
+async fn missing_authority_delete_tombstones_replica() {
+    assert_missing_authority_delete_tombstones_replica_with_backend(backend()).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- add name-only deletion tombstones to authoritative resource watch streams
- persist and relay those tombstones through in-memory, SQLite, HTTP, and routed replica paths
- remove stale replicas when the authority no longer has the typed resource object
- preserve the connected-origin guard for direct replica collection

## Root cause

Replica collection refused whenever the origin was connected, assuming the origin could delete and cascade the authoritative record. After an authority store reset, the origin no longer had the object needed by the typed delete event, so its delete returned not found while replicas remained protected by the connectivity guard.

The authority can now advance its resource stream with a name-only tombstone when a replicated kind is already absent. Peers retain that tombstone in the existing replica tombstone store, preventing stale relay resurrection without transferring deletion judgment to replicas.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- focused InProcessDaemon connected-origin convergence regression
- in-memory and SQLite resource backend tombstone contracts

Closes #1445
