### PR TITLE
Add replica-aware resource point lookup

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -39,23 +39,23 @@ use flotilla_resources::{
     api_version, apply_resource_document, apply_status_patch as apply_resource_status_patch,
     apply_status_patch_checked as apply_resource_status_patch_checked, bound_change_request_record_name,
     controller::delete_lifecycle_owned_matching, ensure_repository, evaluate_landing_settlement, expected_change_request_leaves,
-    expected_checkout_refs, external_patches as convoy_external_patches, list_resource_kind, list_resource_kind_including_replicas,
-    normalize_project_spec, repository_display_labels, resolve_project_issue_sources, terminal_session_attach_target, watch_resource_kind,
-    watch_resource_kind_from, watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, BoundChangeRequest,
-    Checkout as ResourceCheckout, CheckoutIntegrationStatus, CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec,
-    CheckoutStatus as ResourceCheckoutStatus, Clock, ConditionValue, Convoy as ResourceConvoy, ConvoyEnsure, ConvoyEnsureSpec,
-    ConvoyEnsureStatusPatch, ConvoyIssue, ConvoyPhase, ConvoyRepositorySpec, ConvoySpec, ConvoyStatusPatch, CredentialGrant,
-    CredentialSpec, CrewCompletionPending, CrewSource, Demand as ResourceDemand, Environment as ResourceEnvironment, HoldAct,
-    Host as ResourceHost, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus,
-    InMemoryBackend, InputMeta, InputValue, IntegrationCondition, IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable,
-    LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec,
-    Presentation as ResourcePresentation, Project, ProjectRepositoryRole, ProjectRepositorySpec, ProjectSpec, Repository, RepositoryKey,
-    RepositorySpec, Resource, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance, SettlementMode, SystemClock,
-    TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession, TerminalSessionIdentity,
-    TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch, TurnDeliveryRung,
-    UnmetSettlementExpectation, Vessel, WatchEvent, WatchStart, WorkCompletionAuthority, WorkPhase as ResourceWorkPhase, WorkflowTemplate,
-    WorkflowTemplateSpec, ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL, HEARTBEAT_READY_TTL_SECS, MANAGED_BY_LABEL, ROLE_LABEL,
-    VESSEL_LABEL, VESSEL_REF_LABEL,
+    expected_checkout_refs, external_patches as convoy_external_patches, get_resource_kind_including_replicas, list_resource_kind,
+    list_resource_kind_including_replicas, normalize_project_spec, repository_display_labels, resolve_project_issue_sources,
+    terminal_session_attach_target, watch_resource_kind, watch_resource_kind_from, watch_resource_kind_including_replicas,
+    watch_resource_kind_replica_sources, BoundChangeRequest, Checkout as ResourceCheckout, CheckoutIntegrationStatus,
+    CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus, Clock,
+    ConditionValue, Convoy as ResourceConvoy, ConvoyEnsure, ConvoyEnsureSpec, ConvoyEnsureStatusPatch, ConvoyIssue, ConvoyPhase,
+    ConvoyRepositorySpec, ConvoySpec, ConvoyStatusPatch, CredentialGrant, CredentialSpec, CrewCompletionPending, CrewSource,
+    Demand as ResourceDemand, Environment as ResourceEnvironment, HoldAct, Host as ResourceHost, HostDirectPlacementPolicyCheckout,
+    HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus, InMemoryBackend, InputMeta, InputValue, IntegrationCondition,
+    IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable, LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec,
+    PlacementPolicy, PlacementPolicySpec, Presentation as ResourcePresentation, Project, ProjectRepositoryRole, ProjectRepositorySpec,
+    ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance,
+    SettlementMode, SystemClock, TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession,
+    TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch,
+    TurnDeliveryRung, UnmetSettlementExpectation, Vessel, WatchEvent, WatchStart, WorkCompletionAuthority, WorkPhase as ResourceWorkPhase,
+    WorkflowTemplate, WorkflowTemplateSpec, ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL, HEARTBEAT_READY_TTL_SECS, MANAGED_BY_LABEL,
+    ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
 use futures::{FutureExt, StreamExt};
 use sha2::{Digest, Sha256};
@@ -9750,22 +9750,16 @@ impl DaemonHandle for InProcessDaemon {
                     Ok(listed) => listed,
                     Err(error) => return Ok(CommandValue::Error { message: error.to_string() }),
                 };
-                let visible = match list_resource_kind_including_replicas(&self.resource_backend, namespace, kind).await {
-                    Ok(listed) => listed,
+                let visible = match get_resource_kind_including_replicas(&self.resource_backend, namespace, kind, name).await {
+                    Ok(object) => object,
+                    Err(ResourceError::NotFound { .. }) => {
+                        return Ok(CommandValue::Error { message: format!("resource {kind}/{namespace}/{name} not found") });
+                    }
                     Err(error) => return Ok(CommandValue::Error { message: error.to_string() }),
-                };
-                let object = visible.value["items"]
-                    .as_array()
-                    .into_iter()
-                    .flatten()
-                    .find(|object| object["metadata"]["name"].as_str() == Some(name.as_str()))
-                    .cloned();
-                let Some(object) = object else {
-                    return Ok(CommandValue::Error { message: format!("resource {kind}/{namespace}/{name} not found") });
                 };
                 let resource_version = cursor_list.value["metadata"]["resourceVersion"].as_str().unwrap_or_default().to_string();
                 let generation = cursor_list.value["metadata"]["generation"].as_str().map(ToOwned::to_owned);
-                let record = resource_record(ResourceRecordType::Current, object, &self.node_id);
+                let record = resource_record(ResourceRecordType::Current, visible.value, &self.node_id);
                 Ok(CommandValue::ResourceRead(Box::new(resource_read_envelope(
                     visible.kind,
                     visible.plural,

--- a/crates/flotilla-daemon/src/server/resource_http.rs
+++ b/crates/flotilla-daemon/src/server/resource_http.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 
 use flotilla_resources::{
-    list_resource_kind, list_resource_kind_including_replicas, list_resource_kind_replica_sources, watch_resource_kind,
-    watch_resource_kind_from, watch_resource_kind_including_replicas, watch_resource_kind_replica_sources, DynamicResourceWatch,
-    ResourceBackend, ResourceError, WatchStart,
+    get_resource_kind, get_resource_kind_including_replicas, list_resource_kind, list_resource_kind_including_replicas,
+    list_resource_kind_replica_sources, watch_resource_kind, watch_resource_kind_from, watch_resource_kind_including_replicas,
+    watch_resource_kind_replica_sources, DynamicResourceWatch, ResourceBackend, ResourceError, WatchStart,
 };
 use futures::StreamExt;
 use tokio::{
@@ -38,13 +38,30 @@ pub(super) async fn serve_resource_http(mut stream: UnixStream, first_byte: u8, 
 
     let (path, raw_query) = target.split_once('?').map_or((target, ""), |parts| parts);
     let segments = path.trim_matches('/').split('/').collect::<Vec<_>>();
-    let ["apis", "flotilla.work", "v1", "namespaces", namespace, kind] = segments.as_slice() else {
-        return write_error(&mut stream, 404, "unknown resource API path").await;
+    let (namespace, kind, name) = match segments.as_slice() {
+        ["apis", "flotilla.work", "v1", "namespaces", namespace, kind] => (*namespace, *kind, None),
+        ["apis", "flotilla.work", "v1", "namespaces", namespace, kind, name] => (*namespace, *kind, Some(*name)),
+        _ => return write_error(&mut stream, 404, "unknown resource API path").await,
     };
     let query = parse_query(raw_query);
     let include_replicas = query_flag(&query, &["includeReplicas", "include-replicas", "include_replicas"]);
     let replica_sources = query_flag(&query, &["replicaSources", "replica-sources", "replica_sources"]);
     let watch = query.get("watch").is_some_and(|value| value == "true");
+
+    if let Some(name) = name {
+        if watch || replica_sources {
+            return write_error(&mut stream, 400, "resource point reads do not support watch or replicaSources").await;
+        }
+        let object = if include_replicas {
+            get_resource_kind_including_replicas(&backend, namespace, kind, name).await
+        } else {
+            get_resource_kind(&backend, namespace, kind, name).await
+        };
+        return match object {
+            Ok(object) => write_json(&mut stream, 200, &object.value).await,
+            Err(error) => write_resource_error(&mut stream, error).await,
+        };
+    }
 
     if !watch {
         let listed = if replica_sources {

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -157,7 +157,7 @@ async fn resource_http_lists_and_watches_over_a_unix_socket() {
     let listener = tokio::net::UnixListener::bind(&socket_path).expect("bind resource HTTP socket");
     let server_backend = source.clone();
     let server = tokio::spawn(async move {
-        for _ in 0..3 {
+        for _ in 0..4 {
             let (mut stream, _) = listener.accept().await.expect("accept resource HTTP request");
             let first_byte = tokio::io::AsyncReadExt::read_u8(&mut stream).await.expect("read HTTP preface");
             let backend = server_backend.clone();
@@ -177,6 +177,11 @@ async fn resource_http_lists_and_watches_over_a_unix_socket() {
                     if origin_root == &NodeId::new("remote-root")
             )
     }));
+    let replica = remote.including_replicas::<Convoy>("flotilla").get("replica-row").await.expect("get replica over Unix-socket HTTP");
+    assert!(matches!(
+        replica.provenance,
+        ResourceProvenance::Replica { ref origin_root, .. } if origin_root == &NodeId::new("remote-root")
+    ));
     let listed = remote.using::<Convoy>("flotilla").list().await.expect("list convoys over Unix-socket HTTP");
     assert_eq!(listed.items.len(), 1);
     let mut watch =

--- a/crates/flotilla-resources/src/backend.rs
+++ b/crates/flotilla-resources/src/backend.rs
@@ -117,6 +117,33 @@ impl<T: Resource> Clone for ReplicaReadResolver<T> {
 }
 
 impl<T: Resource> ReplicaReadResolver<T> {
+    pub async fn get(&self, name: &str) -> Result<ReadResourceObject<T>, ResourceError> {
+        ensure_replication_enabled::<T>()?;
+        if let ResourceBackend::Http(backend) = &self.backend {
+            return backend.get_including_replicas_typed::<T>(&self.namespace, name).await;
+        }
+        if T::REPLICATION_CLASS == crate::ReplicationClass::Definitions {
+            return self
+                .backend
+                .definitions::<T>(&self.namespace)
+                .get(name)
+                .await
+                .map(|object| ReadResourceObject { object, provenance: ResourceProvenance::Local });
+        }
+        match self.backend.using::<T>(&self.namespace).get(name).await {
+            Ok(object) => Ok(ReadResourceObject { object, provenance: ResourceProvenance::Local }),
+            Err(ResourceError::NotFound { .. }) => {
+                let replicas = match &self.backend {
+                    ResourceBackend::InMemory(backend) => backend.get_replicas_typed::<T>(&self.namespace, name).await?,
+                    ResourceBackend::Sqlite(backend) => backend.get_replicas_typed::<T>(&self.namespace, name).await?,
+                    ResourceBackend::Http(_) => unreachable!("HTTP handled above"),
+                };
+                replicas.into_iter().next().ok_or_else(|| ResourceError::not_found(name))
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     pub async fn list(&self) -> Result<ReadResourceList<T>, ResourceError> {
         ensure_replication_enabled::<T>()?;
         if let ResourceBackend::Http(backend) = &self.backend {

--- a/crates/flotilla-resources/src/definition.rs
+++ b/crates/flotilla-resources/src/definition.rs
@@ -48,13 +48,7 @@ impl<T: Resource> DefinitionResolver<T> {
             return Err(ResourceError::not_found(name));
         }
         let object = merge_sources(&sources)?;
-        let deleted = object
-            .metadata
-            .merge
-            .as_ref()
-            .and_then(|merge| merge.fields.get(DELETION_FIELD))
-            .is_some_and(|_| object.metadata.deletion_timestamp.is_some());
-        if deleted && !object.metadata.merge.as_ref().is_some_and(|merge| merge.conflicts.contains_key(DELETION_FIELD)) {
+        if !definition_is_visible(&object) {
             return Err(ResourceError::not_found(name));
         }
         Ok(object)
@@ -69,13 +63,7 @@ impl<T: Resource> DefinitionResolver<T> {
         let mut merged = Vec::with_capacity(by_name.len());
         for sources in by_name.into_values() {
             let object = merge_sources(&sources)?;
-            let deleted = object
-                .metadata
-                .merge
-                .as_ref()
-                .and_then(|merge| merge.fields.get(DELETION_FIELD))
-                .is_some_and(|_| object.metadata.deletion_timestamp.is_some());
-            if !deleted || object.metadata.merge.as_ref().is_some_and(|merge| merge.conflicts.contains_key(DELETION_FIELD)) {
+            if definition_is_visible(&object) {
                 merged.push(object);
             }
         }
@@ -262,6 +250,16 @@ impl<T: Resource> DefinitionResolver<T> {
         }));
         Ok(sources)
     }
+}
+
+fn definition_is_visible<T: Resource>(object: &ResourceObject<T>) -> bool {
+    let deleted = object
+        .metadata
+        .merge
+        .as_ref()
+        .and_then(|merge| merge.fields.get(DELETION_FIELD))
+        .is_some_and(|_| object.metadata.deletion_timestamp.is_some());
+    !deleted || object.metadata.merge.as_ref().is_some_and(|merge| merge.conflicts.contains_key(DELETION_FIELD))
 }
 
 fn ensure_definitions<T: Resource>() -> Result<(), ResourceError> {

--- a/crates/flotilla-resources/src/definition.rs
+++ b/crates/flotilla-resources/src/definition.rs
@@ -206,7 +206,24 @@ impl<T: Resource> DefinitionResolver<T> {
     }
 
     async fn sources_for_name(&self, name: &str) -> Result<Vec<DefinitionSource<T>>, ResourceError> {
-        Ok(self.sources().await?.into_iter().filter(|source| source.object.metadata.name == name).collect())
+        let local_root = self.backend.local_root()?;
+        let mut sources = match self.backend.using::<T>(&self.namespace).get(name).await {
+            Ok(object) => vec![DefinitionSource { object, origin: local_root, synced_at: None }],
+            Err(ResourceError::NotFound { .. }) => Vec::new(),
+            Err(error) => return Err(error),
+        };
+        let replicas = match &self.backend {
+            ResourceBackend::InMemory(backend) => backend.get_replicas_typed::<T>(&self.namespace, name).await?,
+            ResourceBackend::Sqlite(backend) => backend.get_replicas_typed::<T>(&self.namespace, name).await?,
+            ResourceBackend::Http(_) => return Err(ResourceError::invalid("HTTP definition views are served by the origin store")),
+        };
+        sources.extend(replicas.into_iter().filter_map(|replica| match replica.provenance {
+            ResourceProvenance::Replica { origin_root, last_synced_at } => {
+                Some(DefinitionSource { object: replica.object, origin: origin_root, synced_at: Some(last_synced_at) })
+            }
+            ResourceProvenance::Local => None,
+        }));
+        Ok(sources)
     }
 
     async fn sources(&self) -> Result<Vec<DefinitionSource<T>>, ResourceError> {

--- a/crates/flotilla-resources/src/definition.rs
+++ b/crates/flotilla-resources/src/definition.rs
@@ -42,7 +42,22 @@ impl<T: Resource> DefinitionResolver<T> {
     }
 
     pub async fn get(&self, name: &str) -> Result<ResourceObject<T>, ResourceError> {
-        self.list().await?.into_iter().find(|object| object.metadata.name == name).ok_or_else(|| ResourceError::not_found(name))
+        ensure_definitions::<T>()?;
+        let sources = self.sources_for_name(name).await?;
+        if sources.is_empty() {
+            return Err(ResourceError::not_found(name));
+        }
+        let object = merge_sources(&sources)?;
+        let deleted = object
+            .metadata
+            .merge
+            .as_ref()
+            .and_then(|merge| merge.fields.get(DELETION_FIELD))
+            .is_some_and(|_| object.metadata.deletion_timestamp.is_some());
+        if deleted && !object.metadata.merge.as_ref().is_some_and(|merge| merge.conflicts.contains_key(DELETION_FIELD)) {
+            return Err(ResourceError::not_found(name));
+        }
+        Ok(object)
     }
 
     pub async fn list(&self) -> Result<Vec<ResourceObject<T>>, ResourceError> {

--- a/crates/flotilla-resources/src/http/mod.rs
+++ b/crates/flotilla-resources/src/http/mod.rs
@@ -100,6 +100,23 @@ impl HttpBackend {
         self.list_read_view_typed::<T>(namespace, "includeReplicas").await
     }
 
+    pub(crate) async fn get_including_replicas_typed<T: Resource>(
+        &self,
+        namespace: &str,
+        name: &str,
+    ) -> Result<ReadResourceObject<T>, ResourceError> {
+        let url = self.namespaced_url(T::API_PATHS, namespace, Some(name), false);
+        let response = self
+            .http
+            .get(url)
+            .query(&[("includeReplicas", "true")])
+            .send()
+            .await
+            .map_err(|err| ResourceError::other(format!("GET resource including replicas: {err}")))?;
+        let object: K8sResourceObject<T> = Self::decode_response(response, Some(name)).await?;
+        read_resource_object(ResourceObject::from_k8s_object(object)?)
+    }
+
     pub async fn list_replica_sources_typed<T: Resource>(&self, namespace: &str) -> Result<ReadResourceList<T>, ResourceError> {
         self.list_read_view_typed::<T>(namespace, "replicaSources").await
     }

--- a/crates/flotilla-resources/src/in_memory.rs
+++ b/crates/flotilla-resources/src/in_memory.rs
@@ -256,6 +256,35 @@ impl InMemoryBackend {
         Ok(items)
     }
 
+    pub(crate) async fn get_replicas_typed<T: Resource>(
+        &self,
+        namespace: &str,
+        name: &str,
+    ) -> Result<Vec<ReadResourceObject<T>>, ResourceError> {
+        let key = Self::store_key::<T>(namespace);
+        let replicas = self.replicas.lock().await;
+        let mut items = Vec::new();
+        for ((origin_root, partition_key), partition) in &replicas.partitions {
+            if partition_key != &key {
+                continue;
+            }
+            let Some(value) = partition.objects.get(name) else {
+                continue;
+            };
+            let last_synced_at = partition
+                .synced_at_by_name
+                .get(name)
+                .copied()
+                .ok_or_else(|| ResourceError::other(format!("replica row '{name}' has no sync timestamp")))?;
+            items.push((origin_root.clone(), ReadResourceObject {
+                object: Self::decode_object(value.clone())?,
+                provenance: ResourceProvenance::Replica { origin_root: origin_root.clone(), last_synced_at },
+            }));
+        }
+        items.sort_by(|(left, _), (right, _)| left.cmp(right));
+        Ok(items.into_iter().map(|(_, item)| item).collect())
+    }
+
     pub(crate) async fn watch_replicas_typed<T: Resource>(
         &self,
         namespace: &str,

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -118,11 +118,11 @@ pub use project::{
 pub use provisioning_identity::{canonicalize_repo_url, clone_key, descriptive_repo_slug, repo_key};
 pub use registry::{
     apply_manifest_resource_document, apply_resource_document, collect_resource_replica_kind, delete_resource_kind, get_resource_kind,
-    list_resource_kind, list_resource_kind_including_replicas, list_resource_kind_replica_sources, patch_resource_status,
-    quarantine_undecodable_stored_objects, replica_cursor_for_resource_kind, resource_document_spec_hash, resource_list_api_version,
-    watch_resource_kind, watch_resource_kind_from, watch_resource_kind_including_replicas, watch_resource_kind_replica_sources,
-    DynamicResourceDelete, DynamicResourceList, DynamicResourceObject, DynamicResourceWatch, RegisteredResourceKind,
-    REGISTERED_RESOURCE_KINDS,
+    get_resource_kind_including_replicas, list_resource_kind, list_resource_kind_including_replicas, list_resource_kind_replica_sources,
+    patch_resource_status, quarantine_undecodable_stored_objects, replica_cursor_for_resource_kind, resource_document_spec_hash,
+    resource_list_api_version, watch_resource_kind, watch_resource_kind_from, watch_resource_kind_including_replicas,
+    watch_resource_kind_replica_sources, DynamicResourceDelete, DynamicResourceList, DynamicResourceObject, DynamicResourceWatch,
+    RegisteredResourceKind, REGISTERED_RESOURCE_KINDS,
 };
 pub use replica::{ReadResourceList, ReadResourceObject, ReadWatchEvent, ReplicaCursor, ReplicationClass, ResourceProvenance};
 pub use repository::{

--- a/crates/flotilla-resources/src/registry.rs
+++ b/crates/flotilla-resources/src/registry.rs
@@ -322,6 +322,15 @@ pub async fn get_resource_kind(
     dispatch_resource_kind!(lookup_resource_kind(requested_kind)?.resource, get_typed(backend, namespace, name).await)
 }
 
+pub async fn get_resource_kind_including_replicas(
+    backend: &ResourceBackend,
+    namespace: &str,
+    requested_kind: &str,
+    name: &str,
+) -> Result<DynamicResourceObject, ResourceError> {
+    dispatch_resource_kind!(lookup_resource_kind(requested_kind)?.resource, get_typed_including_replicas(backend, namespace, name).await)
+}
+
 pub async fn delete_resource_kind(
     backend: &ResourceBackend,
     namespace: &str,
@@ -572,6 +581,20 @@ async fn get_typed<T: Resource>(backend: &ResourceBackend, namespace: &str, name
         plural: T::API_PATHS.plural.to_string(),
         namespace: namespace.to_string(),
         value: object_value(&object)?,
+    })
+}
+
+async fn get_typed_including_replicas<T: Resource>(
+    backend: &ResourceBackend,
+    namespace: &str,
+    name: &str,
+) -> Result<DynamicResourceObject, ResourceError> {
+    let object = backend.including_replicas::<T>(namespace).get(name).await?;
+    Ok(DynamicResourceObject {
+        kind: T::API_PATHS.kind.to_string(),
+        plural: T::API_PATHS.plural.to_string(),
+        namespace: namespace.to_string(),
+        value: read_object_value(&object)?,
     })
 }
 

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -265,6 +265,9 @@ impl SqliteBackend {
                     PRIMARY KEY (origin_root, group_name, version, kind, namespace, name)
                 );
 
+                CREATE INDEX IF NOT EXISTS replica_objects_by_resource_name
+                    ON replica_objects (group_name, version, kind, namespace, name, origin_root);
+
                 CREATE TABLE IF NOT EXISTS replica_cursors (
                     origin_root TEXT NOT NULL,
                     group_name TEXT NOT NULL,

--- a/crates/flotilla-resources/src/sqlite.rs
+++ b/crates/flotilla-resources/src/sqlite.rs
@@ -787,6 +787,78 @@ impl SqliteBackend {
         .await
     }
 
+    pub(crate) async fn get_replicas_typed<T: Resource>(
+        &self,
+        namespace: &str,
+        name: &str,
+    ) -> Result<Vec<ReadResourceObject<T>>, ResourceError> {
+        let key = Self::store_key::<T>(namespace);
+        let requested_name = name.to_string();
+        self.call(move |connection| {
+            let rows = {
+                let mut statement = connection
+                    .prepare(
+                        r#"
+                        SELECT o.origin_root, o.last_synced_at, o.body_json
+                        FROM replica_objects o
+                        WHERE o.group_name = ?1 AND o.version = ?2 AND o.kind = ?3 AND o.namespace = ?4 AND o.name = ?5
+                        ORDER BY o.origin_root
+                        "#,
+                    )
+                    .map_err(|err| Self::map_sqlite(err, "prepare sqlite replica point lookup"))?;
+                let rows = statement
+                    .query_map(params![key.0, key.1, key.2, key.3, requested_name], |row| {
+                        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))
+                    })
+                    .map_err(|err| Self::map_sqlite(err, "query sqlite replica point lookup"))?;
+                rows.collect::<Result<Vec<_>, _>>().map_err(|err| Self::map_sqlite(err, "read sqlite replica point lookup row"))?
+            };
+
+            let mut items = Vec::new();
+            for (origin_root, last_synced_at, body) in rows {
+                let identity = format!("kind={} namespace={} name={} origin={}", T::API_PATHS.kind, key.3, requested_name, origin_root);
+                let decoded = serde_json::from_str(&body)
+                    .map_err(|err| format!("decode cached replica object {identity}: {err}"))
+                    .and_then(|value| Self::decode_object(value).map_err(|err| format!("decode cached replica object {identity}: {err}")))
+                    .and_then(|object| {
+                        DateTime::parse_from_rfc3339(&last_synced_at)
+                            .map(|last_synced_at| (object, last_synced_at.with_timezone(&Utc)))
+                            .map_err(|err| format!("decode cached replica sync timestamp {identity}: {err}"))
+                    });
+                match decoded {
+                    Ok((object, last_synced_at)) => items.push(ReadResourceObject {
+                        object,
+                        provenance: ResourceProvenance::Replica { origin_root: NodeId::new(origin_root), last_synced_at },
+                    }),
+                    Err(error) => {
+                        let tx = connection.transaction().map_err(|err| Self::map_sqlite(err, "begin invalid replica cache cleanup"))?;
+                        for table in ["replica_objects", "replica_tombstones", "replica_cursors"] {
+                            tx.execute(
+                                &format!(
+                                    "DELETE FROM {table}
+                                     WHERE origin_root = ?1 AND group_name = ?2 AND version = ?3 AND kind = ?4 AND namespace = ?5"
+                                ),
+                                params![origin_root, key.0, key.1, key.2, key.3],
+                            )
+                            .map_err(|err| Self::map_sqlite(err, "drop undecodable sqlite replica partition"))?;
+                        }
+                        tx.commit().map_err(|err| Self::map_sqlite(err, "commit invalid replica cache cleanup"))?;
+                        tracing::warn!(
+                            origin = %origin_root,
+                            kind = T::API_PATHS.kind,
+                            namespace = %key.3,
+                            name = %requested_name,
+                            %error,
+                            "dropping undecodable cached replica partition; origin will be fully resynced"
+                        );
+                    }
+                }
+            }
+            Ok(items)
+        })
+        .await
+    }
+
     pub(crate) async fn watch_replicas_typed<T: Resource>(
         &self,
         namespace: &str,

--- a/crates/flotilla-resources/tests/common/contract.rs
+++ b/crates/flotilla-resources/tests/common/contract.rs
@@ -191,6 +191,7 @@ pub async fn assert_replica_read_view_contract(backend: ResourceBackend) {
     let remote = remote_backend.using::<Convoy>("flotilla");
     remote.create(&convoy_meta("remote"), &convoy_spec("remote-template")).await.expect("create remote convoy");
     remote.create(&convoy_meta("untouched"), &convoy_spec("untouched-template")).await.expect("create untouched remote convoy");
+    remote.create(&convoy_meta("local"), &convoy_spec("shadowed-template")).await.expect("create shadowed remote convoy");
     let remote_list = remote.list().await.expect("list remote convoy");
     let synced_at = Utc::now();
 
@@ -200,7 +201,7 @@ pub async fn assert_replica_read_view_contract(backend: ResourceBackend) {
     assert_eq!(local_only.items.iter().map(|item| item.metadata.name.as_str()).collect::<Vec<_>>(), ["local"]);
 
     let all = backend.including_replicas::<Convoy>("flotilla").list().await.expect("list resources including replicas");
-    assert_eq!(all.items.len(), 3);
+    assert_eq!(all.items.len(), 4);
     assert!(matches!(all.items[0].provenance, ResourceProvenance::Local));
     let replica = all.items.iter().find(|item| item.object.metadata.name == "remote").expect("remote replica row");
     assert_eq!(replica.provenance, ResourceProvenance::Replica { origin_root: origin.clone(), last_synced_at: synced_at });
@@ -214,6 +215,15 @@ pub async fn assert_replica_read_view_contract(backend: ResourceBackend) {
         .expect("wire replica row");
     assert_eq!(wire_replica["metadata"]["annotations"]["flotilla.work/origin-root"], "feta-root");
     assert!(wire_replica["metadata"]["annotations"]["flotilla.work/last-synced-at"].is_string());
+
+    let read = backend.including_replicas::<Convoy>("flotilla");
+    let local_point = read.get("local").await.expect("point-read local convoy");
+    assert_eq!(local_point.object.spec.workflow_ref, "local-template");
+    assert_eq!(local_point.provenance, ResourceProvenance::Local);
+    let replica_point = read.get("remote").await.expect("point-read remote convoy");
+    assert_eq!(replica_point.object.spec.workflow_ref, "remote-template");
+    assert_eq!(replica_point.provenance, ResourceProvenance::Replica { origin_root: origin.clone(), last_synced_at: synced_at });
+    assert!(matches!(read.get("missing").await, Err(flotilla_resources::ResourceError::NotFound { .. })));
 
     let cursor =
         backend.replica_writer::<Convoy>(origin.clone(), "flotilla").cursor().await.expect("read replica cursor").expect("replica cursor");
@@ -251,7 +261,7 @@ pub async fn assert_replica_read_view_contract(backend: ResourceBackend) {
     let event = timeout(Duration::from_secs(1), watch.next()).await.expect("replica delete watch timeout");
     assert!(matches!(event, Some(Ok(flotilla_resources::ReadWatchEvent::Deleted(_)))));
     let remaining = backend.including_replicas::<Convoy>("flotilla").list().await.expect("list after replica delete");
-    assert_eq!(remaining.items.len(), 2);
+    assert_eq!(remaining.items.len(), 3);
 
     let mut new_generation = remote.list().await.expect("list new origin generation");
     new_generation.generation = Some("generation-2".to_string());

--- a/crates/flotilla-resources/tests/common/contract.rs
+++ b/crates/flotilla-resources/tests/common/contract.rs
@@ -393,6 +393,13 @@ pub async fn assert_project_definition_edit_converges_with_backend(backend: Reso
 
     let visible_on_feta = feta.definitions::<Project>("flotilla").get("widgets").await.expect("Project should be visible on feta");
     assert_eq!(visible_on_feta.spec.display_name, "Widgets");
+    let point_read = feta.including_replicas::<Project>("flotilla").get("widgets").await.expect("point-read replicated Project definition");
+    assert_eq!(point_read.object.spec.display_name, "Widgets");
+    assert_eq!(point_read.provenance, ResourceProvenance::Local, "merged definitions are presented as the local read view");
+    assert!(matches!(
+        feta.including_replicas::<Project>("flotilla").get("missing").await,
+        Err(flotilla_resources::ResourceError::NotFound { .. })
+    ));
     assert!(feta.using::<Project>("flotilla").list().await.expect("list feta local log").items.is_empty());
 
     feta.definitions::<Project>("flotilla")

--- a/crates/flotilla-resources/tests/http_wire.rs
+++ b/crates/flotilla-resources/tests/http_wire.rs
@@ -97,6 +97,44 @@ async fn list_decodes_collection_resource_version() {
 
 #[tokio::test]
 #[cfg_attr(feature = "skip-no-sandbox-tests", ignore = "excluded by `skip-no-sandbox-tests`; run without that feature to include")]
+async fn replica_point_get_requests_read_view_and_decodes_provenance() {
+    let body = serde_json::json!({
+        "apiVersion": "flotilla.work/v1",
+        "kind": "Convoy",
+        "metadata": {
+            "name": "alpha",
+            "namespace": "flotilla",
+            "resourceVersion": "7",
+            "labels": {},
+            "annotations": {
+                "flotilla.work/origin-root": "remote-root",
+                "flotilla.work/last-synced-at": "2026-04-13T12:00:00Z"
+            },
+            "creationTimestamp": "2026-04-13T12:00:00Z"
+        },
+        "spec": {
+            "workflow_ref": "review",
+            "inputs": {},
+            "placement_policy": "laptop-docker"
+        },
+        "status": { "phase": "Active" }
+    })
+    .to_string();
+    let (base_url, request_rx) = spawn_one_shot_server(response("200 OK", &body)).await;
+    let backend = ResourceBackend::Http(HttpBackend::new(flotilla_resources::tls::client(), base_url));
+
+    let object = backend.including_replicas::<Convoy>("flotilla").get("alpha").await.expect("get replica read view");
+
+    assert!(matches!(
+        object.provenance,
+        flotilla_resources::ResourceProvenance::Replica { ref origin_root, .. } if origin_root.as_str() == "remote-root"
+    ));
+    let request = request_rx.await.expect("captured request");
+    assert!(request.starts_with("GET /apis/flotilla.work/v1/namespaces/flotilla/convoys/alpha?includeReplicas=true HTTP/1.1"));
+}
+
+#[tokio::test]
+#[cfg_attr(feature = "skip-no-sandbox-tests", ignore = "excluded by `skip-no-sandbox-tests`; run without that feature to include")]
 async fn update_status_uses_status_subresource_path_and_body() {
     let body = serde_json::json!({
         "apiVersion": "flotilla.work/v1",

--- a/crates/flotilla-resources/tests/sqlite.rs
+++ b/crates/flotilla-resources/tests/sqlite.rs
@@ -43,6 +43,30 @@ fn backend() -> ResourceBackend {
     ResourceBackend::Sqlite(SqliteBackend::open_in_memory().expect("sqlite backend should open"))
 }
 
+#[test]
+fn replica_point_lookup_uses_resource_name_index() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let path = directory.path().join("resources.sqlite");
+    drop(SqliteBackend::open(&path).expect("initialize sqlite backend"));
+    let connection = rusqlite::Connection::open(&path).expect("open raw sqlite connection");
+
+    let plan = connection
+        .query_row(
+            r#"
+            EXPLAIN QUERY PLAN
+            SELECT origin_root, last_synced_at, body_json
+            FROM replica_objects
+            WHERE group_name = ?1 AND version = ?2 AND kind = ?3 AND namespace = ?4 AND name = ?5
+            ORDER BY origin_root
+            "#,
+            rusqlite::params!["flotilla.work", "v1", "Convoy", "flotilla", "remote"],
+            |row| row.get::<_, String>(3),
+        )
+        .expect("explain replica point lookup");
+
+    assert!(plan.contains("replica_objects_by_resource_name"), "unexpected replica point-lookup plan: {plan}");
+}
+
 struct AlwaysEligible;
 
 #[async_trait]


### PR DESCRIPTION
## What changed

- add `ReplicaReadResolver::get` with local-first reads and deterministic replica fallback
- implement point lookup for in-memory, SQLite, and HTTP resource backends while preserving replica provenance
- route `QueryResourceGet` through the point lookup instead of listing and serializing the complete replica overlay
- add contract, HTTP wire, daemon socket, and query regression coverage

## Why

`flotilla get <kind> <name>` must see remote replicas, but collection-only replica reads made each lookup scan both the local and federated collections. This adds the missing point-read primitive while retaining the local collection cursor needed for replay-safe query responses.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1390
