### PR TITLE
fix: prefer local authority over self-origin replicas

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -4961,9 +4961,6 @@ impl InProcessDaemon {
             return Ok(());
         };
         let target_host = &placement.target_host;
-        if self.local_host_id().as_ref().is_some_and(|host_id| host_id.as_str() == target_host.reference) {
-            return Ok(());
-        }
 
         let sources =
             self.resource_backend.including_replicas::<ResourceHost>(namespace).list().await.map_err(|error| error.to_string())?;
@@ -4981,10 +4978,19 @@ impl InProcessDaemon {
             return Ok(());
         }
 
-        let capacity = matching_sources
-            .into_iter()
-            .filter_map(|source| source.object.status)
-            .find_map(|status| status.admission_free_space_floor_bytes.map(|floor| (floor, status.disk_free_bytes)));
+        let owns_target_identity = self.local_host_id().as_ref().is_some_and(|host_id| host_id.as_str() == target_host.reference);
+        let capacity = if owns_target_identity {
+            matching_sources
+                .iter()
+                .find(|source| matches!(source.provenance, ResourceProvenance::Local))
+                .and_then(|source| source.object.status.as_ref())
+                .and_then(|status| status.admission_free_space_floor_bytes.map(|floor| (floor, status.disk_free_bytes)))
+        } else {
+            matching_sources
+                .into_iter()
+                .filter_map(|source| source.object.status)
+                .find_map(|status| status.admission_free_space_floor_bytes.map(|floor| (floor, status.disk_free_bytes)))
+        };
         let Some((floor_bytes, free_bytes)) = capacity else {
             return Err(format!("placement refused on host `{}`: admission free-space floor is unavailable", target_host.display_name));
         };

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -77,6 +77,75 @@ fn turn_delivery_session_plans_preserve_terminal_lifecycle_invariants() {
 const TEST_LOCAL_ATTACH_HOST: &str = "local";
 
 #[tokio::test]
+async fn self_targeted_admission_uses_live_local_host_over_stale_self_origin_replica() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(temp.path().join("daemon.toml"), "machine_id = \"local-host\"\n").expect("daemon config");
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let daemon = InProcessDaemon::new_with_resource_backend(
+        Vec::new(),
+        Arc::new(ConfigStore::with_base(temp.path())),
+        fake_discovery(false),
+        HostName::new("local-host"),
+        backend.clone(),
+    )
+    .await;
+    let host_id = daemon.local_host_id().expect("local host identity").to_string();
+
+    let stale_source = ResourceBackend::InMemory(InMemoryBackend::default());
+    stale_source
+        .using::<ResourceHost>("flotilla")
+        .create(&empty_input_meta(&host_id), &HostSpec { display_name: "local-host".to_string() })
+        .await
+        .expect("stale self-origin host");
+    backend
+        .replica_writer::<ResourceHost>(daemon.node_id.clone(), "flotilla")
+        .replace(&stale_source.using::<ResourceHost>("flotilla").list().await.expect("stale host list"), Utc::now())
+        .await
+        .expect("seed stale self-origin replica");
+
+    let hosts = backend.using::<ResourceHost>("flotilla");
+    let local = hosts
+        .create(&empty_input_meta(&host_id), &HostSpec { display_name: "local-host".to_string() })
+        .await
+        .expect("authoritative local host");
+    hosts
+        .update_status(&host_id, &local.metadata.resource_version, &HostStatus {
+            disk_free_bytes: Some(100 * 1024 * 1024 * 1024),
+            admission_free_space_floor_bytes: Some(20 * 1024 * 1024 * 1024),
+            ..HostStatus::default()
+        })
+        .await
+        .expect("publish live local capacity");
+    backend
+        .using::<PlacementPolicy>("flotilla")
+        .create(
+            &empty_input_meta("self-targeted"),
+            &PlacementPolicySpec::builder()
+                .pool("passthrough".to_string())
+                .host_direct(HostDirectPlacementPolicySpec {
+                    host_ref: host_id.clone(),
+                    checkout: HostDirectPlacementPolicyCheckout::Worktree,
+                })
+                .build(),
+        )
+        .await
+        .expect("self-targeted placement policy");
+
+    daemon
+        .check_remote_placement_free_space_floor(
+            "flotilla",
+            Some(&PlacementDecision {
+                policy_name: "self-targeted".to_string(),
+                target_host: PlacementTargetHost { reference: host_id, display_name: "local-host".to_string() },
+                refused_candidates: Vec::new(),
+                viable_not_selected: Vec::new(),
+            }),
+        )
+        .await
+        .expect("healthy authoritative local capacity should admit self-targeted placement");
+}
+
+#[tokio::test]
 async fn standing_convoy_ensure_starts_restarts_with_backoff_and_recovers_from_reaping() {
     let temp = tempfile::tempdir().expect("tempdir");
     std::fs::write(temp.path().join("daemon.toml"), "machine_id = \"standing-test\"\n").expect("daemon config");

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -1691,7 +1691,7 @@ async fn crew_completion_partition_is_persisted_and_names_the_unreachable_author
 async fn dispatch_execute_keeps_remote_placement_convoy_on_the_admitting_store() {
     let (_tmp, daemon) = empty_daemon().await;
     let (_remote_tmp, remote_daemon) = empty_daemon_named("feta").await;
-    let remote_host_id = remote_daemon.local_host_id().expect("remote host identity").to_string();
+    let remote_host_id = "feta-host-id".to_string();
     let remote_hosts = remote_daemon.resource_backend().using::<Host>("flotilla");
     let remote_host = remote_hosts
         .create(&InputMeta::builder().name(remote_host_id.clone()).build(), &HostSpec::default())
@@ -1708,7 +1708,7 @@ async fn dispatch_execute_keeps_remote_placement_convoy_on_the_admitting_store()
         .expect("publish remote host capacity");
     daemon
         .resource_backend()
-        .replica_writer::<Host>(remote_daemon.node_id().clone(), "flotilla")
+        .replica_writer::<Host>(node("feta"), "flotilla")
         .replace(&remote_hosts.list().await.expect("list remote host resources"), chrono::Utc::now())
         .await
         .expect("replicate remote host capacity");

--- a/crates/flotilla-resources/src/backend.rs
+++ b/crates/flotilla-resources/src/backend.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeMap, marker::PhantomData};
+use std::{
+    collections::{BTreeMap, HashSet},
+    marker::PhantomData,
+};
 
 use chrono::{DateTime, Utc};
 use flotilla_protocol::NodeId;
@@ -160,7 +163,22 @@ impl<T: Resource> ReplicaReadResolver<T> {
                 .collect();
             return Ok(ReadResourceList { items });
         }
-        self.list_sources().await
+        let local_root = self.backend.local_root()?;
+        let mut listed = self.list_sources().await?;
+        let local_names = listed
+            .items
+            .iter()
+            .filter(|item| matches!(item.provenance, ResourceProvenance::Local))
+            .map(|item| item.object.metadata.name.clone())
+            .collect::<HashSet<_>>();
+        listed.items.retain(|item| {
+            !matches!(
+                &item.provenance,
+                ResourceProvenance::Replica { origin_root, .. }
+                    if origin_root == &local_root && local_names.contains(&item.object.metadata.name)
+            )
+        });
+        Ok(listed)
     }
 
     pub(crate) async fn list_sources(&self) -> Result<ReadResourceList<T>, ResourceError> {
@@ -198,7 +216,42 @@ impl<T: Resource> ReplicaReadResolver<T> {
         }
         let raw = self.watch_sources().await?;
         if T::REPLICATION_CLASS != crate::ReplicationClass::Definitions {
-            return Ok(raw);
+            let backend = self.backend.clone();
+            let namespace = self.namespace.clone();
+            let local_root = backend.local_root()?;
+            return Ok(raw
+                .filter_map(move |event| {
+                    let backend = backend.clone();
+                    let namespace = namespace.clone();
+                    let local_root = local_root.clone();
+                    async move {
+                        let event = match event {
+                            Ok(event) => event,
+                            Err(error) => return Some(Err(error)),
+                        };
+                        let self_origin_name = match &event {
+                            ReadWatchEvent::Added(item) | ReadWatchEvent::Modified(item) | ReadWatchEvent::Deleted(item) => matches!(
+                                &item.provenance,
+                                ResourceProvenance::Replica { origin_root, .. } if origin_root == &local_root
+                            )
+                            .then_some(item.object.metadata.name.as_str()),
+                            ReadWatchEvent::DeletedByName { tombstone, provenance } => matches!(
+                                provenance,
+                                ResourceProvenance::Replica { origin_root, .. } if origin_root == &local_root
+                            )
+                            .then_some(tombstone.name.as_str()),
+                        };
+                        let Some(name) = self_origin_name else {
+                            return Some(Ok(event));
+                        };
+                        match backend.using::<T>(&namespace).get(name).await {
+                            Ok(_) => None,
+                            Err(ResourceError::NotFound { .. }) => Some(Ok(event)),
+                            Err(error) => Some(Err(error)),
+                        }
+                    }
+                })
+                .boxed());
         }
         let backend = self.backend.clone();
         let namespace = self.namespace.clone();

--- a/crates/flotilla-resources/tests/common/contract.rs
+++ b/crates/flotilla-resources/tests/common/contract.rs
@@ -3,10 +3,10 @@ use std::{collections::BTreeSet, time::Duration};
 use chrono::Utc;
 use flotilla_protocol::ResourceRef;
 use flotilla_resources::{
-    delete_resource_kind, Convoy, Demand, DemandAddressee, DemandKind, DemandPoolRef, DemandSpec, InMemoryBackend, InputMeta, IssueSource,
-    OwnerReference, PrincipalRef, Project, ProjectRepositorySpec, ProjectSpec, Regard, RegardExpiryPolicy, RegardSource, RegardSpec,
-    RepositoryKey, Resource, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance, TypedResolver, WatchEvent, WatchStart,
-    WorkflowTemplate,
+    delete_resource_kind, Convoy, Demand, DemandAddressee, DemandKind, DemandPoolRef, DemandSpec, Host, HostSpec, HostStatus,
+    InMemoryBackend, InputMeta, IssueSource, OwnerReference, PrincipalRef, Project, ProjectRepositorySpec, ProjectSpec, Regard,
+    RegardExpiryPolicy, RegardSource, RegardSpec, RepositoryKey, Resource, ResourceBackend, ResourceError, ResourceObject,
+    ResourceProvenance, TypedResolver, WatchEvent, WatchStart, WorkflowTemplate,
 };
 use futures::StreamExt;
 use tokio::time::timeout;
@@ -352,6 +352,53 @@ pub async fn assert_missing_authority_delete_tombstones_replica_with_backend(bac
         delete_resource_kind(&backend, "flotilla", "convoys", "lost-at-authority").await.expect("repeat missing authority delete");
     assert!(repeated.already_deleted, "a retained name tombstone must make repeat deletion idempotent");
     assert!(timeout(Duration::from_millis(100), watch.next()).await.is_err(), "repeat deletion must not emit a fresh tombstone event");
+}
+
+pub async fn assert_local_authority_shadows_self_origin_replica_with_backend(backend: ResourceBackend) {
+    let local_root = flotilla_protocol::NodeId::new("local-root");
+    let backend = backend.with_local_root(local_root.clone());
+    let stale_source = ResourceBackend::InMemory(InMemoryBackend::default());
+    let stale_hosts = stale_source.using::<Host>("flotilla");
+    stale_hosts
+        .create(&InputMeta::builder().name("local-host".to_string()).build(), &HostSpec::default())
+        .await
+        .expect("create stale self-origin host");
+    backend
+        .replica_writer::<Host>(local_root, "flotilla")
+        .replace(&stale_hosts.list().await.expect("list stale self-origin host"), Utc::now())
+        .await
+        .expect("seed stale self-origin replica");
+
+    let hosts = backend.using::<Host>("flotilla");
+    let local = hosts
+        .create(&InputMeta::builder().name("local-host".to_string()).build(), &HostSpec::default())
+        .await
+        .expect("create authoritative local host");
+    hosts
+        .update_status(&local.metadata.name, &local.metadata.resource_version, &HostStatus {
+            disk_free_bytes: Some(100 * 1024 * 1024 * 1024),
+            admission_free_space_floor_bytes: Some(20 * 1024 * 1024 * 1024),
+            ..HostStatus::default()
+        })
+        .await
+        .expect("publish authoritative local capacity");
+
+    let visible = backend.including_replicas::<Host>("flotilla").list().await.expect("list converged host view");
+    assert_eq!(visible.items.len(), 1, "a stale self-origin replica must not remain visible beside local authority");
+    assert!(matches!(visible.items[0].provenance, ResourceProvenance::Local));
+    assert_eq!(visible.items[0].object.status.as_ref().and_then(|status| status.disk_free_bytes), Some(100 * 1024 * 1024 * 1024));
+
+    let mut visible_watch = backend.including_replicas::<Host>("flotilla").watch().await.expect("watch converged host view");
+    let stale = stale_hosts.get("local-host").await.expect("read stale self-origin host");
+    backend
+        .replica_writer::<Host>(flotilla_protocol::NodeId::new("local-root"), "flotilla")
+        .apply(WatchEvent::Modified(stale), Utc::now() + chrono::Duration::seconds(1))
+        .await
+        .expect("relay newer stale self-origin host");
+    assert!(
+        timeout(Duration::from_millis(100), visible_watch.next()).await.is_err(),
+        "a self-origin replica event must not overwrite the live local row"
+    );
 }
 
 pub async fn assert_watch_rejects_version_ahead_of_stream_with_backend(backend: ResourceBackend) {

--- a/crates/flotilla-resources/tests/in_memory.rs
+++ b/crates/flotilla-resources/tests/in_memory.rs
@@ -6,7 +6,8 @@ use common::{
     contract::{
         assert_consumer_relists_after_expired_watch_and_converges_with_backend, assert_create_get_list_roundtrip,
         assert_delete_emits_event, assert_identical_status_update_is_noop_with_backend, assert_identical_update_is_noop_with_backend,
-        assert_metadata_roundtrip, assert_missing_authority_delete_tombstones_replica_with_backend, assert_namespace_isolation,
+        assert_local_authority_shadows_self_origin_replica_with_backend, assert_metadata_roundtrip,
+        assert_missing_authority_delete_tombstones_replica_with_backend, assert_namespace_isolation,
         assert_project_definition_causal_merge_with_backend, assert_project_definition_delete_conflicts_with_concurrent_edit_with_backend,
         assert_project_definition_edit_converges_with_backend, assert_project_definition_edit_preserves_unrelated_conflict_with_backend,
         assert_project_definition_metadata_edit_converges_with_backend,
@@ -21,6 +22,11 @@ use common::{
     convoy_meta, convoy_spec,
 };
 use flotilla_resources::{Convoy, EventRetention, InMemoryBackend, ResourceBackend};
+
+#[tokio::test]
+async fn local_authority_shadows_self_origin_replica() {
+    assert_local_authority_shadows_self_origin_replica_with_backend(ResourceBackend::InMemory(InMemoryBackend::default())).await;
+}
 
 fn resolver(namespace: &str) -> flotilla_resources::TypedResolver<Convoy> {
     ResourceBackend::InMemory(InMemoryBackend::default()).using::<Convoy>(namespace)

--- a/crates/flotilla-resources/tests/sqlite.rs
+++ b/crates/flotilla-resources/tests/sqlite.rs
@@ -12,9 +12,10 @@ use common::{
     contract::{
         assert_consumer_relists_after_expired_watch_and_converges_with_backend, assert_create_get_list_roundtrip_with_backend,
         assert_delete_emits_event_with_backend, assert_identical_status_update_is_noop_with_backend,
-        assert_identical_update_is_noop_with_backend, assert_metadata_roundtrip_with_backend,
-        assert_missing_authority_delete_tombstones_replica_with_backend, assert_namespace_isolation_with_backend,
-        assert_project_definition_causal_merge_with_backend, assert_project_definition_delete_conflicts_with_concurrent_edit_with_backend,
+        assert_identical_update_is_noop_with_backend, assert_local_authority_shadows_self_origin_replica_with_backend,
+        assert_metadata_roundtrip_with_backend, assert_missing_authority_delete_tombstones_replica_with_backend,
+        assert_namespace_isolation_with_backend, assert_project_definition_causal_merge_with_backend,
+        assert_project_definition_delete_conflicts_with_concurrent_edit_with_backend,
         assert_project_definition_edit_converges_with_backend, assert_project_definition_edit_preserves_unrelated_conflict_with_backend,
         assert_project_definition_metadata_edit_converges_with_backend,
         assert_project_definition_optional_field_can_be_cleared_with_backend,
@@ -41,6 +42,11 @@ use tokio::time::{timeout, Duration};
 
 fn backend() -> ResourceBackend {
     ResourceBackend::Sqlite(SqliteBackend::open_in_memory().expect("sqlite backend should open"))
+}
+
+#[tokio::test]
+async fn local_authority_shadows_self_origin_replica() {
+    assert_local_authority_shadows_self_origin_replica_with_backend(backend()).await;
 }
 
 #[test]


### PR DESCRIPTION
## What changed

- suppress self-origin replica rows when the same resource name has a live locally authoritative record
- suppress matching self-origin watch events while local authority exists
- make self-targeted capacity admission read the local Host status exclusively
- cover the convergence contract on both in-memory and SQLite stores and reproduce admission through `InProcessDaemon`

## Why

The overlay read layer emitted both a live local Host and a stale replica of that same Host from the daemon's own origin partition. Admission could then select stale pre-schema capacity data, and list/watch consumers saw duplicate records.

## Impact

Self-targeted placement uses current authoritative capacity. Stale self-origin replicas remain durable internally but cannot shadow or overwrite a live local record in list/watch views. Replicas from genuinely remote origins remain visible.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- `cargo test -p flotilla-core --locked --features test-support --test in_process_daemon`

Closes #1465
