### PR TITLE
Decouple providers from follower polling

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1944,6 +1944,17 @@ const FLEET_REPLICA_FRESH_SECS: i64 = 90;
 const FLEET_REPLICA_REFRESH_TIMEOUT: Duration = Duration::from_secs(2);
 const ENSURE_BACKOFF_RESET_AFTER: ChronoDuration = ChronoDuration::minutes(10);
 
+fn mark_external_polling_disabled(providers: &mut [HostProviderStatus], follower: bool) {
+    if !follower {
+        return;
+    }
+    for provider in providers {
+        if matches!(provider.category.as_str(), "change_request" | "cloud_agent") {
+            provider.disabled_reason = Some("polling disabled".to_string());
+        }
+    }
+}
+
 fn ensure_retry_delay(restart_count: u32) -> ChronoDuration {
     let exponent = restart_count.min(5);
     ChronoDuration::seconds((30_i64.saturating_mul(1_i64 << exponent)).min(15 * 60))
@@ -2070,7 +2081,7 @@ impl InProcessDaemon {
                 }
             }
             let slug = repo_slug.clone();
-            let mut model = RepoModel::new(
+            let mut model = RepoModel::new_with_external_polling(
                 path.clone(),
                 registry,
                 repo_slug,
@@ -2078,6 +2089,10 @@ impl InProcessDaemon {
                 Some(local_host_id.clone()),
                 attachable_store,
                 Arc::clone(&agent_state_store),
+                match discovery.observer_polling() {
+                    crate::providers::discovery::ObserverPolling::Enabled => crate::refresh::ExternalPolling::Enabled,
+                    crate::providers::discovery::ObserverPolling::Disabled => crate::refresh::ExternalPolling::Disabled,
+                },
             );
             model.data.loading = true;
             let root = RepoRootState { path: path.clone(), model, slug, repo_bag, unmet, is_local: true };
@@ -2091,14 +2106,16 @@ impl InProcessDaemon {
             path_identities.insert(path.clone(), identity);
         }
 
+        let mut local_provider_statuses = crate::host_summary::provider_statuses_from_registries(
+            repos.values().map(|state| state.preferred_root().model.registry.as_ref()),
+        );
+        mark_external_polling_disabled(&mut local_provider_statuses, follower);
         let local_host_summary = crate::host_summary::build_local_host_summary(
             &local_node_id,
             &host_name,
             EnvironmentId::host(environment_manager.local_host_id().clone()),
             &environment_manager,
-            crate::host_summary::provider_statuses_from_registries(
-                repos.values().map(|state| state.preferred_root().model.registry.as_ref()),
-            ),
+            local_provider_statuses,
             &*discovery.env,
         )
         .await;
@@ -6239,7 +6256,7 @@ impl InProcessDaemon {
             }
         }
         let slug = repo_slug.clone();
-        let mut model = RepoModel::new(
+        let mut model = RepoModel::new_with_external_polling(
             path.clone(),
             registry,
             repo_slug,
@@ -6247,6 +6264,10 @@ impl InProcessDaemon {
             Some(self.environment_manager.host_id_for_environment(&self.local_environment_id).expect("local host id must be available")),
             self.discovery.shared_attachable_store(&self.config),
             Arc::clone(&self.agent_state_store),
+            match self.discovery.observer_polling() {
+                crate::providers::discovery::ObserverPolling::Enabled => crate::refresh::ExternalPolling::Enabled,
+                crate::providers::discovery::ObserverPolling::Disabled => crate::refresh::ExternalPolling::Disabled,
+            },
         );
         model.data.loading = true;
         let root = RepoRootState { path: path.clone(), model, slug, repo_bag, unmet, is_local: true };
@@ -6447,14 +6468,10 @@ impl InProcessDaemon {
             .into_iter()
             .map(|(category, name)| {
                 let healthy = snapshot.provider_health.get(&category).and_then(|providers| providers.get(&name)).copied().unwrap_or(true);
-                ProviderInfo { category, name, healthy, disabled_reason: None }
+                let disabled_reason = (self.follower && matches!(category.as_str(), "change_request" | "cloud_agent"))
+                    .then(|| "polling disabled".to_string());
+                ProviderInfo { category, name, healthy, disabled_reason }
             })
-            .chain(self.discovery.follower_suppressions().map(|category| ProviderInfo {
-                category: category.slug().to_string(),
-                name: category.display_name().to_string(),
-                healthy: true,
-                disabled_reason: Some("follower mode".to_string()),
-            }))
             .collect();
 
         let unmet_requirements =
@@ -8181,11 +8198,7 @@ impl InProcessDaemon {
                 providers.push(advertised.clone());
             }
         }
-        providers.extend(
-            self.discovery
-                .follower_suppressions()
-                .map(|category| HostProviderStatus::disabled(category.slug(), category.display_name(), "follower mode")),
-        );
+        mark_external_polling_disabled(&mut providers, self.follower);
         providers.sort_by(|left, right| (&left.category, &left.name).cmp(&(&right.category, &right.name)));
         let summary = crate::host_summary::build_local_host_summary(
             &self.node_id,
@@ -8212,11 +8225,7 @@ impl InProcessDaemon {
     }
 
     fn missing_external_provider_error(&self, error: &str) -> String {
-        if self.follower {
-            format!("{error}: this host runs in follower mode; dispatch from a leader host")
-        } else {
-            error.to_string()
-        }
+        error.to_string()
     }
 
     pub async fn execute_with_remote_executor(

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -105,13 +105,13 @@ use crate::{
         ai_utility::{AiUtility, ConvoyNames},
         discovery::{
             discover_providers_with_host_scoped, run_host_detectors, DiscoveryResult, DiscoveryRuntime, EnvironmentAssertion,
-            EnvironmentBag,
+            EnvironmentBag, ObserverPolling,
         },
         issue_tracker::{forge_issue_source, IssueProvider},
         ssh_runner::SshCommandRunner,
         ChannelLabel, CommandRunner,
     },
-    refresh::RefreshSnapshot,
+    refresh::{ExternalPolling, RefreshSnapshot},
     regard_lifecycle::{RegardLifecycle, SurfaceGestureOutcome, DEFAULT_REGARD_DECAY_SECONDS, DEFAULT_REGARD_REFRESH_SECONDS},
     repo_state::{RepoRootState, RepoState, SnapshotBuildContext},
     repository_inspection::{
@@ -1955,6 +1955,13 @@ fn mark_external_polling_disabled(providers: &mut [HostProviderStatus], follower
     }
 }
 
+fn external_polling_policy(discovery: &DiscoveryRuntime) -> ExternalPolling {
+    match discovery.observer_polling() {
+        ObserverPolling::Enabled => ExternalPolling::Enabled,
+        ObserverPolling::Disabled => ExternalPolling::Disabled,
+    }
+}
+
 fn ensure_retry_delay(restart_count: u32) -> ChronoDuration {
     let exponent = restart_count.min(5);
     ChronoDuration::seconds((30_i64.saturating_mul(1_i64 << exponent)).min(15 * 60))
@@ -2089,10 +2096,7 @@ impl InProcessDaemon {
                 Some(local_host_id.clone()),
                 attachable_store,
                 Arc::clone(&agent_state_store),
-                match discovery.observer_polling() {
-                    crate::providers::discovery::ObserverPolling::Enabled => crate::refresh::ExternalPolling::Enabled,
-                    crate::providers::discovery::ObserverPolling::Disabled => crate::refresh::ExternalPolling::Disabled,
-                },
+                external_polling_policy(&discovery),
             );
             model.data.loading = true;
             let root = RepoRootState { path: path.clone(), model, slug, repo_bag, unmet, is_local: true };
@@ -2336,9 +2340,9 @@ impl InProcessDaemon {
             .host_scoped_providers
             .discover_for_environment(&self.local_environment_id, &host_bag, &self.discovery.factories, &self.config, &probe_root, runner)
             .await;
-        let provider = host_scoped.issue_provider_for(source).ok_or_else(|| {
-            self.missing_external_provider_error(&format!("no issue provider available for {} {}", source.service, source.scope))
-        })?;
+        let provider = host_scoped
+            .issue_provider_for(source)
+            .ok_or_else(|| format!("no issue provider available for {} {}", source.service, source.scope))?;
         Ok(provider)
     }
 
@@ -6264,10 +6268,7 @@ impl InProcessDaemon {
             Some(self.environment_manager.host_id_for_environment(&self.local_environment_id).expect("local host id must be available")),
             self.discovery.shared_attachable_store(&self.config),
             Arc::clone(&self.agent_state_store),
-            match self.discovery.observer_polling() {
-                crate::providers::discovery::ObserverPolling::Enabled => crate::refresh::ExternalPolling::Enabled,
-                crate::providers::discovery::ObserverPolling::Disabled => crate::refresh::ExternalPolling::Disabled,
-            },
+            external_polling_policy(&self.discovery),
         );
         model.data.loading = true;
         let root = RepoRootState { path: path.clone(), model, slug, repo_bag, unmet, is_local: true };
@@ -8218,14 +8219,11 @@ impl InProcessDaemon {
         let repos = self.repos.read().await;
         let state = repos.get(&identity).ok_or_else(|| "repo not found".to_string())?;
         let source = forge_issue_source(state.identity());
-        let provider = state.registry().issue_provider_for(&source).ok_or_else(|| {
-            self.missing_external_provider_error(&format!("no issue provider available for {} {}", source.service, source.scope))
-        })?;
+        let provider = state
+            .registry()
+            .issue_provider_for(&source)
+            .ok_or_else(|| format!("no issue provider available for {} {}", source.service, source.scope))?;
         Ok((provider, source))
-    }
-
-    fn missing_external_provider_error(&self, error: &str) -> String {
-        error.to_string()
     }
 
     pub async fn execute_with_remote_executor(

--- a/crates/flotilla-core/src/model.rs
+++ b/crates/flotilla-core/src/model.rs
@@ -15,7 +15,7 @@ use crate::{
         registry::{ProviderRegistry, ProviderSet},
         types::RepoCriteria,
     },
-    refresh::{RefreshSchedule, RepoRefreshHandle},
+    refresh::{ExternalPolling, RefreshSchedule, RepoRefreshHandle},
 };
 pub fn labels_from_registry(registry: &ProviderRegistry) -> RepoLabels {
     fn labels<T: ?Sized>(set: &ProviderSet<T>) -> CategoryLabels {
@@ -92,11 +92,34 @@ impl RepoModel {
         attachable_store: SharedAttachableStore,
         agent_state_store: crate::agents::SharedAgentStateStore,
     ) -> Self {
+        Self::new_with_external_polling(
+            repo_root,
+            registry,
+            repo_slug,
+            environment_id,
+            host_id,
+            attachable_store,
+            agent_state_store,
+            ExternalPolling::Enabled,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_external_polling(
+        repo_root: PathBuf,
+        registry: ProviderRegistry,
+        repo_slug: Option<String>,
+        environment_id: Option<EnvironmentId>,
+        host_id: Option<HostId>,
+        attachable_store: SharedAttachableStore,
+        agent_state_store: crate::agents::SharedAgentStateStore,
+        external_polling: ExternalPolling,
+    ) -> Self {
         let labels = labels_from_registry(&registry);
         let registry = Arc::new(registry);
         let criteria = RepoCriteria { repo_slug };
         let refresh_schedule = RefreshSchedule::for_repo(&repo_root, Duration::from_secs(10), Duration::from_secs(60));
-        let refresh_handle = RepoRefreshHandle::spawn_with_schedule(
+        let refresh_handle = RepoRefreshHandle::spawn_with_schedule_and_external_polling(
             repo_root,
             registry.clone(),
             criteria,
@@ -105,6 +128,7 @@ impl RepoModel {
             attachable_store,
             agent_state_store,
             refresh_schedule,
+            external_polling,
         );
         Self { registry, data: DataStore::default(), labels, refresh_handle, environment_id }
     }

--- a/crates/flotilla-core/src/providers/discovery/factories/mod.rs
+++ b/crates/flotilla-core/src/providers/discovery/factories/mod.rs
@@ -66,22 +66,6 @@ impl FactoryRegistry {
             presentation_managers: presentation_factories(),
             terminal_pools: terminal_pool_factories(),
             environment_providers: vec![Box::new(docker::DockerEnvironmentFactory)],
-            suppressions: vec![],
-        }
-    }
-
-    pub fn for_follower() -> Self {
-        Self {
-            vcs: vec![Box::new(git::GitVcsFactory)],
-            checkout_managers: checkout_manager_factories(),
-            change_requests: vec![],
-            issue_trackers: vec![],
-            cloud_agents: vec![],
-            ai_utilities: vec![],
-            presentation_managers: presentation_factories(),
-            terminal_pools: terminal_pool_factories(),
-            environment_providers: vec![Box::new(docker::DockerEnvironmentFactory)],
-            suppressions: super::ProviderCategory::FOLLOWER_SUPPRESSED.to_vec(),
         }
     }
 }
@@ -101,27 +85,20 @@ mod tests {
         assert!(!reg.ai_utilities.is_empty());
         assert!(!reg.presentation_managers.is_empty());
         assert!(!reg.terminal_pools.is_empty());
-        assert!(reg.suppressions.is_empty());
     }
 
     #[test]
-    fn for_follower_omits_external_providers() {
-        let reg = FactoryRegistry::for_follower();
+    fn follower_runtime_constructs_external_providers() {
+        let runtime = super::super::DiscoveryRuntime::for_process(true);
+        let reg = &runtime.factories;
         assert!(!reg.vcs.is_empty());
         assert!(!reg.checkout_managers.is_empty());
-        assert!(reg.change_requests.is_empty());
-        assert!(reg.issue_trackers.is_empty());
-        assert!(reg.cloud_agents.is_empty());
-        assert!(reg.ai_utilities.is_empty());
+        assert!(!reg.change_requests.is_empty());
+        assert!(!reg.issue_trackers.is_empty());
+        assert!(!reg.cloud_agents.is_empty());
+        assert!(!reg.ai_utilities.is_empty());
         assert!(!reg.presentation_managers.is_empty());
         assert!(!reg.terminal_pools.is_empty());
-        assert_eq!(reg.suppressions, super::super::ProviderCategory::FOLLOWER_SUPPRESSED);
-    }
-
-    #[test]
-    fn follower_detection_is_independent_of_suppression_order() {
-        let mut runtime = super::super::DiscoveryRuntime::for_process(true);
-        runtime.factories.suppressions.reverse();
         assert!(runtime.is_follower());
     }
 }

--- a/crates/flotilla-core/src/providers/discovery/mod.rs
+++ b/crates/flotilla-core/src/providers/discovery/mod.rs
@@ -269,8 +269,6 @@ pub enum ProviderCategory {
 }
 
 impl ProviderCategory {
-    pub const FOLLOWER_SUPPRESSED: [Self; 4] = [Self::ChangeRequest, Self::IssueProvider, Self::CloudAgent, Self::AiUtility];
-
     pub fn slug(&self) -> &'static str {
         match self {
             Self::Vcs => "vcs",
@@ -432,8 +430,6 @@ pub struct FactoryRegistry {
     pub presentation_managers: Vec<Box<PresentationManagerFactory>>,
     pub terminal_pools: Vec<Box<TerminalPoolFactory>>,
     pub environment_providers: Vec<Box<EnvironmentProviderFactory>>,
-    /// Categories intentionally omitted by the selected daemon mode.
-    pub suppressions: Vec<ProviderCategory>,
 }
 
 impl FactoryRegistry {
@@ -505,8 +501,15 @@ pub struct DiscoveryRuntime {
     pub host_detectors: Vec<Box<dyn HostDetector>>,
     pub repo_detectors: Vec<Box<dyn RepoDetector>>,
     pub factories: FactoryRegistry,
+    observer_polling: ObserverPolling,
     pub(crate) attachable_store: OnceLock<SharedAttachableStore>,
     pub(crate) host_scoped_providers: HostScopedProviderCache,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ObserverPolling {
+    Enabled,
+    Disabled,
 }
 
 const HOST_SCAN_CACHE_TTL: Duration = Duration::from_secs(10);
@@ -635,14 +638,14 @@ impl HostScopedProviderCache {
 
 impl DiscoveryRuntime {
     pub fn for_process(follower: bool) -> Self {
-        let factories = if follower { FactoryRegistry::for_follower() } else { FactoryRegistry::default_all() };
         Self {
             runner: Arc::new(crate::providers::ProcessCommandRunner),
             env: Arc::new(ProcessEnvVars),
             available_space_probe: system_available_space_probe(),
             host_detectors: detectors::default_host_detectors(),
             repo_detectors: detectors::default_repo_detectors(),
-            factories,
+            factories: FactoryRegistry::default_all(),
+            observer_polling: if follower { ObserverPolling::Disabled } else { ObserverPolling::Enabled },
             attachable_store: OnceLock::new(),
             host_scoped_providers: HostScopedProviderCache::default(),
         }
@@ -653,12 +656,11 @@ impl DiscoveryRuntime {
     }
 
     pub fn is_follower(&self) -> bool {
-        self.factories.suppressions.len() == ProviderCategory::FOLLOWER_SUPPRESSED.len()
-            && ProviderCategory::FOLLOWER_SUPPRESSED.iter().all(|category| self.factories.suppressions.contains(category))
+        self.observer_polling == ObserverPolling::Disabled
     }
 
-    pub fn follower_suppressions(&self) -> impl Iterator<Item = ProviderCategory> + '_ {
-        self.factories.suppressions.iter().copied()
+    pub fn observer_polling(&self) -> ObserverPolling {
+        self.observer_polling
     }
 }
 
@@ -1037,7 +1039,6 @@ mod orchestrator_tests {
             presentation_managers: vec![],
             terminal_pools: vec![],
             environment_providers: vec![],
-            suppressions: vec![],
         };
 
         let result = discover_providers(&host_bag, &repo_root, &repo_dets, &fact_reg, &config, runner, &TestEnvVars::default()).await;
@@ -1067,7 +1068,6 @@ mod orchestrator_tests {
             presentation_managers: vec![],
             terminal_pools: vec![],
             environment_providers: vec![],
-            suppressions: vec![],
         };
 
         let result = discover_providers(&host_bag, &repo_root, &repo_dets, &fact_reg, &config, runner, &TestEnvVars::default()).await;

--- a/crates/flotilla-core/src/providers/discovery/test_support.rs
+++ b/crates/flotilla-core/src/providers/discovery/test_support.rs
@@ -303,7 +303,6 @@ pub fn git_process_discovery(follower: bool) -> super::DiscoveryRuntime {
 }
 
 fn minimal_discovery_runtime(follower: bool, runner: std::sync::Arc<dyn CommandRunner>) -> super::DiscoveryRuntime {
-    let factories = if follower { super::FactoryRegistry::for_follower() } else { super::FactoryRegistry::default_all() };
     super::DiscoveryRuntime {
         runner,
         env: std::sync::Arc::new(TestEnvVars::default()),
@@ -314,7 +313,8 @@ fn minimal_discovery_runtime(follower: bool, runner: std::sync::Arc<dyn CommandR
             super::detectors::generic::parse_first_dotted_version,
         ))],
         repo_detectors: super::detectors::default_repo_detectors(),
-        factories,
+        factories: super::FactoryRegistry::default_all(),
+        observer_polling: if follower { super::ObserverPolling::Disabled } else { super::ObserverPolling::Enabled },
         attachable_store: OnceLock::new(),
         host_scoped_providers: Default::default(),
     }
@@ -1331,11 +1331,20 @@ pub fn fake_discovery_with_provider_set(providers: FakeDiscoveryProviders) -> Di
             presentation_managers: presentation_manager_factories,
             terminal_pools: terminal_pool_factories,
             environment_providers: vec![],
-            suppressions: vec![],
         },
+        observer_polling: super::ObserverPolling::Enabled,
         attachable_store,
         host_scoped_providers: Default::default(),
     }
+}
+
+/// Build a follower-mode discovery runtime with deterministic injected
+/// providers. Provider construction remains enabled while observer polling is
+/// disabled, matching production follower behavior.
+pub fn fake_discovery_with_provider_set_for_follower(providers: FakeDiscoveryProviders) -> DiscoveryRuntime {
+    let mut runtime = fake_discovery_with_provider_set(providers);
+    runtime.observer_polling = super::ObserverPolling::Disabled;
+    runtime
 }
 
 fn fixed_available_space_probe() -> Arc<dyn crate::admission::AvailableSpaceProbe> {

--- a/crates/flotilla-core/src/providers/discovery/tests.rs
+++ b/crates/flotilla-core/src/providers/discovery/tests.rs
@@ -303,7 +303,6 @@ fn factories_with_presentation(factory: CountingPresentationFactory) -> FactoryR
         presentation_managers: vec![Box::new(factory)],
         terminal_pools: vec![],
         environment_providers: vec![],
-        suppressions: vec![],
     }
 }
 

--- a/crates/flotilla-core/src/refresh.rs
+++ b/crates/flotilla-core/src/refresh.rs
@@ -54,6 +54,12 @@ pub struct RepoRefreshHandle {
     _task_handle: JoinHandle<()>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExternalPolling {
+    Enabled,
+    Disabled,
+}
+
 #[derive(Clone, Copy)]
 struct RefreshCadence {
     interval: Duration,
@@ -183,6 +189,31 @@ impl RepoRefreshHandle {
         agent_state_store: crate::agents::SharedAgentStateStore,
         schedule: RefreshSchedule,
     ) -> Self {
+        Self::spawn_with_schedule_and_external_polling(
+            repo_root,
+            registry,
+            criteria,
+            environment_id,
+            host_id,
+            attachable_store,
+            agent_state_store,
+            schedule,
+            ExternalPolling::Enabled,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn spawn_with_schedule_and_external_polling(
+        repo_root: PathBuf,
+        registry: Arc<ProviderRegistry>,
+        criteria: RepoCriteria,
+        environment_id: Option<EnvironmentId>,
+        host_id: Option<HostId>,
+        attachable_store: SharedAttachableStore,
+        agent_state_store: crate::agents::SharedAgentStateStore,
+        schedule: RefreshSchedule,
+        external_polling: ExternalPolling,
+    ) -> Self {
         let (snapshot_tx, snapshot_rx) = watch::channel(Arc::new(RefreshSnapshot::default()));
         let refresh_trigger = Arc::new(Notify::new());
         let trigger = refresh_trigger.clone();
@@ -211,6 +242,7 @@ impl RepoRefreshHandle {
                 host_id.as_ref(),
                 &attachable_store,
                 &agent_state_store,
+                external_polling,
             )
             .await;
             if snapshot_tx.send(initial).is_err() {
@@ -239,6 +271,7 @@ impl RepoRefreshHandle {
                     host_id.as_ref(),
                     &attachable_store,
                     &agent_state_store,
+                    external_polling,
                 )
                 .await;
 
@@ -285,6 +318,7 @@ async fn run_refresh_cycle(
     host_id: Option<&HostId>,
     attachable_store: &SharedAttachableStore,
     agent_state_store: &crate::agents::SharedAgentStateStore,
+    external_polling: ExternalPolling,
 ) -> Arc<RefreshSnapshot> {
     match kind {
         RefreshKind::Full => {
@@ -292,7 +326,7 @@ async fn run_refresh_cycle(
             let mut slow_data = provider_data.clone();
             let (new_fast_errors, new_slow_errors) = tokio::join!(
                 refresh_fast_providers(&mut fast_data, repo_root, registry, environment_id, host_id, attachable_store, agent_state_store,),
-                refresh_slow_providers(&mut slow_data, repo_root, registry, criteria, host_id),
+                refresh_slow_providers(&mut slow_data, repo_root, registry, criteria, host_id, external_polling),
             );
             install_fast_provider_data(provider_data, fast_data);
             install_slow_provider_data(provider_data, slow_data);
@@ -305,7 +339,7 @@ async fn run_refresh_cycle(
                     .await;
         }
         RefreshKind::Slow => {
-            *slow_errors = refresh_slow_providers(provider_data, repo_root, registry, criteria, host_id).await;
+            *slow_errors = refresh_slow_providers(provider_data, repo_root, registry, criteria, host_id, external_polling).await;
         }
     }
     let errors: Vec<_> = fast_errors.iter().chain(slow_errors.iter()).cloned().collect();
@@ -386,7 +420,7 @@ async fn refresh_providers(
     agent_state_store: &crate::agents::SharedAgentStateStore,
 ) -> Vec<RefreshError> {
     let mut errors = refresh_fast_providers(pd, repo_root, registry, environment_id, host_id, attachable_store, agent_state_store).await;
-    errors.extend(refresh_slow_providers(pd, repo_root, registry, criteria, host_id).await);
+    errors.extend(refresh_slow_providers(pd, repo_root, registry, criteria, host_id, ExternalPolling::Enabled).await);
     errors
 }
 
@@ -485,21 +519,33 @@ async fn refresh_slow_providers(
     registry: &ProviderRegistry,
     criteria: &RepoCriteria,
     host_id: Option<&HostId>,
+    external_polling: ExternalPolling,
 ) -> Vec<RefreshError> {
     let mut errors = Vec::new();
     let ee_root = ExecutionEnvironmentPath::new(repo_root);
-    let cr_fut = collect_named_results(
-        registry.change_requests.iter().map(|(desc, cr)| (desc.display_name.clone(), cr.list_change_requests(repo_root, 20))).collect(),
-    );
-    let sessions_fut = collect_named_results(
-        registry.cloud_agents.iter().map(|(desc, agent)| (desc.display_name.clone(), agent.list_sessions(criteria))).collect(),
-    );
+    let cr_fut = collect_named_results(match external_polling {
+        ExternalPolling::Enabled => {
+            registry.change_requests.iter().map(|(desc, cr)| (desc.display_name.clone(), cr.list_change_requests(repo_root, 20))).collect()
+        }
+        ExternalPolling::Disabled => Vec::new(),
+    });
+    let sessions_fut = collect_named_results(match external_polling {
+        ExternalPolling::Enabled => {
+            registry.cloud_agents.iter().map(|(desc, agent)| (desc.display_name.clone(), agent.list_sessions(criteria))).collect()
+        }
+        ExternalPolling::Disabled => Vec::new(),
+    });
     let branches_fut = collect_named_results(
         registry.vcs.iter().map(|(desc, vcs)| (desc.display_name.clone(), vcs.list_remote_branches(&ee_root))).collect(),
     );
-    let merged_fut = collect_named_results(
-        registry.change_requests.iter().map(|(desc, cr)| (desc.display_name.clone(), cr.list_merged_branch_names(repo_root, 50))).collect(),
-    );
+    let merged_fut = collect_named_results(match external_polling {
+        ExternalPolling::Enabled => registry
+            .change_requests
+            .iter()
+            .map(|(desc, cr)| (desc.display_name.clone(), cr.list_merged_branch_names(repo_root, 50)))
+            .collect(),
+        ExternalPolling::Disabled => Vec::new(),
+    });
     let ((change_requests, cr_errors), (sessions, session_errors), (branches, branch_errors), (merged, merged_errors)) =
         tokio::join!(cr_fut, sessions_fut, branches_fut, merged_fut);
 

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -22,10 +22,10 @@ use flotilla_core::{
         coding_agent::CloudAgentService,
         discovery::{
             test_support::{
-                fake_discovery, fake_discovery_with_provider_set, fake_discovery_with_providers, fake_vcs_discovery, git_process_discovery,
-                init_git_repo, init_git_repo_with_remote, DiscoveryMockRunner, FakeChangeRequest, FakeCheckoutManager,
-                FakeCheckoutManagerFactory, FakeDiscoveryProviders, FakeIssueProvider, FakePresentationManager, FakeTerminalPool,
-                FakeVcsFactory, FakeVcsState, TestEnvVars,
+                fake_discovery, fake_discovery_with_provider_set, fake_discovery_with_provider_set_for_follower,
+                fake_discovery_with_providers, fake_vcs_discovery, git_process_discovery, init_git_repo, init_git_repo_with_remote,
+                DiscoveryMockRunner, FakeChangeRequest, FakeCheckoutManager, FakeCheckoutManagerFactory, FakeDiscoveryProviders,
+                FakeIssueProvider, FakePresentationManager, FakeTerminalPool, FakeVcsFactory, FakeVcsState, TestEnvVars,
             },
             DiscoveryRuntime, EnvironmentAssertion, EnvironmentBag, Factory, HostDetector, HostPlatform, ProviderCategory,
             ProviderDescriptor, RepoDetector, UnmetRequirement,
@@ -653,6 +653,39 @@ impl ChangeRequestTracker for FailingChangeRequestTracker {
 
     async fn list_merged_branch_names(&self, _: &Path, _: usize) -> Result<Vec<String>, String> {
         Err("merged branch listing failed".into())
+    }
+}
+
+struct CountingChangeRequestTracker {
+    polls: AtomicUsize,
+}
+
+#[async_trait]
+impl ChangeRequestTracker for CountingChangeRequestTracker {
+    async fn list_change_requests(&self, _: &Path, _: usize) -> Result<Vec<(String, ChangeRequest)>, String> {
+        self.polls.fetch_add(1, Ordering::SeqCst);
+        Ok(Vec::new())
+    }
+
+    async fn get_change_request(&self, _: &Path, id: &str) -> Result<(String, ChangeRequest), String> {
+        Err(format!("change request {id} not found"))
+    }
+
+    async fn open_in_browser(&self, _: &Path, _: &str) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn close_change_request(&self, _: &Path, _: &str) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn merge_change_request(&self, _: &Path, _: &str) -> Result<(), String> {
+        Ok(())
+    }
+
+    async fn list_merged_branch_names(&self, _: &Path, _: usize) -> Result<Vec<String>, String> {
+        self.polls.fetch_add(1, Ordering::SeqCst);
+        Ok(Vec::new())
     }
 }
 
@@ -2287,6 +2320,58 @@ async fn convoy_start_admits_fully_specified_issue_intent_as_one_persisted_snaps
     ));
 
     drop(temp);
+}
+
+#[tokio::test]
+async fn follower_convoy_start_resolves_issue_through_local_provider() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let source = IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() };
+    let reference = IssueRef { source: source.clone(), id: "1432".into() };
+    let mut issue = TestIssue::new("Decouple providers from follower mode").id("1432").build();
+    issue.reference = reference.clone();
+    let provider = Arc::new(FakeIssueProvider::new());
+    provider.add_issues(vec![(reference.id.clone(), issue)]).await;
+    let discovery = fake_discovery_with_provider_set_for_follower(
+        FakeDiscoveryProviders::new().with_issue_tracker(provider as Arc<dyn flotilla_core::providers::issue_tracker::IssueProvider>),
+    );
+    let daemon = InProcessDaemon::new(vec![], test_config_store(temp.path().join("config")), discovery, HostName::local()).await;
+    assert!(daemon.is_follower());
+    let backend = daemon.resource_backend();
+    create_test_convoy_project(&backend, Some(source)).await;
+    let mut events = daemon.subscribe();
+
+    let command_id = daemon
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyStart {
+                intent: Box::new(ConvoyStartIntent {
+                    namespace: None,
+                    project_ref: "flotilla".into(),
+                    change_request: None,
+                    issues: vec![IssueSelector::Reference(reference.clone())],
+                    name: Some("issue-1432".into()),
+                    branch: Some("fix/issue-1432".into()),
+                    workflow_ref: Some("single-agent-contained".into()),
+                    inputs: Vec::new(),
+                    instruction: None,
+                    placement_policy: None,
+                    agent_overrides: Vec::new(),
+                    auto_attach: flotilla_protocol::ConvoyAutoAttach::Never,
+                }),
+            },
+        })
+        .await
+        .expect("start command accepted");
+
+    assert_eq!(recv_command_finished(&mut events, command_id).await, CommandValue::ConvoyStarted {
+        name: "issue-1432".into(),
+        attach_plan: None,
+        binding: None,
+    });
+    let convoy = backend.using::<ResourceConvoy>("flotilla").get("issue-1432").await.expect("persisted convoy");
+    assert_eq!(convoy.spec.issues[0].reference, reference);
 }
 
 #[tokio::test]
@@ -6265,60 +6350,44 @@ async fn follower_mode_flag_is_stored() {
 }
 
 #[tokio::test]
-async fn follower_mode_skips_external_providers() {
+async fn follower_mode_constructs_external_providers_without_polling_them() {
     let temp = tempfile::tempdir().unwrap();
     let repo = temp.path().to_path_buf();
     init_git_repo(&repo);
 
     let config = test_config_store(temp.path().join("config"));
-    let daemon = InProcessDaemon::new(vec![repo.clone()], config, git_process_discovery(true), HostName::local()).await;
+    let provider = Arc::new(CountingChangeRequestTracker { polls: AtomicUsize::new(0) });
+    let discovery = fake_discovery_with_provider_set_for_follower(
+        FakeDiscoveryProviders::new().with_change_request(provider.clone() as Arc<dyn ChangeRequestTracker>),
+    );
+    let daemon = InProcessDaemon::new(vec![repo.clone()], config, discovery, HostName::local()).await;
 
     assert!(daemon.is_follower());
 
     // list_repos gives us RepoInfo with provider_names populated from the registry
     let repos = daemon.list_repos().await.expect("list_repos");
     assert_eq!(repos.len(), 1);
-    assert!(repos[0].repository_key.is_some(), "startup repo should expose its queryable repository key");
     let provider_names = &repos[0].provider_names;
 
-    // VCS should be present (local provider, .git dir exists)
-    assert!(provider_names.contains_key("vcs"), "follower should have VCS provider");
-    // checkout_manager should also be present (git-based fallback)
-    assert!(provider_names.contains_key("checkout_manager"), "follower should have checkout_manager provider");
+    assert!(provider_names.contains_key("change_request"), "follower should construct its credentialed change-request provider");
 
-    // External providers should be absent
-    assert!(!provider_names.contains_key("change_request"), "follower should not have change_request provider");
-    assert!(!provider_names.contains_key("issue_tracker"), "follower should not have issue_tracker provider");
-    // cloud_agent and ai_utility depend on Claude/Codex/Cursor being
-    // installed, so they may or may not be present in non-follower mode.
-    // In follower mode they should always be absent.
-    assert!(!provider_names.contains_key("cloud_agent"), "follower should not have cloud_agent provider");
-    assert!(!provider_names.contains_key("ai_utility"), "follower should not have ai_utility provider");
+    daemon.refresh(&RepoSelector::Path(repo.clone())).await.expect("manual refresh accepted");
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(provider.polls.load(Ordering::SeqCst), 0, "follower must not start external observer polling");
 
-    let expected_suppressions = ["ai_utility", "change_request", "cloud_agent", "issue_tracker"];
     let host_summary = daemon.local_host_summary().await;
-    let mut host_suppressions = host_summary
-        .providers
-        .iter()
-        .filter(|provider| provider.disabled_reason.as_deref() == Some("follower mode"))
-        .map(|provider| provider.category.as_str())
-        .collect::<Vec<_>>();
-    host_suppressions.sort_unstable();
-    assert_eq!(host_suppressions, expected_suppressions);
+    let host_polling_disabled =
+        host_summary.providers.iter().find(|status| status.category == "change_request").expect("host change-request status");
+    assert_eq!(host_polling_disabled.disabled_reason.as_deref(), Some("polling disabled"));
 
     let repo_providers = daemon.get_repo_providers_internal(&RepoSelector::Path(repo)).await.expect("repo providers");
-    let mut repo_suppressions = repo_providers
-        .providers
-        .iter()
-        .filter(|provider| provider.disabled_reason.as_deref() == Some("follower mode"))
-        .map(|provider| provider.category.as_str())
-        .collect::<Vec<_>>();
-    repo_suppressions.sort_unstable();
-    assert_eq!(repo_suppressions, expected_suppressions);
+    let repo_polling_disabled =
+        repo_providers.providers.iter().find(|status| status.category == "change_request").expect("repo change-request status");
+    assert_eq!(repo_polling_disabled.disabled_reason.as_deref(), Some("polling disabled"));
 }
 
 #[tokio::test]
-async fn missing_issue_provider_explains_follower_mode_only_on_followers() {
+async fn missing_issue_provider_names_the_missing_capability_on_every_host() {
     let config_tmp = tempfile::tempdir().expect("tempdir");
     let config = test_config_store(config_tmp.path().to_path_buf());
     let source = IssueSource { service: "https://github.com".into(), scope: "flotilla-org/flotilla".into() };
@@ -6329,10 +6398,7 @@ async fn missing_issue_provider_explains_follower_mode_only_on_followers() {
 
     let follower = InProcessDaemon::new(vec![], config, fake_discovery(true), HostName::local()).await;
     let follower_error = follower.issue_provider_for_source(&source).await.err().expect("follower should have no issue provider");
-    assert_eq!(
-        follower_error,
-        "no issue provider available for https://github.com flotilla-org/flotilla: this host runs in follower mode; dispatch from a leader host"
-    );
+    assert_eq!(follower_error, "no issue provider available for https://github.com flotilla-org/flotilla");
 }
 
 #[tokio::test]

--- a/crates/flotilla-protocol/src/host_summary.rs
+++ b/crates/flotilla-protocol/src/host_summary.rs
@@ -95,7 +95,7 @@ pub struct HostProviderStatus {
     #[serde(default)]
     pub implementation: String,
     pub healthy: bool,
-    /// Why this provider category is intentionally unavailable.
+    /// Why this provider is fully or partially disabled.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub disabled_reason: Option<String>,
 }


### PR DESCRIPTION
Closes #1432

## Summary
- construct credentialed external providers on follower-mode hosts
- gate only continuous change-request and cloud-agent observer polling
- report constructed providers as polling disabled instead of unavailable in follower mode
- remove leader guidance from genuinely missing issue-provider errors

## Tests
- follower convoy dispatch resolves an injected issue provider end to end
- follower refresh never calls an injected external observer provider
- credential-less follower error names the missing issue-provider capability
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`