### PR TITLE
fix: unify free-space measurement path

### DIFF
--- a/crates/flotilla-core/src/admission.rs
+++ b/crates/flotilla-core/src/admission.rs
@@ -43,10 +43,6 @@ pub(crate) fn check_free_space_floor(probe: &dyn AvailableSpaceProbe, host: &str
     check_measured_free_space(host, free_bytes, floor_bytes)
 }
 
-pub fn measure_available_space(path: &Path) -> Option<u64> {
-    SystemAvailableSpaceProbe.measure(path)
-}
-
 pub(crate) fn check_measured_free_space(host: &str, free_bytes: u64, floor_bytes: u64) -> Result<(), String> {
     if free_bytes >= floor_bytes {
         return Ok(());

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1933,6 +1933,13 @@ pub struct InProcessDaemon {
     resource_replication_failures: RwLock<HashMap<NodeId, BTreeMap<String, String>>>,
     repository_inspector: RwLock<Option<Arc<dyn RepositoryInspector>>>,
     local_placement_provider_statuses: RwLock<Vec<HostProviderStatus>>,
+    /// Filesystem path whose capacity governs convoy admission on this host.
+    ///
+    /// The daemon runtime sets this to the host-direct checkout root. Keeping
+    /// the path here makes the local gate and the capacity published to peers
+    /// use the same measurement basis even when daemon state is on another
+    /// mount.
+    admission_free_space_path: std::sync::RwLock<PathBuf>,
     leaf_subscriptions: LeafSubscriptionTable,
 }
 
@@ -2114,6 +2121,7 @@ impl InProcessDaemon {
             tracing::warn!(%error, "garbage collect orphaned change request observations at startup failed");
         }
         let leaf_subscriptions = LeafSubscriptionTable::new(resource_backend.clone(), event_tx.clone(), change_request_refresher);
+        let admission_free_space_path = config.state_dir().as_path().to_path_buf();
         let daemon = Arc::new_cyclic(|self_weak| Self {
             repos: RwLock::new(repos),
             repo_order: RwLock::new(order),
@@ -2152,6 +2160,7 @@ impl InProcessDaemon {
             resource_replication_failures: RwLock::new(HashMap::new()),
             repository_inspector: RwLock::new(None),
             local_placement_provider_statuses: RwLock::new(Vec::new()),
+            admission_free_space_path: std::sync::RwLock::new(admission_free_space_path),
             leaf_subscriptions: leaf_subscriptions.clone(),
         });
         leaf_subscriptions.set_turn_delivery_actuator(Arc::new(DaemonTurnDeliveryActuator { daemon: Arc::downgrade(&daemon) })).await;
@@ -2229,6 +2238,18 @@ impl InProcessDaemon {
         statuses.sort_by(|left, right| (&left.category, &left.implementation).cmp(&(&right.category, &right.implementation)));
         *self.local_placement_provider_statuses.write().await = statuses;
         let _ = self.refresh_local_host_summary().await;
+    }
+
+    /// Use `path` as the canonical capacity source for both local and
+    /// federated convoy admission.
+    pub fn set_admission_free_space_path(&self, path: PathBuf) {
+        *self.admission_free_space_path.write().expect("admission free-space path lock poisoned") = path;
+    }
+
+    pub async fn admission_free_space_bytes(&self) -> Result<Option<u64>, String> {
+        let path = self.admission_free_space_path.read().expect("admission free-space path lock poisoned").clone();
+        let probe = Arc::clone(&self.discovery.available_space_probe);
+        tokio::task::spawn_blocking(move || probe.measure(&path)).await.map_err(|error| format!("measure available disk space: {error}"))
     }
 
     pub fn local_environment_id(&self) -> &EnvironmentId {
@@ -4894,13 +4915,14 @@ impl InProcessDaemon {
     async fn check_local_free_space_floor(&self) -> Result<(), String> {
         let config = Arc::clone(&self.config);
         let available_space_probe = Arc::clone(&self.discovery.available_space_probe);
+        let admission_free_space_path = self.admission_free_space_path.read().expect("admission free-space path lock poisoned").clone();
         let host_name = self.host_name.to_string();
         tokio::task::spawn_blocking(move || {
             let daemon_config = config.load_daemon_config()?;
             crate::admission::check_free_space_floor(
                 &*available_space_probe,
                 &host_name,
-                config.state_dir().as_path(),
+                &admission_free_space_path,
                 daemon_config.admission.free_space_floor_gib,
             )
         })

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -5437,6 +5437,46 @@ async fn create_empty_workflow(backend: &ResourceBackend, name: &str) {
 }
 
 #[tokio::test]
+async fn local_and_published_admission_capacity_use_checkout_root_when_state_is_on_another_mount() {
+    struct MountAwareAvailableSpaceProbe {
+        state_dir: PathBuf,
+        repo_default_dir: PathBuf,
+    }
+
+    impl crate::admission::AvailableSpaceProbe for MountAwareAvailableSpaceProbe {
+        fn measure(&self, path: &Path) -> Option<u64> {
+            const GIB: u64 = 1024 * 1024 * 1024;
+            if path == self.state_dir {
+                Some(100 * GIB)
+            } else if path == self.repo_default_dir {
+                Some(10 * GIB)
+            } else {
+                None
+            }
+        }
+    }
+
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_dir = temp.path().join("config");
+    let state_dir = temp.path().join("state-mount");
+    let repo_default_dir = temp.path().join("checkout-mount");
+    std::fs::create_dir_all(&config_dir).expect("create config dir");
+    std::fs::write(config_dir.join("daemon.toml"), "machine_id = \"test-machine\"\n\n[admission]\nfree_space_floor_gib = 20\n")
+        .expect("write daemon config");
+    let mut discovery = fake_discovery(false);
+    discovery.available_space_probe =
+        Arc::new(MountAwareAvailableSpaceProbe { state_dir: state_dir.clone(), repo_default_dir: repo_default_dir.clone() });
+    let config = Arc::new(ConfigStore::new(DaemonHostPath::new(config_dir), DaemonHostPath::new(state_dir)));
+    let daemon = InProcessDaemon::new(vec![], config, discovery, HostName::new("kiwi")).await;
+    daemon.set_admission_free_space_path(repo_default_dir);
+
+    let local_error = daemon.check_local_free_space_floor().await.expect_err("checkout mount below floor must be refused");
+
+    assert!(local_error.contains("10.0 GiB free is below the 20.0 GiB floor"), "{local_error}");
+    assert_eq!(daemon.admission_free_space_bytes().await.expect("published capacity measurement"), Some(10 * 1024 * 1024 * 1024));
+}
+
+#[tokio::test]
 async fn convoy_start_refuses_local_placement_below_configured_free_space_floor_without_creating_state() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");

--- a/crates/flotilla-core/src/lib.rs
+++ b/crates/flotilla-core/src/lib.rs
@@ -45,6 +45,5 @@ pub mod terminal_manager;
 pub const DAEMON_LIFECYCLE_LOCK_FILE: &str = "flotillad-lifecycle.lock";
 
 // Re-export shared infrastructure and host types for convenience.
-pub use admission::measure_available_space;
 pub use flotilla_protocol::HostName;
 pub use flotilla_resources::tls;

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -23,7 +23,6 @@ use flotilla_core::{
     },
     config::ConfigStore,
     in_process::InProcessDaemon,
-    measure_available_space,
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     placement_policy::reconcile_registered_policy,
     providers::{
@@ -405,6 +404,7 @@ impl DaemonRuntime {
 
         let local_registry = probe_local_provider_registry(&daemon, &config).await?;
         let profile = build_local_profile(&daemon, &local_registry)?;
+        daemon.set_admission_free_space_path(PathBuf::from(&profile.repo_default_dir));
         let credential_store = Arc::new(CredentialStore::new(
             daemon.resource_backend(),
             &options.namespace,
@@ -1217,6 +1217,7 @@ async fn apply_host_heartbeat_with_credentials(
     health: &DaemonHealthIdentity,
     runtime_health: &RuntimeHealth,
 ) -> Result<(), String> {
+    daemon.set_admission_free_space_path(PathBuf::from(&profile.repo_default_dir));
     ensure_host_exists(&daemon.resource_backend(), namespace, &profile.host_id, &profile.display_name).await?;
     let backend = daemon.resource_backend();
     let hosts = backend.using::<Host>(namespace);
@@ -1241,10 +1242,7 @@ async fn apply_host_heartbeat_with_credentials(
         Some(store) => store.held_credentials().await?,
         None => BTreeSet::new(),
     };
-    let repo_default_dir = PathBuf::from(&profile.repo_default_dir);
-    let disk_free_bytes = tokio::task::spawn_blocking(move || measure_available_space(&repo_default_dir))
-        .await
-        .map_err(|error| format!("measure available disk space: {error}"))?;
+    let disk_free_bytes = daemon.admission_free_space_bytes().await?;
     let admission_free_space_floor_bytes = daemon.admission_free_space_floor_bytes()?;
     let mut conditions = runtime_health.conditions().await;
     conditions.extend(file_descriptor_pressure_condition());

--- a/crates/flotilla-resources/src/host.rs
+++ b/crates/flotilla-resources/src/host.rs
@@ -44,6 +44,7 @@ pub struct HostStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub daemon_started_at: Option<DateTime<Utc>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Available bytes on the host-direct checkout root used for convoy admission.
     pub disk_free_bytes: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub admission_free_space_floor_bytes: Option<u64>,

--- a/crates/flotilla-resources/src/host.rs
+++ b/crates/flotilla-resources/src/host.rs
@@ -43,8 +43,8 @@ pub struct HostStatus {
     pub daemon_version: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub daemon_started_at: Option<DateTime<Utc>>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     /// Available bytes on the host-direct checkout root used for convoy admission.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub disk_free_bytes: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub admission_free_space_floor_bytes: Option<u64>,


### PR DESCRIPTION
## Summary

- make the host-direct checkout root the canonical free-space measurement path for convoy admission
- use the same injected capacity probe for the local admission gate and published `HostStatus.disk_free_bytes`
- document the field semantic and cover separate state/checkouts mounts with a regression test

## Why

The local gate measured `state_dir` while federated admission consumed capacity measured at `repo_default_dir`. Hosts with those directories on different mounts could make contradictory admission decisions. Checkout storage is the primary disk consumer, so both paths now use `repo_default_dir`.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #1441