### PR TITLE
fix: force raw deletion past abandoned finalizers

### DIFF
--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -580,16 +580,30 @@ async fn delete_typed<T: Resource>(backend: &ResourceBackend, namespace: &str, n
     let (value, already_deleted) = match resolver.get(name).await {
         Ok(object) => {
             resolver.delete(name).await?;
+            if T::REPLICATION_CLASS == crate::ReplicationClass::Definitions {
+                return Ok(DynamicResourceDelete {
+                    object: DynamicResourceObject {
+                        kind: T::API_PATHS.kind.to_string(),
+                        plural: T::API_PATHS.plural.to_string(),
+                        namespace: namespace.to_string(),
+                        value: object_value(&object)?,
+                    },
+                    already_deleted: false,
+                });
+            }
+            force_pending_finalization(&resolver, name).await?;
+            match resolver.get(name).await {
+                Err(ResourceError::NotFound { .. }) => {}
+                Ok(_) => return Err(ResourceError::other(format!("delete reported success but {name} remains in the resource store"))),
+                Err(error) => return Err(error),
+            }
+            if T::REPLICATION_CLASS != crate::ReplicationClass::None {
+                retain_authoritative_name_tombstone::<T>(backend, namespace, name).await?;
+            }
             (object_value(&object)?, false)
         }
         Err(ResourceError::NotFound { .. }) if T::REPLICATION_CLASS != crate::ReplicationClass::None => {
-            let write = resolver.tombstone(name).await?;
-            if write.created {
-                backend
-                    .replica_writer::<T>(backend.local_root()?, namespace)
-                    .apply(WatchEvent::DeletedByName(write.tombstone.clone()), Utc::now())
-                    .await?;
-            }
+            let write = retain_authoritative_name_tombstone::<T>(backend, namespace, name).await?;
             (tombstone_value::<T>(&write.tombstone), !write.created)
         }
         Err(error) => return Err(error),
@@ -603,6 +617,48 @@ async fn delete_typed<T: Resource>(backend: &ResourceBackend, namespace: &str, n
         },
         already_deleted,
     })
+}
+
+/// Raw resource deletion is the recovery path documented in the governor
+/// charter, so it must not leave an object stuck behind an abandoned
+/// finalizer. Ordinary controller deletion still goes through
+/// `TypedResolver::delete` and retains normal finalizer semantics.
+async fn force_pending_finalization<T: Resource>(resolver: &crate::TypedResolver<T>, name: &str) -> Result<(), ResourceError> {
+    for _ in 0..3 {
+        let object = match resolver.get(name).await {
+            Err(ResourceError::NotFound { .. }) => return Ok(()),
+            Ok(object) => object,
+            Err(error) => return Err(error),
+        };
+        if !object.metadata.is_pending_finalization() {
+            return Err(ResourceError::other(format!("delete left {name} present without pending finalizers")));
+        }
+
+        let mut meta = InputMeta::from(&object.metadata);
+        meta.finalizers.clear();
+        match resolver.update(&meta, &object.metadata.resource_version, &object.spec).await {
+            Ok(_) => {}
+            Err(ResourceError::Conflict { .. }) => continue,
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(ResourceError::conflict(name, "finalizer removal retry budget exhausted"))
+}
+
+async fn retain_authoritative_name_tombstone<T: Resource>(
+    backend: &ResourceBackend,
+    namespace: &str,
+    name: &str,
+) -> Result<crate::watch::TombstoneWrite, ResourceError> {
+    let write = backend.using::<T>(namespace).tombstone(name).await?;
+    if write.created {
+        backend
+            .replica_writer::<T>(backend.local_root()?, namespace)
+            .apply(WatchEvent::DeletedByName(write.tombstone.clone()), Utc::now())
+            .await?;
+    }
+    Ok(write)
 }
 
 async fn collect_replica_typed<T: Resource>(

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -637,7 +637,7 @@ async fn force_pending_finalization<T: Resource>(resolver: &crate::TypedResolver
         let mut meta = InputMeta::from(&object.metadata);
         meta.finalizers.clear();
         match resolver.update(&meta, &object.metadata.resource_version, &object.spec).await {
-            Ok(_) => {}
+            Ok(_) => return Ok(()),
             Err(ResourceError::Conflict { .. }) => continue,
             Err(error) => return Err(error),
         }

--- a/crates/flotilla-resources/tests/fixtures/terminal_session_pending_finalization.json
+++ b/crates/flotilla-resources/tests/fixtures/terminal_session_pending_finalization.json
@@ -1,0 +1,70 @@
+{
+  "apiVersion": "flotilla.work/v1",
+  "kind": "TerminalSession",
+  "metadata": {
+    "annotations": {
+      "flotilla.work/actuator-host-ref": "d783f8a7-6b6f-44a9-bd04-5e6e2d43f878",
+      "flotilla.work/actuator-source-root": "0fe74f4d513e0b1cce3bc748f0ae6cf4"
+    },
+    "creationTimestamp": "2026-08-02T16:28:30.787142516Z",
+    "deletionTimestamp": "2026-08-02T16:38:59.098638511Z",
+    "finalizers": ["flotilla.work/terminal-teardown"],
+    "labels": {
+      "flotilla.work/authority": "managed",
+      "flotilla.work/convoy": "checkout-cascade",
+      "flotilla.work/crew_ordinal": "000",
+      "flotilla.work/role": "coder",
+      "flotilla.work/vessel": "work",
+      "flotilla.work/vessel_ordinal": "000",
+      "flotilla.work/vessel_ref": "checkout-cascade-work"
+    },
+    "name": "terminal-checkout-cascade-work-coder",
+    "namespace": "flotilla",
+    "ownerReferences": [
+      {
+        "apiVersion": "flotilla.work/v1",
+        "controller": true,
+        "kind": "Vessel",
+        "name": "checkout-cascade-work"
+      }
+    ],
+    "resourceVersion": "9234"
+  },
+  "spec": {
+    "cwd": "/workspace",
+    "env_ref": "env-checkout-cascade-work",
+    "pool": "cleat",
+    "role": "coder",
+    "source": {
+      "brief": {
+        "content": "",
+        "copies": ["/workspace"],
+        "path": ".flotilla/briefs/coder.md"
+      },
+      "context": {
+        "convoy": "checkout-cascade",
+        "namespace": "flotilla",
+        "vessel_ref": "checkout-cascade-work"
+      },
+      "kind": "agent",
+      "selector": {"capability": "code"}
+    }
+  },
+  "status": {
+    "attention": {
+      "as_of": "2026-08-02T16:38:47.198692512Z",
+      "source": "screen",
+      "state": "working"
+    },
+    "crew": {
+      "adapter": "codex",
+      "id": "e19bfd03-dc13-4c85-8657-fdb1ae911282",
+      "stance": "trusted-implicit"
+    },
+    "inner_command_status": "Running",
+    "launch_command": "codex --dangerously-bypass-approvals-and-sandbox 'Read your crew brief at .flotilla/briefs/coder.md and follow it.'",
+    "phase": "Running",
+    "session_id": "terminal-checkout-cascade-work-coder",
+    "started_at": "2026-08-02T16:28:31.119287805Z"
+  }
+}

--- a/crates/flotilla-resources/tests/sqlite.rs
+++ b/crates/flotilla-resources/tests/sqlite.rs
@@ -381,6 +381,81 @@ async fn authoritative_name_tombstone_survives_backend_restart() {
 }
 
 #[tokio::test]
+async fn raw_delete_removes_real_pending_terminal_row_and_prevents_relay_resurrection() {
+    // Extracted read-only from feta's resource_objects table on 2026-08-12.
+    // The fixture preserves the stored row shape and values; only the opaque
+    // brief body was elided because it has no resource-store semantics.
+    const NAME: &str = "terminal-checkout-cascade-work-coder";
+    const BODY: &str = include_str!("fixtures/terminal_session_pending_finalization.json");
+
+    let directory = tempfile::tempdir().expect("tempdir");
+    let path = directory.path().join("resources.sqlite");
+    let authority_root = flotilla_protocol::NodeId::new("9ad3ffb1931f9996979535186f45027f");
+    drop(SqliteBackend::open(&path).expect("initialize sqlite backend"));
+    {
+        let connection = rusqlite::Connection::open(&path).expect("open raw sqlite fixture connection");
+        connection
+            .execute(
+                "INSERT INTO resource_objects (group_name, version, kind, namespace, name, resource_version, body_json)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                rusqlite::params!["flotilla.work", "v1", "TerminalSession", "flotilla", NAME, 9234_u64, BODY],
+            )
+            .expect("insert row extracted from feta resource store");
+        connection
+            .execute(
+                "INSERT INTO resource_sequences (group_name, version, kind, namespace, next_version)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                rusqlite::params!["flotilla.work", "v1", "TerminalSession", "flotilla", 9235_u64],
+            )
+            .expect("insert extracted stream sequence");
+    }
+
+    let authority =
+        ResourceBackend::Sqlite(SqliteBackend::open(&path).expect("open fixture backend")).with_local_root(authority_root.clone());
+    let terminals = authority.using::<TerminalSession>("flotilla");
+    let extracted = terminals.get(NAME).await.expect("real pending row should be servable before recovery");
+    assert_eq!(extracted.metadata.resource_version, "9234");
+    assert!(extracted.metadata.is_pending_finalization());
+    let stale_snapshot = terminals.list().await.expect("capture stale relay snapshot");
+    let mut watch = terminals.watch(WatchStart::resuming_from(&stale_snapshot)).await.expect("watch authoritative deletion");
+
+    let deleted = flotilla_resources::delete_resource_kind(&authority, "flotilla", "terminalsessions", NAME)
+        .await
+        .expect("raw delete should force abandoned finalization");
+    assert!(!deleted.already_deleted);
+    assert!(matches!(terminals.get(NAME).await, Err(ResourceError::NotFound { .. })));
+
+    let mut delete_events = Vec::new();
+    while let Ok(Some(Ok(event))) = timeout(Duration::from_millis(100), watch.next()).await {
+        delete_events.push(event);
+    }
+    assert!(delete_events.iter().any(|event| matches!(event, WatchEvent::Deleted(object) if object.metadata.name == NAME)));
+    let tombstone = delete_events
+        .iter()
+        .find(|event| matches!(event, WatchEvent::DeletedByName(tombstone) if tombstone.name == NAME))
+        .cloned()
+        .expect("raw delete should retain an authoritative name tombstone");
+
+    let peers = [ResourceBackend::InMemory(InMemoryBackend::default()), ResourceBackend::InMemory(InMemoryBackend::default())];
+    let stale_synced_at = Utc::now() - chrono::Duration::minutes(1);
+    for peer in &peers {
+        let writer = peer.replica_writer::<TerminalSession>(authority_root.clone(), "flotilla");
+        writer.replace(&stale_snapshot, stale_synced_at).await.expect("seed stale peer row");
+        writer.apply(tombstone.clone(), Utc::now()).await.expect("relay authoritative tombstone");
+        writer
+            .apply(WatchEvent::Added(stale_snapshot.items[0].clone()), stale_synced_at)
+            .await
+            .expect("exercise stale relay after deletion");
+        assert!(peer.including_replicas::<TerminalSession>("flotilla").list().await.expect("list peer overlay").items.is_empty());
+    }
+
+    let repeated = flotilla_resources::delete_resource_kind(&authority, "flotilla", "terminalsessions", NAME)
+        .await
+        .expect("repeat delete should use retained tombstone");
+    assert!(repeated.already_deleted);
+}
+
+#[tokio::test]
 async fn replicated_project_definition_survives_backend_restart_without_peer() {
     let directory = tempfile::tempdir().expect("tempdir");
     let path = directory.path().join("resources.sqlite");


### PR DESCRIPTION
## What changed

- make the raw `resource delete` recovery path clear abandoned runtime finalizers and verify the object is physically absent before reporting success
- retain and relay an authoritative name tombstone after deleting replicated resources, making repeat deletes report `already deleted` and preventing stale resurrection
- add a SQLite regression fixture extracted read-only from feta and exercise local delete plus two-peer relay

## Root cause

Read-only inspection of feta corrected the initial version-less hypothesis: the physical row had resource version `9234` in both the scalar column and JSON metadata. The ten zombie terminal rows were already marked for deletion but retained `flotilla.work/terminal-teardown`. Ordinary store deletion correctly no-ops while finalization is pending, while the raw administrative command incorrectly rendered that no-op as `deleted` on every call.

The raw command is documented as the sharp recovery path that bypasses lifecycle and teardown gates. It now forces only that administrative path past abandoned finalizers; controller-facing deletion keeps normal finalizer semantics.

## Impact

A raw deletion either removes the object and reports `deleted` once, reports `already deleted` from its retained tombstone on repeats, or returns an error if the object remains. Replicas converge on the tombstone and reject older relayed writes.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #1450