### PR TITLE
fix: converge lost record tombstones

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -8347,26 +8347,42 @@ impl InProcessDaemon {
 
         if let flotilla_protocol::CommandAction::ResourceDelete { namespace, kind, name, replica_origin } = &command.action {
             let empty_identity = self.start_context_free_command(id, command.description().to_string());
-            let deleted = if let Some(origin_root) = replica_origin {
-                if self.peer_connection_status(origin_root).await == PeerConnectionState::Connected {
+            let result = if let Some(origin_root) = replica_origin {
+                let deleted = if self.peer_connection_status(origin_root).await == PeerConnectionState::Connected {
                     Err(ResourceError::invalid(format!(
                         "replica origin {origin_root} is connected; delete the authoritative resource instead"
                     )))
                 } else {
                     flotilla_resources::collect_resource_replica_kind(&self.resource_backend, namespace, kind, name, origin_root).await
+                };
+                match deleted {
+                    Ok(deleted) => flotilla_protocol::CommandValue::ResourceDeleted(Box::new(ResourceJsonResponse {
+                        kind: deleted.kind,
+                        plural: deleted.plural,
+                        namespace: deleted.namespace,
+                        value: deleted.value,
+                        replica_origin: replica_origin.clone(),
+                    })),
+                    Err(error) => flotilla_protocol::CommandValue::Error { message: error.to_string() },
                 }
             } else {
-                flotilla_resources::delete_resource_kind(&self.resource_backend, namespace, kind, name).await
-            };
-            let result = match deleted {
-                Ok(deleted) => flotilla_protocol::CommandValue::ResourceDeleted(Box::new(ResourceJsonResponse {
-                    kind: deleted.kind,
-                    plural: deleted.plural,
-                    namespace: deleted.namespace,
-                    value: deleted.value,
-                    replica_origin: replica_origin.clone(),
-                })),
-                Err(error) => flotilla_protocol::CommandValue::Error { message: error.to_string() },
+                match flotilla_resources::delete_resource_kind(&self.resource_backend, namespace, kind, name).await {
+                    Ok(deleted) => {
+                        let response = Box::new(ResourceJsonResponse {
+                            kind: deleted.object.kind,
+                            plural: deleted.object.plural,
+                            namespace: deleted.object.namespace,
+                            value: deleted.object.value,
+                            replica_origin: None,
+                        });
+                        if deleted.already_deleted {
+                            flotilla_protocol::CommandValue::ResourceAlreadyDeleted(response)
+                        } else {
+                            flotilla_protocol::CommandValue::ResourceDeleted(response)
+                        }
+                    }
+                    Err(error) => flotilla_protocol::CommandValue::Error { message: error.to_string() },
+                }
             };
             self.finish_context_free_command(id, empty_identity, result);
             return Ok(id);

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -51,8 +51,8 @@ use flotilla_resources::{
     CheckoutSpec as ResourceCheckoutSpec, Convoy as ResourceConvoy, ConvoyPhase, DockerCheckoutStrategy,
     DockerPerVesselPlacementPolicySpec, Host as ResourceHost, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec,
     HostStatus, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project, ProjectRepositorySpec,
-    ProjectSpec, Regard, RegardExpiryPolicy, RegardSource, Repository, RepositoryRelation, RepositorySpec, ResourceError, Stance,
-    TypedResolver, WatchEvent, WatchStart, WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate, AGENT_ADAPTERS_CAPABILITY,
+    ProjectSpec, Regard, RegardExpiryPolicy, RegardSource, Repository, RepositoryRelation, RepositorySpec, ResourceBackend, ResourceError,
+    Stance, TypedResolver, WatchEvent, WatchStart, WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate, AGENT_ADAPTERS_CAPABILITY,
     REPO_KEY_LABEL, REPO_LABEL,
 };
 use futures::StreamExt;
@@ -854,7 +854,7 @@ async fn orphaned_authority_record_can_be_collected_from_the_replica_store() {
 }
 
 #[tokio::test]
-async fn deleting_a_missing_authoritative_resource_tombstones_connected_peer_replicas() {
+async fn deleting_a_missing_authoritative_resource_converges_across_peer_relay_cycles() {
     let authority_temp = tempfile::tempdir().expect("create authority tempdir");
     let authority = InProcessDaemon::new(
         vec![],
@@ -863,69 +863,49 @@ async fn deleting_a_missing_authoritative_resource_tombstones_connected_peer_rep
         HostName::new("authority"),
     )
     .await;
-    let peer_temp = tempfile::tempdir().expect("create peer tempdir");
-    let peer =
-        InProcessDaemon::new(vec![], test_config_store(peer_temp.path().join("config")), fake_discovery(false), HostName::new("peer"))
-            .await;
+    let peer_one_temp = tempfile::tempdir().expect("create first peer tempdir");
+    let peer_one = InProcessDaemon::new(
+        vec![],
+        test_config_store(peer_one_temp.path().join("config")),
+        fake_discovery(false),
+        HostName::new("peer-one"),
+    )
+    .await;
+    let peer_two_temp = tempfile::tempdir().expect("create second peer tempdir");
+    let peer_two = InProcessDaemon::new(
+        vec![],
+        test_config_store(peer_two_temp.path().join("config")),
+        fake_discovery(false),
+        HostName::new("peer-two"),
+    )
+    .await;
     let origin = authority.node_id().clone();
-    let authority_node = NodeInfo::new(origin.clone(), "authority");
-    peer.set_configured_peers(vec![authority_node.clone()]).await;
-
-    let peer_local = peer.resource_backend().using::<ResourceConvoy>("flotilla");
-    peer_local
+    let fixture_backend = ResourceBackend::InMemory(Default::default());
+    let fixture = fixture_backend.using::<ResourceConvoy>("flotilla");
+    fixture
         .create(
             &InputMeta::builder().name("lost-at-authority".to_string()).build(),
             &flotilla_resources::ConvoySpec::builder().workflow_ref("wf".to_string()).build(),
         )
         .await
         .expect("create stale source object");
-    let stale_snapshot = peer_local.list().await.expect("snapshot stale source object");
-    peer_local.delete("lost-at-authority").await.expect("remove local source object");
-    peer.resource_backend()
-        .replica_writer::<ResourceConvoy>(origin.clone(), "flotilla")
-        .replace(&stale_snapshot, chrono::Utc::now())
-        .await
-        .expect("seed stale peer replica");
+    let stale_snapshot = fixture.list().await.expect("snapshot stale source object");
+    let stale_object = stale_snapshot.items[0].clone();
+    let stale_synced_at = chrono::Utc::now() - chrono::Duration::minutes(1);
+    for daemon in [&authority, &peer_one, &peer_two] {
+        daemon
+            .resource_backend()
+            .replica_writer::<ResourceConvoy>(origin.clone(), "flotilla")
+            .replace(&stale_snapshot, stale_synced_at)
+            .await
+            .expect("seed stale replica");
+    }
 
     let authority_convoys = authority.resource_backend().using::<ResourceConvoy>("flotilla");
-    authority_convoys
-        .create(
-            &InputMeta::builder().name("held-at-authority".to_string()).build(),
-            &flotilla_resources::ConvoySpec::builder().workflow_ref("wf".to_string()).build(),
-        )
-        .await
-        .expect("create held authority object");
-    let authority_snapshot = authority_convoys.list().await.expect("snapshot held authority object");
-    peer.resource_backend()
-        .replica_writer::<ResourceConvoy>(origin.clone(), "flotilla")
-        .apply(WatchEvent::Added(authority_snapshot.items[0].clone()), chrono::Utc::now())
-        .await
-        .expect("seed held peer replica");
-
-    let mut peer_events = peer.subscribe();
-    InProcessDaemon::publish_peer_connection_status(peer.as_ref(), &authority_node, PeerConnectionState::Connected).await;
-    let refused_id = peer
-        .execute(Command {
-            node_id: None,
-            provisioning_target: None,
-            context_repo: None,
-            action: CommandAction::ResourceDelete {
-                namespace: "flotilla".to_string(),
-                kind: "convoys".to_string(),
-                name: "held-at-authority".to_string(),
-                replica_origin: Some(origin.clone()),
-            },
-        })
-        .await
-        .expect("request collection of held resource");
-    let refused = recv_command_finished(&mut peer_events, refused_id).await;
-    assert!(
-        matches!(refused, CommandValue::Error { ref message } if message.contains("is connected")),
-        "a connected authority that holds the record must retain deletion authority: {refused:?}"
-    );
-
     let listed = authority_convoys.list().await.expect("list before authority tombstone");
     let mut authority_watch = authority_convoys.watch(WatchStart::resuming_from(&listed)).await.expect("watch authority tombstones");
+    let mut peer_one_relay =
+        peer_one.resource_backend().including_replicas::<ResourceConvoy>("flotilla").watch().await.expect("watch first peer replicas");
     let mut authority_events = authority.subscribe();
     let delete_id = authority
         .execute(Command {
@@ -953,16 +933,69 @@ async fn deleting_a_missing_authoritative_resource_tombstones_connected_peer_rep
         matches!(&tombstone_event, WatchEvent::DeletedByName(tombstone) if tombstone.name == "lost-at-authority"),
         "missing authority delete must emit a name tombstone: {tombstone_event:?}"
     );
-    peer.resource_backend()
-        .replica_writer::<ResourceConvoy>(origin, "flotilla")
-        .apply(tombstone_event, chrono::Utc::now())
-        .await
-        .expect("relay authority tombstone to peer");
+    let tombstone_synced_at = chrono::Utc::now();
+    for peer in [&peer_one, &peer_two] {
+        peer.resource_backend()
+            .replica_writer::<ResourceConvoy>(origin.clone(), "flotilla")
+            .apply(tombstone_event.clone(), tombstone_synced_at)
+            .await
+            .expect("relay authority tombstone to peer");
+    }
 
-    let remaining =
-        peer.resource_backend().including_replicas::<ResourceConvoy>("flotilla").list().await.expect("list converged peer replicas");
-    assert_eq!(remaining.items.len(), 1);
-    assert_eq!(remaining.items[0].object.metadata.name, "held-at-authority");
+    let relayed = tokio::time::timeout(Duration::from_secs(1), peer_one_relay.next())
+        .await
+        .expect("peer relay tombstone timeout")
+        .expect("peer relay watch ended")
+        .expect("peer relay watch failed");
+    let flotilla_resources::ReadWatchEvent::DeletedByName { tombstone, provenance } = relayed else {
+        panic!("expected relayed name tombstone");
+    };
+    let flotilla_resources::ResourceProvenance::Replica { last_synced_at, .. } = provenance else {
+        panic!("expected replica provenance");
+    };
+    peer_two
+        .resource_backend()
+        .replica_writer::<ResourceConvoy>(origin.clone(), "flotilla")
+        .apply(WatchEvent::DeletedByName(tombstone), last_synced_at)
+        .await
+        .expect("apply peer relay tombstone");
+
+    for daemon in [&authority, &peer_one, &peer_two] {
+        daemon
+            .resource_backend()
+            .replica_writer::<ResourceConvoy>(origin.clone(), "flotilla")
+            .apply(WatchEvent::Added(stale_object.clone()), stale_synced_at)
+            .await
+            .expect("exercise a stale relay cycle after deletion");
+        assert!(
+            daemon
+                .resource_backend()
+                .including_replicas::<ResourceConvoy>("flotilla")
+                .list()
+                .await
+                .expect("list converged replicas")
+                .items
+                .is_empty(),
+            "authority and both peers must remain absent after stale relay cycles"
+        );
+    }
+
+    let repeated_id = authority
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ResourceDelete {
+                namespace: "flotilla".to_string(),
+                kind: "convoys".to_string(),
+                name: "lost-at-authority".to_string(),
+                replica_origin: None,
+            },
+        })
+        .await
+        .expect("repeat delete missing authority resource");
+    let repeated = recv_command_finished(&mut authority_events, repeated_id).await;
+    assert!(matches!(repeated, CommandValue::ResourceAlreadyDeleted(_)), "repeat delete must be explicit: {repeated:?}");
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -5595,7 +5595,7 @@ mod tests {
         let deleted = flotilla_resources::delete_resource_kind(&backend, NAMESPACE, "workflowtemplates", "single-agent-contained")
             .await
             .expect("raw delete should remove builtin");
-        assert_eq!(deleted.value["metadata"]["name"], "single-agent-contained");
+        assert_eq!(deleted.object.value["metadata"]["name"], "single-agent-contained");
         assert!(matches!(
             backend.using::<WorkflowTemplate>(NAMESPACE).get("single-agent-contained").await,
             Err(ResourceError::NotFound { .. })

--- a/crates/flotilla-daemon/tests/overlay_replication.rs
+++ b/crates/flotilla-daemon/tests/overlay_replication.rs
@@ -258,6 +258,93 @@ async fn connected_daemons_replicate_home_bound_runtime_kinds_and_deletes() {
 }
 
 #[tokio::test]
+async fn lost_authority_record_tombstone_converges_through_two_peers() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let kiwi = daemon(temp.path().join("kiwi"), "kiwi-root", "kiwi").await;
+    let feta = daemon(temp.path().join("feta"), "feta-root", "feta").await;
+    let gouda = daemon(temp.path().join("gouda"), "gouda-root", "gouda").await;
+    let origin = kiwi.node_id().clone();
+
+    let fixture_backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let fixture = fixture_backend.using::<TerminalSession>("flotilla");
+    fixture
+        .create(
+            &InputMeta::builder().name("lost-at-authority".to_string()).build(),
+            &TerminalSessionSpec::builder()
+                .env_ref("env".to_string())
+                .role("coder".to_string())
+                .source(TerminalSessionSource::Tool { command: "true".to_string() })
+                .cwd("/tmp".to_string())
+                .pool("passthrough".to_string())
+                .build(),
+        )
+        .await
+        .expect("create stale session fixture");
+    let stale = fixture.list().await.expect("list stale session fixture");
+    let stale_synced_at = chrono::Utc::now() - chrono::Duration::minutes(1);
+    for daemon in [&kiwi, &feta, &gouda] {
+        daemon
+            .resource_backend()
+            .replica_writer::<TerminalSession>(origin.clone(), "flotilla")
+            .replace(&stale, stale_synced_at)
+            .await
+            .expect("seed stale origin replica");
+    }
+
+    let deleted = flotilla_resources::delete_resource_kind(&kiwi.resource_backend(), "flotilla", "terminalsessions", "lost-at-authority")
+        .await
+        .expect("tombstone lost authority record");
+    assert!(!deleted.already_deleted);
+    assert_eq!(deleted.object.value["metadata"]["resourceVersion"], "2", "the tombstone must advance beyond the recovered replica cursor");
+
+    let kiwi_feta = spawn_in_memory_request_topology(Arc::clone(&kiwi), Arc::clone(&feta)).await.expect("connect authority to first peer");
+    let feta_gouda = spawn_in_memory_request_topology(Arc::clone(&feta), Arc::clone(&gouda)).await.expect("connect relay to second peer");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let mut converged = true;
+            for daemon in [&kiwi, &feta, &gouda] {
+                converged &= daemon
+                    .resource_backend()
+                    .including_replicas::<TerminalSession>("flotilla")
+                    .list()
+                    .await
+                    .expect("list converging session replicas")
+                    .items
+                    .is_empty();
+            }
+            if converged {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("authority tombstone did not converge through both peers");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    for daemon in [&kiwi, &feta, &gouda] {
+        assert!(
+            daemon
+                .resource_backend()
+                .including_replicas::<TerminalSession>("flotilla")
+                .list()
+                .await
+                .expect("list settled session replicas")
+                .items
+                .is_empty(),
+            "the stale replica must not resurrect after relay cycles"
+        );
+    }
+
+    let repeated = flotilla_resources::delete_resource_kind(&kiwi.resource_backend(), "flotilla", "terminalsessions", "lost-at-authority")
+        .await
+        .expect("repeat lost authority delete");
+    assert!(repeated.already_deleted);
+    drop(feta_gouda);
+    drop(kiwi_feta);
+}
+
+#[tokio::test]
 async fn connected_in_process_daemons_replicate_checkout_settlement_evidence() {
     let temp = tempfile::tempdir().expect("tempdir");
     let kiwi = daemon(temp.path().join("kiwi"), "kiwi-root", "kiwi").await;

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -908,6 +908,7 @@ pub enum CommandValue {
     ResourceRead(Box<ResourceReadEnvelope>),
     ResourceObject(Box<ResourceJsonResponse>),
     ResourceDeleted(Box<ResourceJsonResponse>),
+    ResourceAlreadyDeleted(Box<ResourceJsonResponse>),
     ResourceWatchEvent(Box<ResourceReadEnvelope>),
     EnvironmentSpecRead {
         spec: crate::EnvironmentSpec,

--- a/crates/flotilla-resources/src/backend.rs
+++ b/crates/flotilla-resources/src/backend.rs
@@ -347,9 +347,12 @@ impl<T: Resource> TypedResolver<T> {
         dispatch_backend!(self, delete_typed, name)
     }
 
-    pub(crate) async fn tombstone(&self, name: &str) -> Result<crate::ResourceTombstone, ResourceError> {
+    pub(crate) async fn tombstone(&self, name: &str) -> Result<crate::watch::TombstoneWrite, ResourceError> {
         ensure_replication_enabled::<T>()?;
-        dispatch_backend!(self, tombstone_typed, name)
+        let origin_root = self.backend.local_root()?;
+        let replica_cursor = self.backend.replica_writer::<T>(origin_root, &self.namespace).cursor().await?;
+        let minimum_resource_version = replica_cursor.as_ref().map(|cursor| cursor.resource_version.as_str());
+        dispatch_backend!(self, tombstone_typed, name, minimum_resource_version)
     }
 
     pub async fn watch(&self, start: WatchStart) -> Result<WatchStream<T>, ResourceError> {

--- a/crates/flotilla-resources/src/http/mod.rs
+++ b/crates/flotilla-resources/src/http/mod.rs
@@ -239,7 +239,12 @@ impl HttpBackend {
         Self::expect_success(response, Some(name)).await
     }
 
-    pub(crate) async fn tombstone_typed<T: Resource>(&self, _namespace: &str, _name: &str) -> Result<ResourceTombstone, ResourceError> {
+    pub(crate) async fn tombstone_typed<T: Resource>(
+        &self,
+        _namespace: &str,
+        _name: &str,
+        _minimum_resource_version: Option<&str>,
+    ) -> Result<crate::watch::TombstoneWrite, ResourceError> {
         Err(ResourceError::invalid(format!("HTTP backends cannot author {} tombstones", T::API_PATHS.kind)))
     }
 

--- a/crates/flotilla-resources/src/in_memory.rs
+++ b/crates/flotilla-resources/src/in_memory.rs
@@ -51,6 +51,7 @@ struct ReplicaPartition {
 #[derive(Debug)]
 struct ResourceStore {
     objects: HashMap<String, Value>,
+    tombstones: HashMap<String, ResourceTombstone>,
     next_version: u64,
     watchers: Vec<mpsc::UnboundedSender<StoredEvent>>,
     event_log: Vec<StoredEvent>,
@@ -97,7 +98,14 @@ impl ResourceStore {
 
 impl Default for ResourceStore {
     fn default() -> Self {
-        Self { objects: HashMap::new(), next_version: 1, watchers: Vec::new(), event_log: Vec::new(), compacted_through: 0 }
+        Self {
+            objects: HashMap::new(),
+            tombstones: HashMap::new(),
+            next_version: 1,
+            watchers: Vec::new(),
+            event_log: Vec::new(),
+            compacted_through: 0,
+        }
     }
 }
 
@@ -574,6 +582,7 @@ impl InMemoryBackend {
             };
 
             let encoded = Self::encode_object(&object)?;
+            store.tombstones.remove(&meta.name);
             store.objects.insert(meta.name.clone(), encoded.clone());
             store.push_event(
                 StoredEvent { version, kind: StoredEventKind::Added, object: encoded },
@@ -723,10 +732,28 @@ impl InMemoryBackend {
         .await
     }
 
-    pub(crate) async fn tombstone_typed<T: Resource>(&self, namespace: &str, name: &str) -> Result<ResourceTombstone, ResourceError> {
+    pub(crate) async fn tombstone_typed<T: Resource>(
+        &self,
+        namespace: &str,
+        name: &str,
+        minimum_resource_version: Option<&str>,
+    ) -> Result<crate::watch::TombstoneWrite, ResourceError> {
+        let minimum_resource_version = minimum_resource_version
+            .map(|version| {
+                version.parse::<u64>().map_err(|error| {
+                    ResourceError::invalid(format!("invalid replica cursor resourceVersion '{version}' while tombstoning: {error}"))
+                })
+            })
+            .transpose()?;
         self.with_store_mut::<T, _>(namespace, |store| {
             if store.objects.contains_key(name) {
                 return Err(ResourceError::conflict(name, "cannot tombstone an existing resource by name"));
+            }
+            if let Some(tombstone) = store.tombstones.get(name) {
+                return Ok(crate::watch::TombstoneWrite { tombstone: tombstone.clone(), created: false });
+            }
+            if let Some(minimum_resource_version) = minimum_resource_version {
+                store.next_version = store.next_version.max(minimum_resource_version.saturating_add(1));
             }
             let version = store.allocate_version();
             let tombstone = ResourceTombstone {
@@ -739,7 +766,8 @@ impl InMemoryBackend {
                 StoredEvent { version, kind: StoredEventKind::Deleted, object: Self::encode_tombstone::<T>(&tombstone) },
                 T::REPLICATION_CLASS.event_retention(self.event_retention.max_events_per_resource_stream()),
             );
-            Ok(tombstone)
+            store.tombstones.insert(name.to_string(), tombstone.clone());
+            Ok(crate::watch::TombstoneWrite { tombstone, created: true })
         })
         .await
     }
@@ -782,6 +810,13 @@ impl InMemoryBackend {
                     requested_version: replay_from.expect("checked replay version").to_string(),
                     compacted_through: Some(store.compacted_through.to_string()),
                 });
+            }
+            if replay_from.is_some_and(|version| version > store.current_version()) {
+                return Err(ResourceError::invalid(format!(
+                    "resourceVersion {} is ahead of current version {}",
+                    replay_from.expect("checked replay version"),
+                    store.current_version()
+                )));
             }
             let replay = match replay_from {
                 Some(version) => store.event_log.iter().filter(|event| event.version > version).cloned().collect(),

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -121,7 +121,8 @@ pub use registry::{
     list_resource_kind, list_resource_kind_including_replicas, list_resource_kind_replica_sources, patch_resource_status,
     quarantine_undecodable_stored_objects, replica_cursor_for_resource_kind, resource_document_spec_hash, resource_list_api_version,
     watch_resource_kind, watch_resource_kind_from, watch_resource_kind_including_replicas, watch_resource_kind_replica_sources,
-    DynamicResourceList, DynamicResourceObject, DynamicResourceWatch, RegisteredResourceKind, REGISTERED_RESOURCE_KINDS,
+    DynamicResourceDelete, DynamicResourceList, DynamicResourceObject, DynamicResourceWatch, RegisteredResourceKind,
+    REGISTERED_RESOURCE_KINDS,
 };
 pub use replica::{ReadResourceList, ReadResourceObject, ReadWatchEvent, ReplicaCursor, ReplicationClass, ResourceProvenance};
 pub use repository::{

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -68,6 +68,12 @@ pub struct DynamicResourceObject {
     pub value: Value,
 }
 
+#[derive(Debug, Clone)]
+pub struct DynamicResourceDelete {
+    pub object: DynamicResourceObject,
+    pub already_deleted: bool,
+}
+
 #[derive(bon::Builder)]
 pub struct DynamicResourceWatch {
     pub kind: String,
@@ -321,7 +327,7 @@ pub async fn delete_resource_kind(
     namespace: &str,
     requested_kind: &str,
     name: &str,
-) -> Result<DynamicResourceObject, ResourceError> {
+) -> Result<DynamicResourceDelete, ResourceError> {
     dispatch_resource_kind!(lookup_resource_kind(requested_kind)?.resource, delete_typed(backend, namespace, name).await)
 }
 
@@ -569,24 +575,33 @@ async fn get_typed<T: Resource>(backend: &ResourceBackend, namespace: &str, name
     })
 }
 
-async fn delete_typed<T: Resource>(backend: &ResourceBackend, namespace: &str, name: &str) -> Result<DynamicResourceObject, ResourceError> {
+async fn delete_typed<T: Resource>(backend: &ResourceBackend, namespace: &str, name: &str) -> Result<DynamicResourceDelete, ResourceError> {
     let resolver = backend.using::<T>(namespace);
-    let value = match resolver.get(name).await {
+    let (value, already_deleted) = match resolver.get(name).await {
         Ok(object) => {
             resolver.delete(name).await?;
-            object_value(&object)?
+            (object_value(&object)?, false)
         }
         Err(ResourceError::NotFound { .. }) if T::REPLICATION_CLASS != crate::ReplicationClass::None => {
-            let tombstone = resolver.tombstone(name).await?;
-            tombstone_value::<T>(&tombstone)
+            let write = resolver.tombstone(name).await?;
+            if write.created {
+                backend
+                    .replica_writer::<T>(backend.local_root()?, namespace)
+                    .apply(WatchEvent::DeletedByName(write.tombstone.clone()), Utc::now())
+                    .await?;
+            }
+            (tombstone_value::<T>(&write.tombstone), !write.created)
         }
         Err(error) => return Err(error),
     };
-    Ok(DynamicResourceObject {
-        kind: T::API_PATHS.kind.to_string(),
-        plural: T::API_PATHS.plural.to_string(),
-        namespace: namespace.to_string(),
-        value,
+    Ok(DynamicResourceDelete {
+        object: DynamicResourceObject {
+            kind: T::API_PATHS.kind.to_string(),
+            plural: T::API_PATHS.plural.to_string(),
+            namespace: namespace.to_string(),
+            value,
+        },
+        already_deleted,
     })
 }
 
@@ -1020,7 +1035,7 @@ mod tests {
         let mut watch = convoys.watch(WatchStart::resuming_from(&listed)).await.expect("watch source");
 
         let deleted = delete_resource_kind(&source, "flotilla", "convoys", "ghost").await.expect("delete exact convoy");
-        assert_eq!(deleted.value["metadata"]["name"], "ghost");
+        assert_eq!(deleted.object.value["metadata"]["name"], "ghost");
         let event = tokio::time::timeout(std::time::Duration::from_secs(1), watch.next())
             .await
             .expect("delete watch event timeout")

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -287,6 +287,16 @@ impl SqliteBackend {
                     last_synced_at TEXT NOT NULL,
                     PRIMARY KEY (origin_root, group_name, version, kind, namespace, name)
                 );
+
+                CREATE TABLE IF NOT EXISTS resource_tombstones (
+                    group_name TEXT NOT NULL,
+                    version TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    namespace TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    body_json TEXT NOT NULL,
+                    PRIMARY KEY (group_name, version, kind, namespace, name)
+                );
                 "#,
             )
             .map_err(|err| ResourceError::other(format!("initialize sqlite resource store: {err}")))?;
@@ -564,7 +574,15 @@ impl SqliteBackend {
     }
 
     fn allocate_version(tx: &rusqlite::Transaction<'_>, key: &StoreKey) -> Result<u64, ResourceError> {
-        let next = tx
+        Self::allocate_version_after(tx, key, None)
+    }
+
+    fn allocate_version_after(
+        tx: &rusqlite::Transaction<'_>,
+        key: &StoreKey,
+        minimum_resource_version: Option<u64>,
+    ) -> Result<u64, ResourceError> {
+        let stored_next = tx
             .query_row(
                 "SELECT next_version FROM resource_sequences WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4",
                 params![key.0, key.1, key.2, key.3],
@@ -573,6 +591,7 @@ impl SqliteBackend {
             .optional()
             .map_err(|err| Self::map_sqlite(err, "read sqlite resource sequence"))?
             .unwrap_or(1);
+        let next = minimum_resource_version.map_or(stored_next, |minimum| stored_next.max(minimum.saturating_add(1)));
         tx.execute(
             r#"
             INSERT INTO resource_sequences (group_name, version, kind, namespace, next_version)
@@ -1302,6 +1321,14 @@ impl SqliteBackend {
             let body_json = serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode object JSON: {err}")))?;
             tx.execute(
                 r#"
+                DELETE FROM resource_tombstones
+                WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4 AND name = ?5
+                "#,
+                params![key.0, key.1, key.2, key.3, meta.name],
+            )
+            .map_err(|err| Self::map_sqlite(err, "clear sqlite resource tombstone"))?;
+            tx.execute(
+                r#"
                 INSERT INTO resource_objects (group_name, version, kind, namespace, name, resource_version, body_json)
                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
                 "#,
@@ -1489,18 +1516,47 @@ impl SqliteBackend {
         .await
     }
 
-    pub(crate) async fn tombstone_typed<T: Resource>(&self, namespace: &str, name: &str) -> Result<ResourceTombstone, ResourceError> {
+    pub(crate) async fn tombstone_typed<T: Resource>(
+        &self,
+        namespace: &str,
+        name: &str,
+        minimum_resource_version: Option<&str>,
+    ) -> Result<crate::watch::TombstoneWrite, ResourceError> {
         let key = Self::store_key::<T>(namespace);
         let namespace = namespace.to_string();
         let name = name.to_string();
         let watchers = Arc::clone(&self.watchers);
         let event_retention = self.event_retention;
+        let minimum_resource_version = minimum_resource_version
+            .map(|version| {
+                version.parse::<u64>().map_err(|error| {
+                    ResourceError::invalid(format!("invalid replica cursor resourceVersion '{version}' while tombstoning: {error}"))
+                })
+            })
+            .transpose()?;
         self.call(move |connection| {
             let tx = connection.transaction().map_err(|err| Self::map_sqlite(err, "begin sqlite resource tombstone"))?;
             if Self::select_existing::<T>(&tx, &key, &name)?.is_some() {
                 return Err(ResourceError::conflict(&name, "cannot tombstone an existing resource by name"));
             }
-            let version = Self::allocate_version(&tx, &key)?;
+            let existing = tx
+                .query_row(
+                    r#"
+                    SELECT body_json FROM resource_tombstones
+                    WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4 AND name = ?5
+                    "#,
+                    params![key.0, key.1, key.2, key.3, name],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()
+                .map_err(|err| Self::map_sqlite(err, "read sqlite resource tombstone"))?;
+            if let Some(body) = existing {
+                let value = serde_json::from_str(&body)
+                    .map_err(|err| ResourceError::decode(format!("decode stored resource tombstone JSON: {err}")))?;
+                let tombstone = Self::decode_tombstone(value)?;
+                return Ok(crate::watch::TombstoneWrite { tombstone, created: false });
+            }
+            let version = Self::allocate_version_after(&tx, &key, minimum_resource_version)?;
             let tombstone = ResourceTombstone {
                 name: name.clone(),
                 namespace: namespace.clone(),
@@ -1510,10 +1566,18 @@ impl SqliteBackend {
             let encoded = Self::encode_tombstone::<T>(&tombstone);
             let body_json =
                 serde_json::to_string(&encoded).map_err(|err| ResourceError::decode(format!("encode tombstone JSON: {err}")))?;
+            tx.execute(
+                r#"
+                INSERT INTO resource_tombstones (group_name, version, kind, namespace, name, body_json)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                "#,
+                params![key.0, key.1, key.2, key.3, name, body_json],
+            )
+            .map_err(|err| Self::map_sqlite(err, "write sqlite resource tombstone"))?;
             Self::insert_event(&tx, &key, version, StoredEventKind::Deleted, &body_json, event_retention, T::REPLICATION_CLASS)?;
             tx.commit().map_err(|err| Self::map_sqlite(err, "commit sqlite resource tombstone"))?;
             Self::notify_watchers(&watchers, &key, StoredEvent { kind: StoredEventKind::Deleted, object: encoded });
-            Ok(tombstone)
+            Ok(crate::watch::TombstoneWrite { tombstone, created: true })
         })
         .await
     }
@@ -1638,6 +1702,10 @@ impl SqliteBackend {
                 requested_version: replay_from.to_string(),
                 compacted_through: Some(compacted_through.to_string()),
             });
+        }
+        let current_version = Self::current_version(conn, key)?;
+        if replay_from > current_version {
+            return Err(ResourceError::invalid(format!("resourceVersion {replay_from} is ahead of current version {current_version}")));
         }
         let mut statement = conn
             .prepare(

--- a/crates/flotilla-resources/src/watch.rs
+++ b/crates/flotilla-resources/src/watch.rs
@@ -87,6 +87,12 @@ pub struct ResourceTombstone {
     pub annotations: std::collections::BTreeMap<String, String>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct TombstoneWrite {
+    pub tombstone: ResourceTombstone,
+    pub created: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound(
     serialize = "T::Spec: Serialize, T::Status: Serialize",

--- a/crates/flotilla-resources/tests/common/contract.rs
+++ b/crates/flotilla-resources/tests/common/contract.rs
@@ -311,6 +311,7 @@ pub async fn assert_replica_events_ignore_stale_writes_and_deletes_with_backend(
 
 pub async fn assert_missing_authority_delete_tombstones_replica_with_backend(backend: ResourceBackend) {
     let origin = flotilla_protocol::NodeId::new("authority-root");
+    let backend = backend.with_local_root(origin.clone());
     let source = ResourceBackend::InMemory(InMemoryBackend::default());
     source
         .using::<Convoy>("flotilla")
@@ -323,18 +324,33 @@ pub async fn assert_missing_authority_delete_tombstones_replica_with_backend(bac
     let local = backend.using::<Convoy>("flotilla");
     let listed = local.list().await.expect("list empty authority store");
     let mut watch = local.watch(WatchStart::resuming_from(&listed)).await.expect("watch authority store");
-    delete_resource_kind(&backend, "flotilla", "convoys", "lost-at-authority").await.expect("delete missing authority object");
+    let deleted =
+        delete_resource_kind(&backend, "flotilla", "convoys", "lost-at-authority").await.expect("delete missing authority object");
+    assert!(!deleted.already_deleted);
     let event = timeout(Duration::from_secs(1), watch.next())
         .await
         .expect("authority tombstone timeout")
         .expect("authority watch ended")
         .expect("authority watch failed");
     assert!(matches!(&event, WatchEvent::DeletedByName(tombstone) if tombstone.name == "lost-at-authority"));
-    backend.replica_writer::<Convoy>(origin, "flotilla").apply(event, Utc::now()).await.expect("apply authority tombstone to replica");
     assert!(
         backend.including_replicas::<Convoy>("flotilla").list().await.expect("list converged replica view").items.is_empty(),
         "the name tombstone must remove the stale replica"
     );
+
+    let repeated =
+        delete_resource_kind(&backend, "flotilla", "convoys", "lost-at-authority").await.expect("repeat missing authority delete");
+    assert!(repeated.already_deleted, "a retained name tombstone must make repeat deletion idempotent");
+    assert!(timeout(Duration::from_millis(100), watch.next()).await.is_err(), "repeat deletion must not emit a fresh tombstone event");
+}
+
+pub async fn assert_watch_rejects_version_ahead_of_stream_with_backend(backend: ResourceBackend) {
+    let resolver = backend.using::<Convoy>("flotilla");
+    let error = resolver
+        .watch(WatchStart::FromVersion("1".to_string()))
+        .await
+        .expect_err("a cursor ahead of an empty authority stream must be rejected");
+    assert!(error.to_string().contains("ahead of current version"), "unexpected error: {error}");
 }
 
 fn project_spec(display_name: &str, workflow: &str) -> ProjectSpec {

--- a/crates/flotilla-resources/tests/in_memory.rs
+++ b/crates/flotilla-resources/tests/in_memory.rs
@@ -137,6 +137,12 @@ async fn missing_authority_delete_tombstones_replica() {
 }
 
 #[tokio::test]
+async fn watch_rejects_version_ahead_of_stream() {
+    common::contract::assert_watch_rejects_version_ahead_of_stream_with_backend(ResourceBackend::InMemory(InMemoryBackend::default()))
+        .await;
+}
+
+#[tokio::test]
 async fn project_definition_edit_converges() {
     assert_project_definition_edit_converges_with_backend(ResourceBackend::InMemory(InMemoryBackend::default())).await;
 }

--- a/crates/flotilla-resources/tests/sqlite.rs
+++ b/crates/flotilla-resources/tests/sqlite.rs
@@ -229,6 +229,11 @@ async fn missing_authority_delete_tombstones_replica() {
 }
 
 #[tokio::test]
+async fn watch_rejects_version_ahead_of_stream() {
+    common::contract::assert_watch_rejects_version_ahead_of_stream_with_backend(backend()).await;
+}
+
+#[tokio::test]
 async fn project_definition_edit_converges() {
     assert_project_definition_edit_converges_with_backend(backend()).await;
 }
@@ -348,6 +353,31 @@ async fn replica_delete_tombstone_survives_backend_restart() {
         reopened.including_replicas::<Convoy>("flotilla").list().await.expect("list replicas after restart").items.is_empty(),
         "the persisted delete tombstone must prevent stale resurrection after restart"
     );
+}
+
+#[tokio::test]
+async fn authoritative_name_tombstone_survives_backend_restart() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let path = directory.path().join("resources.sqlite");
+    let origin = flotilla_protocol::NodeId::new("feta-root");
+
+    {
+        let backend = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("open sqlite backend")).with_local_root(origin.clone());
+        let deleted = flotilla_resources::delete_resource_kind(&backend, "flotilla", "convoys", "lost-at-authority")
+            .await
+            .expect("write authoritative name tombstone");
+        assert!(!deleted.already_deleted);
+    }
+
+    let reopened = ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("reopen sqlite backend")).with_local_root(origin);
+    let listed = reopened.using::<Convoy>("flotilla").list().await.expect("list reopened authority stream");
+    let mut watch =
+        reopened.using::<Convoy>("flotilla").watch(WatchStart::resuming_from(&listed)).await.expect("watch reopened authority stream");
+    let repeated = flotilla_resources::delete_resource_kind(&reopened, "flotilla", "convoys", "lost-at-authority")
+        .await
+        .expect("repeat authoritative delete after restart");
+    assert!(repeated.already_deleted);
+    assert!(timeout(Duration::from_millis(100), watch.next()).await.is_err(), "repeat delete must not emit a fresh tombstone");
 }
 
 #[tokio::test]

--- a/crates/flotilla-tui/src/app/executor.rs
+++ b/crates/flotilla-tui/src/app/executor.rs
@@ -274,6 +274,7 @@ pub fn handle_result(result: CommandValue, app: &mut App) {
         | CommandValue::ResourceRead(_)
         | CommandValue::ResourceObject(_)
         | CommandValue::ResourceDeleted(_)
+        | CommandValue::ResourceAlreadyDeleted(_)
         | CommandValue::ResourceWatchEvent(_) => {
             tracing::warn!("query result reached TUI handler — should be handled by CLI");
         }

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -740,6 +740,11 @@ fn format_command_result(result: &flotilla_protocol::commands::CommandValue) -> 
                 )
             }
         }
+        CommandValue::ResourceAlreadyDeleted(response) => {
+            let name = response.value["metadata"]["name"].as_str().unwrap_or("<unknown>");
+            let api_version = response.value["apiVersion"].as_str().unwrap_or("<unknown>");
+            format!("already deleted {api_version}/{}/{}/{name}", response.kind, response.namespace)
+        }
         CommandValue::ResourceWatchEvent(response) => flotilla_protocol::output::json_pretty(response),
         CommandValue::EnvironmentSpecRead { .. } => "environment spec read".to_string(),
         CommandValue::IssuePage(page) => format!("issue page: {} items, has_more={}", page.items.len(), page.has_more),

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -721,6 +721,25 @@ mod command_result_human {
     }
 
     #[test]
+    fn resource_already_deleted_is_explicit() {
+        let response = ResourceJsonResponse {
+            kind: "Convoy".to_string(),
+            plural: "convoys".to_string(),
+            namespace: "flotilla".to_string(),
+            value: serde_json::json!({
+                "apiVersion": "flotilla.work/v1",
+                "metadata": {"name": "lost-at-authority"}
+            }),
+            replica_origin: None,
+        };
+
+        assert_eq!(
+            format_command_result(&CommandValue::ResourceAlreadyDeleted(Box::new(response))),
+            "already deleted flotilla.work/v1/Convoy/flotilla/lost-at-authority"
+        );
+    }
+
+    #[test]
     fn fleet_list() {
         let result = CommandValue::FleetList(Box::new(FleetListResponse {
             rows: vec![FleetListRow::builder()


### PR DESCRIPTION
## Summary

- retain authority-side name tombstones so repeated deletes are idempotent and report `already deleted`
- advance recovered tombstones beyond the authority's self-origin replica cursor, preventing a reset store from reusing a stale replica resource version
- apply authority tombstones to the local replica partition and reject ahead-of-stream watch cursors so stale overlays relist or consume the newer delete
- cover durable SQLite restart behavior plus a real three-host authority → peer → peer relay topology with no resurrection

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo test -p flotilla-core --locked --features test-support --test in_process_daemon`

Closes #1448
