### PR TITLE
docs: adopt ADRs 0030 (standing agents) and 0031 (plane-a retirement)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -238,7 +238,17 @@ Appears in the `independents` query and nowhere else; joining a Convoy removes
 it there (convoy-bound sessions surface on vessel rows instead), so nothing is
 ever double-listed.
 _Avoid_: Session (maximally overloaded — cloud agents, cleat, tmux, zellij all
-claim it), free-floating session, loose session.
+claim it), free-floating session, loose session. Do not use for ensure-declared
+services — that is a **Standing Convoy**.
+
+**Standing Convoy**:
+A **Convoy** declared by an `ensure` ops entry whose workflow omits `exit`:
+the ensure loop maintains its presence — starting it, force-restarting it on
+failure with backoff — until the entry is removed and the project refreshed
+(ADR 0027, ADR 0030). Its crew serves operator turns; the first instance is
+the andamento **Governor**.
+_Avoid_: Independent (reserved for convoy-less terminal sessions), service,
+daemon-agent.
 
 **External Result**:
 An artifact a **Convoy** produces in an external service — a PR, a CMS article, a

--- a/docs/adr/0030-the-first-standing-agent-is-a-governor-entry-point.md
+++ b/docs/adr/0030-the-first-standing-agent-is-a-governor-entry-point.md
@@ -1,0 +1,118 @@
+# The first standing agent is a governor, and it is an entry point before it is a loop
+
+**Status:** Accepted
+**Date:** 2026-08-13
+**Relates to:** ADR 0009 (PersistentAgent roles — the Governor this ADR
+materializes first), ADR 0017 (settlement planes the charter enforces),
+ADR 0027 (the workflow substrate whose `ensure` entries declare standing
+convoys), ADR 0028 (the delivery ladder this ADR's restart ruling composes
+with), #1412 (usage-observer thread where governor-first was ruled), #1440
+(the chartering grill — all six rulings), #1442 (busy-crew message delivery,
+the open delivery question this shape promotes), #1428 (the ensure mechanism).
+
+## Context
+
+The ensure mechanism (ADR 0027, #1428) made standing convoys declarable, and
+the usage observer (#1412) was nearly its first user: a tool-crewed poller
+patching one resource's status on a five-minute cadence. Two objections
+stopped it. First, its semantics turned out to be substantial design work
+about *usage* — gauge-versus-telemetry, coalescing, multi-writer ordering,
+subject identity — none of which taught us anything about standing agents.
+Second, and sharper: a substrate's first user shapes it. A no-judgment poller
+would have tuned the ensure mechanism toward "cadenced script patching a
+status" while leaving untested everything standing agents exist for — agent
+crews, memory across restarts, tracker-writing authority, credential
+delivery.
+
+Meanwhile the Governor role (ADR 0009, `docs/charters/governor.md`) had
+accumulated the deepest manual practice of any persistent-agent role: an
+operator-plus-agent session had been performing it across weeks of dogfood —
+dispatching, settling, chivvying, recording rulings — with the charter
+already encoding its authority model, settlement discipline, and escalation
+list.
+
+## Decision
+
+**The first standing agent is a Governor for a non-platform island, run as a
+standing convoy, and it is an entry point the operator talks to — not a
+scheduled loop.**
+
+### Governor-first, on someone else's island
+
+The first governed island is **andamento**, not flotilla. A flotilla-scoped
+governor is meta-circular during substrate churn: fleet bumps restart its own
+daemon beneath it, no-compat wire changes invalidate its CLI mid-turn, and
+the ensure mechanism it stands on is itself under construction. Flotilla's
+own governor arrives once the mechanism is boring. Andamento is the
+representative case: its work does not touch the platform, it has a live
+ticket queue and its own CI gates, and — since most flotillas will steward
+work unrelated to flotilla itself — the unrelated island is the general
+case, not the exception. (A cold-start island with no convoy history is the
+natural *second* entry.)
+
+The usage observer is demoted to a background entry added later; its merged
+artifacts (the Usage record shape, the generic status-patch verb, the
+workload-script pattern) stand regardless.
+
+### Entry point before loop
+
+The first-cut governor has no scheduler and no wake cadence. On start it runs
+**one read-only orientation sweep** (fleet state, open PRs, ready queue) and
+posts a short on-station report; then it idles, and every mutating action is
+an operator-initiated turn. Scheduled behaviour arrives later as *additional
+input sources into the same standing session* — first watches over in-flight
+work, then event-driven wakes — because operator conversation is expected to
+remain a major share of interactions even in the proactive era. The ensure
+loop's whole job in this cut is presence.
+
+### The record is the memory
+
+A restarted governor knows the charter and what the durable record tells it:
+tracker issues, ruling comments, ADRs, fleet surfaces. No private state
+survives restart — no memory directory, no transcript continuation — in the
+first cut. This composes with ADR 0028's delivery ladder rather than
+replacing it: upper rungs (warm session, adapter resume) restore
+conversational comfort when available, but the **bottom rung — fresh agent,
+reconstructed brief — must be sufficient**. Anything whose loss would hurt at
+the bottom rung belonged on the record, so a painful restart indicts the
+recording discipline, not the mechanism. This is also the honest test of
+that discipline, which the charter already mandates (rulings land when made;
+bodies are contracts).
+
+### Layered charter
+
+The platform charter (`docs/charters/governor.md`) is generic — one island,
+seven verbs, settlement planes — and is *referenced, not copied* by the
+standing brief. Project-specific guidance (CI gates, priorities, house
+conventions) lives in the island's ops member, which the standing brief
+points into: "look in your ops repo for X."
+
+### Crewing and placement
+
+The workflow names a **capability** (`governor`), not a harness; seeding
+binds it to an adapter and model per host. Model choice follows judgment
+density: the governor is the most judgment-concentrated, lowest-volume role
+in the fleet, so it gets the strongest planner available (fable at time of
+writing), with per-island and budget-driven adaptivity as trajectory, not
+cut-one machinery. Stance is contained; placement is an always-on host —
+never a desk machine whose lid couples governor liveness. Placement is free
+because dispatch works from any credentialed host (ADR 0031's
+rank-retirement).
+
+## Consequences
+
+- The ensure mechanism's first real exerciser tests presence, restart
+  sufficiency, agent crewing, and credential delivery — not cadence tuning.
+- Message delivery to a busy standing crew becomes a primary interface
+  question rather than a resume edge case; #1442 (refuse vs queue vs steer)
+  is promoted accordingly.
+- The on-station report makes restarts self-evidencing: a restart-looping
+  governor is visible as a timestamped series, without inspecting backoff
+  internals.
+- **Terminology:** the ensure-declared service is a **standing convoy**.
+  "Independent" is *not* used for it — that term is reserved by the glossary
+  for terminal sessions with no convoy association.
+- The flotilla-island governor, transcript-carrying restarts, memory
+  directories, and scheduled wakes are all deliberate deferrals, each with a
+  named trigger (mechanism boring; bottom rung shown insufficient; a restart
+  that loses something the tracker couldn't have held; the proactive phase).

--- a/docs/adr/0031-plane-a-retires-rank-dies-with-polling.md
+++ b/docs/adr/0031-plane-a-retires-rank-dies-with-polling.md
@@ -1,0 +1,94 @@
+# Plane A retires: rank dies with polling, and the store keeps what survives disconnection
+
+**Status:** Accepted
+**Date:** 2026-08-13
+**Relates to:** the roadmap (phases 3–4, which this ADR schedules and
+sharpens), ADR 0025 (store authority and federated actuation — the admission
+model that made "leader" unnecessary), ADR 0029 (demand-bound observation —
+the direction on-demand reads align with), #1432 (external-provider
+decoupling), #1457/#1458/#1459 (the cull slices), #885/#1169 (the original
+single-poller rationale that became follower mode).
+
+## Context
+
+Plane A — providers → correlation → WorkItems → snapshots → the repo page —
+was frozen (roadmap phase 0) while the control plane grew underneath it. By
+2026-08 the straddle had stopped paying: the operator had not initiated
+Plane-A work for a week, convoys carried all real work, and the repo page
+went unread. The straddle's cost surfaced concretely when governor placement
+(ADR 0030) hit `this host runs in follower mode; dispatch from a leader
+host` — a refusal whose rationale, on inspection, belonged entirely to the
+frozen plane.
+
+The `follower` flag suppressed construction of *all* external service
+providers on non-leader hosts. That single gate conflated three orthogonal
+things: continuous polling (the #885 don't-poll-GitHub-three-times concern —
+a Plane-A observation need), on-demand external reads (one API call at
+dispatch time), and admission (already leaderless: ADR 0025 puts each convoy
+on its admitting host's store, single writer per store).
+
+## Decision
+
+**Plane A is deleted, not merely frozen, in a ruled sequence; "leader" and
+"follower" are retired as concepts; and the store's boundary is fixed: it
+keeps what must survive disconnection, and nothing whose truth is the live
+link.**
+
+### Rank dies with polling
+
+Hosts differ by **capability, not rank**. External service providers are
+constructed on every host whose environment supports them (credentials,
+binaries); a host that cannot is reported by the missing capability's name,
+never by rank. On-demand reads — issue resolution at dispatch, PR state —
+work anywhere (aligned with ADR 0029's demand-bound direction). Continuous
+polling remains singleton only until the observer deletion removes polling
+altogether, at which point the `follower` flag evaporates. (#1432, landed.)
+
+### The deletion sequence
+
+1. **Repo page** (#1457, landed): the interactive WorkItem surfaces leave the
+   TUI; resource-fed project/query tabs are the surviving surface.
+2. **Observer pipeline** (#1458): correlation/union-find, `WorkItem`, the
+   `ProviderData → WorkItem → Snapshot` pipeline, provider polling, the
+   last WorkItem-consuming CLI commands (`repo detail`, `repo work` —
+   operator-confirmed), and the follower flag. Subsystems with mixed
+   consumers (attachables, RepoModel) are audited and split, not bulldozed.
+3. **Peer-merge** (#1459): the PeerData snapshot-merge subsystem goes; the
+   shared socket transport stays, carrying overlay resource replication — the
+   precursor shape for the Tender extraction, which remains out of scope
+   until boundary-proven.
+
+### The store boundary
+
+**If it must survive disconnection to be useful, it is a resource; if its
+truth is the live link, it is transport-state.** Host facts — capacity,
+floors, adapter availability — are resources (they feed disconnected
+admission and replicate with bounded staleness). Peer connectivity, dial
+direction, and routing are link-state, consulted live at the point of use
+and never stored: a replicated "connected" record is exactly the stale claim
+the settlement discipline (ADR 0017) exists to distrust.
+
+### Deletion contracts escalate
+
+Every cull contract carries a binding escalation rule: discovering a live
+surviving-plane consumer of something slated for deletion is an escalation —
+stop that piece, report the dependency path, continue with the rest. No
+shims, no improvised re-homings. **An incomplete deletion is acceptable;
+breaking used surviving-plane behavior is not.** (#1457 validated the rule
+immediately: two live dependencies found, reported, preserved.)
+
+## Consequences
+
+- Dispatch, and therefore governor placement (ADR 0030), is host-agnostic;
+  provisioning a host is adding capabilities, not conferring rank.
+- The TUI becomes a pure Surface over resources and the view-model layer;
+  the extraction path in the roadmap's phase 6 loses its Plane-A
+  entanglement.
+- The peer transport survives as deliberately unglamorous plumbing with a
+  clean link-state interface — what the Tender inherits later.
+- Store surgery residue (stale self-origin replicas, abandoned finalizers —
+  the #1422 lineage) shrinks as the merge-era write paths disappear; the
+  raw-delete recovery path stays as the operator's sharp tool.
+- The roadmap's phase 3–4 ordering is now enacted rather than aspirational;
+  correlation returns, if ever, as an on-demand Aggregator utility over
+  observed resources — not as a pipeline.

--- a/docs/project-declarations.md
+++ b/docs/project-declarations.md
@@ -101,7 +101,7 @@ presents-as: fleet
 `placement`, `stance`, and `presents-as` are optional. A stance preference
 overrides every vessel in the pinned workflow snapshot. `presents-as` is only
 a presentation annotation; `fleet` has no special scope semantics. Fleet-level
-independents are declared by convention in the fleet project.
+standing convoys are declared by convention in the fleet project.
 
 The ensure loop starts a missing convoy and restarts a failed or explicitly
 reaped convoy with exponential backoff. Convoy metadata records the entry name,


### PR DESCRIPTION
Consolidates the 2026-08-11→13 rulings into two ADRs, discharging the ADR-carry lines on #1412, #1432, #1440, and #1459:

**ADR 0030 — The first standing agent is a governor, and it is an entry point before it is a loop.** Governor-first on a non-platform island (andamento; meta-circularity deferral for flotilla's own island), entry-point-before-loop (orient-then-idle, no scheduler), record-is-memory as *floor-rung sufficiency* composing with ADR 0028's delivery ladder, layered charter (platform charter referenced + ops-member guidance), capability-selected crewing on an always-on host.

**ADR 0031 — Plane A retires: rank dies with polling, and the store keeps what survives disconnection.** Leader/follower retired (capability, not rank; construction everywhere, polling singleton until deleted — #1432, landed), the ruled three-slice deletion sequence (#1457 landed / #1458 in flight / #1459 queued), the store boundary (survives-disconnection → resource; truth-is-the-link → transport-state), and the binding escalation rule for deletion contracts.

Glossary: adds **Standing Convoy** to CONTEXT.md and reserves **Independent** for convoy-less terminal sessions (resolving the collision); aligns one wording in docs/project-declarations.md.

https://claude.ai/code/session_01P3eF4i73CQk8zWVKBVArKp
