### PR TITLE
fix: canonicalize placement host references

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/presentation.rs
+++ b/crates/flotilla-controllers/src/reconcilers/presentation.rs
@@ -31,6 +31,18 @@ use tracing::warn;
 
 type RegistryLookup = dyn Fn(&str) -> Result<Arc<ProviderRegistry>, String> + Send + Sync;
 
+fn canonical_host_ref(hosts: &[ResourceObject<Host>], host_ref: &str) -> Result<String, String> {
+    if hosts.iter().any(|host| host.metadata.name == host_ref) {
+        return Ok(host_ref.to_string());
+    }
+    let mut matching = hosts.iter().filter(|host| host.spec.display_name == host_ref);
+    let host = matching.next().ok_or_else(|| format!("host {host_ref} lookup failed: not found"))?;
+    if matching.any(|candidate| candidate.metadata.name != host.metadata.name) {
+        return Err(format!("host reference {host_ref} is ambiguous"));
+    }
+    Ok(host.metadata.name.clone())
+}
+
 #[async_trait]
 pub trait PresentationRuntime: Send + Sync {
     async fn apply(&self, plan: &PresentationPlan) -> Result<AppliedPresentation, ApplyPresentationError>;
@@ -232,6 +244,11 @@ impl<R> PresentationReconciler<R> {
         vec![Box::new(LabelJoinWatch::<TerminalSession, Presentation> { label_key: CONVOY_LABEL, _marker: PhantomData })]
     }
 
+    async fn canonical_host_ref(&self, host_ref: &str) -> Result<String, String> {
+        let hosts = self.hosts.list().await.map_err(|error| format!("host list failed: {error}"))?;
+        canonical_host_ref(&hosts.items, host_ref)
+    }
+
     async fn resolve_process(&self, session: &ResourceObject<TerminalSession>) -> Result<ResolvedProcess, String> {
         let environment = self
             .environments
@@ -245,7 +262,7 @@ impl<R> PresentationReconciler<R> {
             .map(|spec| spec.host_ref.as_str())
             .or_else(|| environment.spec.docker.as_ref().map(|spec| spec.host_ref.as_str()))
             .ok_or_else(|| format!("environment {} has no host binding", session.spec.env_ref))?;
-        self.hosts.get(host_ref).await.map_err(|err| format!("host {} lookup failed: {err}", host_ref))?;
+        let host_ref = self.canonical_host_ref(host_ref).await?;
 
         let registry = self.hop_chain.registry_for_env(&session.spec.env_ref)?;
         let pool = registry
@@ -257,13 +274,13 @@ impl<R> PresentationReconciler<R> {
         let session_cwd = ExecutionEnvironmentPath::new(&session.spec.cwd);
         let attach_target = flotilla_resources::terminal_session_attach_target(session)?;
         let attach_args = pool.attach_args(attach_target.session_id, attach_target.launch_command, &session_cwd, &Vec::new())?;
-        let attach_command = self.build_attach_command(session, &environment, host_ref, attach_args)?;
+        let attach_command = self.build_attach_command(session, &environment, &host_ref, attach_args)?;
 
         Ok(ResolvedProcess {
             role: session.spec.role.clone(),
             labels: session.metadata.labels.clone(),
             attach_command,
-            host: self.hop_chain.target_host(host_ref),
+            host: self.hop_chain.target_host(&host_ref),
         })
     }
 
@@ -613,10 +630,44 @@ fn session_sort_key(session: &ResourceObject<TerminalSession>) -> (&str, &str, &
 
 #[cfg(test)]
 mod tests {
-    use super::yaml_string;
+    use std::collections::BTreeMap;
+
+    use chrono::Utc;
+    use flotilla_resources::{HostSpec, ObjectMeta};
+
+    use super::{canonical_host_ref, yaml_string, HopChainContext, Host, HostName, ResourceObject};
 
     #[test]
     fn yaml_string_escapes_control_characters() {
         assert_eq!(yaml_string("role\n\r\t\"\\\u{7}"), "\"role\\n\\r\\t\\\"\\\\\\u0007\"");
+    }
+
+    #[test]
+    fn presentation_routes_local_display_name_alias_without_ssh() {
+        let hosts = [ResourceObject::<Host> {
+            metadata: ObjectMeta {
+                name: "local-host-id".to_string(),
+                namespace: "flotilla".to_string(),
+                resource_version: "1".to_string(),
+                labels: BTreeMap::new(),
+                annotations: BTreeMap::new(),
+                owner_references: Vec::new(),
+                finalizers: Vec::new(),
+                deletion_timestamp: None,
+                creation_timestamp: Utc::now(),
+                merge: None,
+            },
+            spec: HostSpec { display_name: "local-host".to_string() },
+            status: None,
+        }];
+        let canonical = canonical_host_ref(&hosts, "local-host").expect("resolve display-name alias");
+        let context = HopChainContext::new(
+            "local-host-id",
+            HostName::new("local-host"),
+            flotilla_core::path_context::DaemonHostPath::new("/tmp"),
+            |_| Err("registry is not used by host routing".to_string()),
+        );
+
+        assert_eq!(context.target_host(&canonical), HostName::new("local-host"));
     }
 }

--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -157,6 +157,16 @@ enum PlacementStrategy {
     },
 }
 
+impl PlacementStrategy {
+    fn canonicalize_host_ref(&mut self, host_ref: &str) {
+        match self {
+            Self::HostDirect { host_ref: strategy_host_ref, .. }
+            | Self::DockerWorktreeOnHostAndMount { host_ref: strategy_host_ref, .. }
+            | Self::DockerFreshCloneInContainer { host_ref: strategy_host_ref, .. } => host_ref.clone_into(strategy_host_ref),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 enum PlannedPatch {
     None,
@@ -284,10 +294,13 @@ impl Reconciler for VesselReconciler {
             }
             Err(err) => return Err(err),
         };
-        let strategy = match placement_strategy(&placement_policy.spec) {
+        let mut strategy = match placement_strategy(&placement_policy.spec) {
             Ok(strategy) => strategy,
             Err(message) => return Ok(VesselDeps::failed(message)),
         };
+        if let Some(decision) = placement_decision.as_ref() {
+            strategy.canonicalize_host_ref(&decision.target_host.reference);
+        }
         let declared_agent_adapters =
             placement_policy.spec.docker_per_vessel.as_ref().map(|docker| docker.agent_adapters.clone()).unwrap_or_default();
 
@@ -1366,9 +1379,15 @@ mod tests {
     };
 
     use flotilla_protocol::{PlacementDecision, PlacementTargetHost};
-    use flotilla_resources::{Convoy, ConvoySpec, InputMeta, ResourceBackend};
+    use flotilla_resources::{
+        Convoy, ConvoySpec, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, InputMeta, PlacementPolicySpec,
+        ResourceBackend,
+    };
 
-    use super::{checkout_name, checkout_placement_scope, environment_with_credentials, legible_waiting_for, VesselReconciler};
+    use super::{
+        checkout_name, checkout_placement_scope, environment_with_credentials, legible_waiting_for, placement_strategy, PlacementStrategy,
+        VesselReconciler,
+    };
 
     #[derive(Clone)]
     struct LogCaptureWriter(Arc<Mutex<Vec<u8>>>);
@@ -1426,6 +1445,31 @@ mod tests {
             legible_waiting_for("checkout checkout-01HXYZ to become ready".to_string(), Some(&decision)),
             "checkout checkout-01HXYZ to become ready",
             "unrelated names containing the host ref must not be rewritten"
+        );
+    }
+
+    #[test]
+    fn placement_strategy_replaces_display_name_alias_with_canonical_host_reference() {
+        let policy = PlacementPolicySpec::builder()
+            .pool("cleat".to_string())
+            .host_direct(HostDirectPlacementPolicySpec {
+                host_ref: "udder".to_string(),
+                checkout: HostDirectPlacementPolicyCheckout::Worktree,
+            })
+            .build();
+        let decision = PlacementDecision {
+            policy_name: "host-direct-udder".to_string(),
+            target_host: PlacementTargetHost { reference: "1c8df992".to_string(), display_name: "udder".to_string() },
+            refused_candidates: Vec::new(),
+            viable_not_selected: Vec::new(),
+        };
+        let mut strategy = placement_strategy(&policy).expect("host-direct policy should produce a placement strategy");
+
+        strategy.canonicalize_host_ref(&decision.target_host.reference);
+
+        assert!(
+            matches!(strategy, PlacementStrategy::HostDirect { ref host_ref, .. } if host_ref == "1c8df992"),
+            "placement strategy should carry the canonical host reference from the decision"
         );
     }
 

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -50,8 +50,8 @@ use flotilla_resources::{
     HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus, InMemoryBackend, InputMeta, InputValue, IntegrationCondition,
     IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable, LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec,
     PlacementPolicy, PlacementPolicySpec, Presentation as ResourcePresentation, Project, ProjectRepositoryRole, ProjectRepositorySpec,
-    ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance,
-    SettlementMode, SystemClock, TerminalAttentionState, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
+    ProjectSpec, ReadResourceObject, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError, ResourceObject,
+    ResourceProvenance, SettlementMode, SystemClock, TerminalAttentionState, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
     TerminalSession as ResourceTerminalSession, TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase,
     TerminalSessionSource, TerminalSessionStatus, TerminalSessionStatusPatch, TurnDeliveryRung, UnmetSettlementExpectation, Vessel,
     WatchEvent, WatchStart, WorkCompletionAuthority, WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec,
@@ -1166,15 +1166,56 @@ async fn placement_target_host(
     policy: &ResourceObject<PlacementPolicy>,
 ) -> Result<PlacementTargetHost, String> {
     let host_ref = placement_host_ref(policy).ok_or_else(|| format!("placement `{}` has no target host", policy.metadata.name))?;
-    let display_name = backend
-        .clone()
-        .using::<ResourceHost>(namespace)
-        .get(host_ref)
+    canonical_placement_host_ref(backend, namespace, host_ref)
         .await
-        .ok()
-        .and_then(|host| (!host.spec.display_name.is_empty()).then_some(host.spec.display_name))
-        .unwrap_or_else(|| host_ref.to_string());
-    Ok(PlacementTargetHost { reference: host_ref.to_string(), display_name })
+        .and_then(|target| target.ok_or_else(|| format!("references unknown host `{host_ref}`")))
+        .map_err(|error| format!("placement `{}` {error}", policy.metadata.name))
+}
+
+async fn canonical_placement_host_ref(
+    backend: &ResourceBackend,
+    namespace: &str,
+    host_ref: &str,
+) -> Result<Option<PlacementTargetHost>, String> {
+    let hosts = backend.including_replicas::<ResourceHost>(namespace).list().await.map_err(|error| error.to_string())?;
+    canonical_placement_host_ref_from_sources(&hosts.items, host_ref)
+}
+
+fn canonical_placement_host_ref_from_sources(
+    hosts: &[ReadResourceObject<ResourceHost>],
+    host_ref: &str,
+) -> Result<Option<PlacementTargetHost>, String> {
+    let exact = hosts.iter().find(|host| host.object.metadata.name == host_ref);
+    let resolved = if let Some(host) = exact {
+        host
+    } else {
+        let mut matching = hosts.iter().filter(|host| host.object.spec.display_name == host_ref);
+        let Some(host) = matching.next() else {
+            return Ok(None);
+        };
+        if matching.any(|candidate| candidate.object.metadata.name != host.object.metadata.name) {
+            return Err(format!("host reference `{host_ref}` is ambiguous"));
+        }
+        host
+    };
+    let display_name = if resolved.object.spec.display_name.is_empty() {
+        resolved.object.metadata.name.clone()
+    } else {
+        resolved.object.spec.display_name.clone()
+    };
+    Ok(Some(PlacementTargetHost { reference: resolved.object.metadata.name.clone(), display_name }))
+}
+
+fn check_placement_capacity(target_host: &PlacementTargetHost, capacity: Option<(u64, Option<u64>)>) -> Result<(), String> {
+    let Some((floor_bytes, free_bytes)) = capacity else {
+        return Err(format!("placement refused on host `{}`: admission free-space floor is unavailable", target_host.display_name));
+    };
+    if floor_bytes == 0 {
+        return Ok(());
+    }
+    let free_bytes =
+        free_bytes.ok_or_else(|| format!("placement refused on host `{}`: free space is unavailable", target_host.display_name))?;
+    crate::admission::check_measured_free_space(&target_host.display_name, free_bytes, floor_bytes)
 }
 
 async fn default_convoy_placement_policy(
@@ -1212,20 +1253,35 @@ async fn default_convoy_placement_policy(
             viable.push(policy);
         }
     }
+    let mut viable_targets = HashMap::new();
+    let mut resolved_viable = Vec::with_capacity(viable.len());
+    for policy in viable {
+        match placement_target_host(backend, namespace, &policy).await {
+            Ok(target_host) => {
+                viable_targets.insert(policy.metadata.name.clone(), target_host);
+                resolved_viable.push(policy);
+            }
+            Err(reason) => refused_candidates.push(PlacementRefusal {
+                policy_name: policy.metadata.name.clone(),
+                target_host: PlacementTargetHost { reference: String::new(), display_name: "no target host".to_string() },
+                reason,
+            }),
+        }
+    }
+    viable = resolved_viable;
     viable.sort_by_key(|policy| {
-        let target_host = placement_host_ref(policy);
-        let is_local = local_host_ref.is_some_and(|local| target_host == Some(local));
+        let target_host = &viable_targets[&policy.metadata.name].reference;
+        let is_local = local_host_ref.is_some_and(|local| target_host == local);
         let is_host_direct = policy.spec.host_direct.is_some();
         (Reverse(policy.spec.priority), !is_local, !is_host_direct, policy.metadata.name.clone())
     });
     if !viable.is_empty() {
         let selected = viable.remove(0);
+        let selected_target = viable_targets.remove(&selected.metadata.name).expect("viable placement target was resolved");
         let mut viable_not_selected = Vec::with_capacity(viable.len());
         for policy in viable {
-            let target_host = placement_target_host(backend, namespace, &policy)
-                .await
-                .unwrap_or_else(|_| PlacementTargetHost { reference: String::new(), display_name: "no target host".to_string() });
-            let reason = placement_ordering_reason(&selected, &policy, local_host_ref);
+            let target_host = viable_targets.remove(&policy.metadata.name).expect("viable placement target was resolved");
+            let reason = placement_ordering_reason(&selected, &selected_target, &policy, &target_host, local_host_ref);
             viable_not_selected.push(PlacementViableCandidate { policy_name: policy.metadata.name.clone(), target_host, reason });
         }
         return Ok(PlacementResolution { selected: Some(selected), refused_candidates, viable_not_selected });
@@ -1250,7 +1306,9 @@ async fn default_convoy_placement_policy(
 
 fn placement_ordering_reason(
     selected: &ResourceObject<PlacementPolicy>,
+    selected_target: &PlacementTargetHost,
     candidate: &ResourceObject<PlacementPolicy>,
+    candidate_target: &PlacementTargetHost,
     local_host_ref: Option<&str>,
 ) -> String {
     if candidate.spec.priority != selected.spec.priority {
@@ -1260,10 +1318,8 @@ fn placement_ordering_reason(
         );
     }
 
-    let selected_host = placement_host_ref(selected);
-    let candidate_host = placement_host_ref(candidate);
-    let selected_is_local = local_host_ref.is_some_and(|local| selected_host == Some(local));
-    let candidate_is_local = local_host_ref.is_some_and(|local| candidate_host == Some(local));
+    let selected_is_local = local_host_ref.is_some_and(|local| selected_target.reference == local);
+    let candidate_is_local = local_host_ref.is_some_and(|local| candidate_target.reference == local);
     if selected_is_local && !candidate_is_local {
         return format!("fallback ordering preferred local policy `{}`", selected.metadata.name);
     }
@@ -2874,13 +2930,14 @@ impl InProcessDaemon {
             .get(policy_name)
             .await
             .map_err(|error| format!("placement policy {policy_name}: {error}"))?;
-        let Some(host_direct) = policy.spec.host_direct else {
-            return Ok(None);
-        };
-        if self.local_host_id().as_ref().is_some_and(|host_id| host_id.as_str() == host_direct.host_ref) {
+        if policy.spec.host_direct.is_none() {
             return Ok(None);
         }
-        Ok(Some(flotilla_protocol::qualified_path::HostId::new(host_direct.host_ref)))
+        let target_host = placement_target_host(&self.resource_backend, namespace, &policy).await?;
+        if self.local_host_id().as_ref().is_some_and(|host_id| host_id.as_str() == target_host.reference) {
+            return Ok(None);
+        }
+        Ok(Some(flotilla_protocol::qualified_path::HostId::new(target_host.reference)))
     }
 
     pub async fn resolve_existing_convoy_target(
@@ -4279,20 +4336,14 @@ async fn validate_workflow_credentials(
     let placement = placement.ok_or_else(|| {
         format!("workflow requires credential `{}`, but no placement is available", required.first().expect("required is non-empty"))
     })?;
-    let host_ref = placement
-        .spec
-        .docker_per_vessel
-        .as_ref()
-        .map(|docker| docker.host_ref.as_str())
-        .or_else(|| placement.spec.host_direct.as_ref().map(|host| host.host_ref.as_str()))
-        .ok_or_else(|| format!("placement `{}` has no credential-bearing host", placement.metadata.name))?;
+    let target_host = placement_target_host(backend, namespace, placement).await?;
     let host = backend
         .clone()
         .using::<ResourceHost>(namespace)
-        .get(host_ref)
+        .get(&target_host.reference)
         .await
         .map_err(|error| format!("placement `{}` target host is not ready: {error}", placement.metadata.name))?;
-    let host_label = if host.spec.display_name.is_empty() { host_ref.to_string() } else { host.spec.display_name.clone() };
+    let host_label = target_host.display_name;
     let mut status =
         host.status.ok_or_else(|| format!("placement `{}` host `{host_label}` has no observed status", placement.metadata.name))?;
     status.apply_heartbeat_readiness(Utc::now());
@@ -4392,14 +4443,15 @@ async fn placement_agent_adapters(
 ) -> Result<(BTreeSet<String>, String), String> {
     if let Some(docker) = &placement.spec.docker_per_vessel {
         Ok((docker.agent_adapters.clone(), format!("image `{}`", docker.image)))
-    } else if let Some(host_direct) = &placement.spec.host_direct {
+    } else if placement.spec.host_direct.is_some() {
+        let target_host = placement_target_host(backend, namespace, placement).await?;
         let host = backend
             .clone()
             .using::<ResourceHost>(namespace)
-            .get(&host_direct.host_ref)
+            .get(&target_host.reference)
             .await
             .map_err(|error| format!("placement `{}` target host is not ready: {error}", placement.metadata.name))?;
-        let host_label = if host.spec.display_name.is_empty() { host_direct.host_ref.clone() } else { host.spec.display_name.clone() };
+        let host_label = target_host.display_name;
         let mut status =
             host.status.ok_or_else(|| format!("placement `{}` host `{host_label}` has no observed status", placement.metadata.name))?;
         status.apply_heartbeat_readiness(Utc::now());
@@ -5010,15 +5062,7 @@ impl InProcessDaemon {
                 .filter_map(|source| source.object.status)
                 .find_map(|status| status.admission_free_space_floor_bytes.map(|floor| (floor, status.disk_free_bytes)))
         };
-        let Some((floor_bytes, free_bytes)) = capacity else {
-            return Err(format!("placement refused on host `{}`: admission free-space floor is unavailable", target_host.display_name));
-        };
-        if floor_bytes == 0 {
-            return Ok(());
-        }
-        let free_bytes =
-            free_bytes.ok_or_else(|| format!("placement refused on host `{}`: free space is unavailable", target_host.display_name))?;
-        crate::admission::check_measured_free_space(&target_host.display_name, free_bytes, floor_bytes)
+        check_placement_capacity(target_host, capacity)
     }
 
     async fn create_convoy_with_workflow_snapshot(
@@ -7743,6 +7787,8 @@ impl InProcessDaemon {
         let observed_checkouts = self.observed_resource_backend.clone().using::<ResourceCheckout>(namespace);
 
         let session_list = terminal_sessions.list().await.map_err(|err| err.to_string())?;
+        let host_sources =
+            self.resource_backend.including_replicas::<ResourceHost>(namespace).list().await.map_err(|err| err.to_string())?;
         let observed_generation = observed_checkouts.list().await.map_err(|err| err.to_string())?.generation;
         let result_sets = self.aggregator_projection_state().await.local_result_sets().await;
         let placement_by_convoy = result_sets
@@ -7810,11 +7856,18 @@ impl InProcessDaemon {
                 Utc::now(),
             );
             let convoy_key = (session.metadata.namespace.clone(), convoy.clone());
-            let host = environment_map
-                .get(&session.spec.env_ref)
-                .and_then(|environment| resource_environment_host_ref(environment))
-                .map(|host_ref| self.target_host_for_resource_ref(host_ref))
-                .unwrap_or_else(|| self.host_name.clone());
+            let host = if let Some(host_ref) =
+                environment_map.get(&session.spec.env_ref).and_then(|environment| resource_environment_host_ref(environment))
+            {
+                let canonical_ref = canonical_placement_host_ref_from_sources(&host_sources.items, host_ref)
+                    .ok()
+                    .flatten()
+                    .map(|target| target.reference)
+                    .unwrap_or_else(|| host_ref.to_string());
+                self.host_name_for_canonical_ref(&canonical_ref)
+            } else {
+                self.host_name.clone()
+            };
             rows.push(
                 FleetListRow::builder()
                     .convoy(convoy.clone())
@@ -8119,7 +8172,7 @@ impl InProcessDaemon {
             .map(|spec| spec.host_ref.as_str())
             .or_else(|| environment.spec.docker.as_ref().map(|spec| spec.host_ref.as_str()))
             .ok_or_else(|| format!("environment {} has no host binding", session.spec.env_ref))?;
-        let target_host = self.target_host_for_resource_ref(host_ref);
+        let target_host = self.target_host_for_resource_ref(&namespace, host_ref).await?;
         if target_host != self.host_name {
             let plan = self.recursive_attach_plan_for_remote(&target_host, reference, seat).await?;
             return Ok((plan, target_host));
@@ -8227,11 +8280,20 @@ impl InProcessDaemon {
         Ok(ResolvedAttachPlan(vec![ResolvedAttachAction::Command(attach_args)]))
     }
 
-    fn target_host_for_resource_ref(&self, host_ref: &str) -> HostName {
-        if self.local_host_id().as_ref().is_some_and(|host_id| host_id.as_str() == host_ref) {
+    async fn target_host_for_resource_ref(&self, namespace: &str, host_ref: &str) -> Result<HostName, String> {
+        let canonical_ref = match canonical_placement_host_ref(&self.resource_backend, namespace, host_ref).await {
+            Ok(Some(target_host)) => target_host.reference,
+            Ok(None) => host_ref.to_string(),
+            Err(error) => return Err(error),
+        };
+        Ok(self.host_name_for_canonical_ref(&canonical_ref))
+    }
+
+    fn host_name_for_canonical_ref(&self, canonical_ref: &str) -> HostName {
+        if self.local_host_id().as_ref().is_some_and(|host_id| host_id.as_str() == canonical_ref) {
             self.host_name.clone()
         } else {
-            HostName::new(host_ref)
+            HostName::new(canonical_ref)
         }
     }
 
@@ -8241,7 +8303,13 @@ impl InProcessDaemon {
         cwd: &Path,
     ) -> Result<Arc<crate::providers::registry::ProviderRegistry>, String> {
         let environment_id = if let Some(host_direct) = environment.spec.host_direct.as_ref() {
-            if self.local_host_id().as_ref().is_some_and(|host_id| host_id.as_str() == host_direct.host_ref) {
+            let canonical_ref =
+                match canonical_placement_host_ref(&self.resource_backend, &environment.metadata.namespace, &host_direct.host_ref).await {
+                    Ok(Some(target_host)) => target_host.reference,
+                    Ok(None) => host_direct.host_ref.clone(),
+                    Err(error) => return Err(error),
+                };
+            if self.local_host_id().as_ref().is_some_and(|host_id| host_id.as_str() == canonical_ref) {
                 self.local_environment_id.clone()
             } else {
                 EnvironmentId::new(environment.metadata.name.clone())

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -105,6 +105,26 @@ fn turn_delivery_session_plans_preserve_terminal_lifecycle_invariants() {
 const TEST_LOCAL_ATTACH_HOST: &str = "local";
 
 #[tokio::test]
+async fn resource_host_routing_falls_back_to_unregistered_canonical_ref() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let daemon = InProcessDaemon::new_with_resource_backend(
+        Vec::new(),
+        Arc::new(ConfigStore::with_base(temp.path())),
+        fake_discovery(false),
+        HostName::new("local-host"),
+        ResourceBackend::InMemory(InMemoryBackend::default()),
+    )
+    .await;
+
+    let target = daemon
+        .target_host_for_resource_ref("flotilla", "unregistered-host-id")
+        .await
+        .expect("unknown canonical ids remain routable for legacy environment records");
+
+    assert_eq!(target, HostName::new("unregistered-host-id"));
+}
+
+#[tokio::test]
 async fn self_targeted_admission_uses_live_local_host_over_stale_self_origin_replica() {
     let temp = tempfile::tempdir().expect("tempdir");
     std::fs::write(temp.path().join("daemon.toml"), "machine_id = \"local-host\"\n").expect("daemon config");
@@ -171,6 +191,144 @@ async fn self_targeted_admission_uses_live_local_host_over_stale_self_origin_rep
         )
         .await
         .expect("healthy authoritative local capacity should admit self-targeted placement");
+}
+
+#[tokio::test]
+async fn self_targeted_admission_resolves_display_name_policy_to_live_local_host() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(temp.path().join("daemon.toml"), "machine_id = \"local-host\"\n").expect("daemon config");
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let daemon = InProcessDaemon::new_with_resource_backend(
+        Vec::new(),
+        Arc::new(ConfigStore::with_base(temp.path())),
+        fake_discovery(false),
+        HostName::new("local-host"),
+        backend.clone(),
+    )
+    .await;
+    let host_id = daemon.local_host_id().expect("local host identity").to_string();
+
+    let foreign_root = NodeId::new("foreign-root");
+    let foreign_authority = ResourceBackend::InMemory(InMemoryBackend::default());
+    foreign_authority
+        .using::<ResourceHost>("flotilla")
+        .create(&empty_input_meta(&host_id), &HostSpec { display_name: "local-host".to_string() })
+        .await
+        .expect("foreign peer's stale authoritative host");
+    let stale_hosts = foreign_authority.using::<ResourceHost>("flotilla").list().await.expect("stale foreign host list");
+
+    let relay = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(NodeId::new("relay-root"));
+    relay
+        .replica_writer::<ResourceHost>(foreign_root.clone(), "flotilla")
+        .replace(&stale_hosts, Utc::now())
+        .await
+        .expect("relay foreign authoritative residue");
+    assert_eq!(
+        relay.including_replicas::<ResourceHost>("flotilla").list().await.expect("relay host view").items.len(),
+        1,
+        "the intermediate peer must hold the stale foreign record"
+    );
+    backend
+        .replica_writer::<ResourceHost>(foreign_root, "flotilla")
+        .replace(&stale_hosts, Utc::now())
+        .await
+        .expect("seed stale foreign-origin replica at admitting host");
+
+    let hosts = backend.using::<ResourceHost>("flotilla");
+    let local = hosts
+        .create(&empty_input_meta(&host_id), &HostSpec { display_name: "local-host".to_string() })
+        .await
+        .expect("authoritative local host");
+    hosts
+        .update_status(&host_id, &local.metadata.resource_version, &HostStatus {
+            disk_free_bytes: Some(100 * 1024 * 1024 * 1024),
+            admission_free_space_floor_bytes: Some(20 * 1024 * 1024 * 1024),
+            ..HostStatus::default()
+        })
+        .await
+        .expect("publish live local capacity");
+    let policy = backend
+        .using::<PlacementPolicy>("flotilla")
+        .create(
+            &empty_input_meta("self-targeted"),
+            &PlacementPolicySpec::builder()
+                .pool("passthrough".to_string())
+                .host_direct(HostDirectPlacementPolicySpec {
+                    host_ref: "local-host".to_string(),
+                    checkout: HostDirectPlacementPolicyCheckout::Worktree,
+                })
+                .build(),
+        )
+        .await
+        .expect("self-targeted placement policy");
+    let target_host = placement_target_host(&backend, "flotilla", &policy).await.expect("resolve display-name host reference");
+    assert_eq!(target_host.reference, host_id, "placement decisions must carry the canonical Host resource id");
+    assert_eq!(
+        daemon.remote_host_direct_placement_host("flotilla", Some("self-targeted")).await.expect("resolve host-direct routing"),
+        None,
+        "a display-name alias for the local Host must not be routed as a remote host id"
+    );
+
+    daemon
+        .check_remote_placement_free_space_floor(
+            "flotilla",
+            Some(&PlacementDecision {
+                policy_name: "self-targeted".to_string(),
+                target_host,
+                refused_candidates: Vec::new(),
+                viable_not_selected: Vec::new(),
+            }),
+        )
+        .await
+        .expect("healthy authoritative local capacity should admit self-targeted placement");
+}
+
+#[tokio::test]
+async fn placement_target_host_rejects_unknown_display_name() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let policy = backend
+        .using::<PlacementPolicy>("flotilla")
+        .create(
+            &empty_input_meta("unknown-host"),
+            &PlacementPolicySpec::builder()
+                .pool("passthrough".to_string())
+                .host_direct(HostDirectPlacementPolicySpec {
+                    host_ref: "missing-host".to_string(),
+                    checkout: HostDirectPlacementPolicyCheckout::Worktree,
+                })
+                .build(),
+        )
+        .await
+        .expect("placement policy");
+
+    let error = placement_target_host(&backend, "flotilla", &policy).await.expect_err("unknown host alias must be rejected");
+    assert_eq!(error, "placement `unknown-host` references unknown host `missing-host`");
+}
+
+#[tokio::test]
+async fn placement_target_host_rejects_ambiguous_display_name() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let hosts = backend.using::<ResourceHost>("flotilla");
+    for host_id in ["host-id-a", "host-id-b"] {
+        hosts.create(&empty_input_meta(host_id), &HostSpec { display_name: "shared-name".to_string() }).await.expect("host");
+    }
+    let policy = backend
+        .using::<PlacementPolicy>("flotilla")
+        .create(
+            &empty_input_meta("ambiguous-host"),
+            &PlacementPolicySpec::builder()
+                .pool("passthrough".to_string())
+                .host_direct(HostDirectPlacementPolicySpec {
+                    host_ref: "shared-name".to_string(),
+                    checkout: HostDirectPlacementPolicyCheckout::Worktree,
+                })
+                .build(),
+        )
+        .await
+        .expect("placement policy");
+
+    let error = placement_target_host(&backend, "flotilla", &policy).await.expect_err("ambiguous host alias must be rejected");
+    assert_eq!(error, "placement `ambiguous-host` host reference `shared-name` is ambiguous");
 }
 
 #[tokio::test]
@@ -1078,6 +1236,46 @@ async fn default_placement_prefers_the_viable_local_host() {
 }
 
 #[tokio::test]
+async fn default_placement_prefers_local_host_referenced_by_display_name() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    create_host_direct_placement(&backend, "host-direct-a-remote", "remote-host", 0, BTreeSet::from(["codex".to_string()])).await;
+
+    let hosts = backend.clone().using::<ResourceHost>("flotilla");
+    let local =
+        hosts.create(&empty_input_meta("local-host-id"), &HostSpec { display_name: "local-host".to_string() }).await.expect("local host");
+    hosts
+        .update_status(&local.metadata.name, &local.metadata.resource_version, &HostStatus {
+            capabilities: [(AGENT_ADAPTERS_CAPABILITY.to_string(), serde_json::json!(["codex"]))].into_iter().collect(),
+            heartbeat_at: Some(Utc::now()),
+            ready: true,
+            ..HostStatus::default()
+        })
+        .await
+        .expect("local host status");
+    backend
+        .using::<PlacementPolicy>("flotilla")
+        .create(
+            &empty_input_meta("host-direct-z-local"),
+            &PlacementPolicySpec::builder()
+                .pool("passthrough".to_string())
+                .host_direct(HostDirectPlacementPolicySpec {
+                    host_ref: "local-host".to_string(),
+                    checkout: HostDirectPlacementPolicyCheckout::Worktree,
+                })
+                .build(),
+        )
+        .await
+        .expect("local placement");
+
+    let resolution = default_convoy_placement_policy(&backend, "flotilla", &trusted_codex_workflow(), Some("local-host-id"))
+        .await
+        .expect("default placement");
+
+    assert_eq!(resolution.selected.expect("viable placement").metadata.name, "host-direct-z-local");
+    assert_eq!(resolution.viable_not_selected[0].reason, "fallback ordering preferred local policy `host-direct-z-local`");
+}
+
+#[tokio::test]
 async fn default_placement_priority_can_prefer_a_remote_work_host_over_the_local_desk() {
     let backend = ResourceBackend::InMemory(InMemoryBackend::default());
     create_host_direct_placement(&backend, "host-direct-feta", "feta", 100, BTreeSet::from(["codex".to_string()])).await;
@@ -1134,6 +1332,46 @@ async fn default_placement_preserves_a_refusal_for_a_policy_without_a_target_hos
         resolution.refused_candidates[0].reason,
         "workflow requires agent adapter `codex`, which is not available in placement `a-malformed` (unknown target environment)"
     );
+}
+
+#[tokio::test]
+async fn default_placement_refuses_unknown_host_without_blocking_tool_workflow() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    backend
+        .using::<PlacementPolicy>("flotilla")
+        .create(
+            &empty_input_meta("a-unknown-host"),
+            &PlacementPolicySpec::builder()
+                .pool("passthrough".to_string())
+                .host_direct(HostDirectPlacementPolicySpec {
+                    host_ref: "deleted-host".to_string(),
+                    checkout: HostDirectPlacementPolicyCheckout::Worktree,
+                })
+                .build(),
+        )
+        .await
+        .expect("orphaned placement create");
+    create_host_direct_placement(&backend, "z-clean", "clean-host", 0, BTreeSet::new()).await;
+    let workflow = WorkflowTemplateSpec::builder()
+        .vessels(vec![VesselRequirement::builder()
+            .name("work".to_string())
+            .stance(Stance::Trusted)
+            .crew(vec![CrewSpec::builder()
+                .role("watcher".to_string())
+                .source(CrewSource::Tool { command: "tail -f log".to_string() })
+                .build()])
+            .build()])
+        .build();
+
+    let resolution = default_convoy_placement_policy(&backend, "flotilla", &workflow, None)
+        .await
+        .expect("one orphaned policy must not block a clean candidate");
+
+    assert_eq!(resolution.selected.expect("clean placement").metadata.name, "z-clean");
+    assert_eq!(resolution.refused_candidates.len(), 1);
+    assert_eq!(resolution.refused_candidates[0].policy_name, "a-unknown-host");
+    assert_eq!(resolution.refused_candidates[0].target_host.display_name, "no target host");
+    assert_eq!(resolution.refused_candidates[0].reason, "placement `a-unknown-host` references unknown host `deleted-host`");
 }
 
 #[tokio::test]
@@ -3063,6 +3301,42 @@ async fn fleet_list_reports_store_backed_local_sessions_with_authority() {
     let snapshot = daemon.fleet_replica_snapshot_internal().await.expect("fleet replica snapshot should succeed");
     assert_eq!(snapshot.host, daemon.host_name);
     assert_eq!(snapshot.rows, response.rows);
+}
+
+#[tokio::test]
+async fn fleet_list_falls_back_per_row_for_an_ambiguous_host_alias() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config_base = temp.path().join("config");
+    std::fs::create_dir_all(&config_base).expect("create config dir");
+    std::fs::write(config_base.join("daemon.toml"), "machine_id = \"test-machine\"\n").expect("write daemon config");
+
+    let daemon = new_attach_test_daemon(&config_base).await;
+    let local_env = create_local_attach_environment(&daemon).await;
+    let ambiguous_env = create_remote_attach_environment(&daemon, "shared-host").await;
+    let hosts = daemon.resource_backend().using::<ResourceHost>("flotilla");
+    for host_id in ["shared-host-id-a", "shared-host-id-b"] {
+        hosts
+            .create(&empty_input_meta(host_id), &HostSpec { display_name: "shared-host".to_string() })
+            .await
+            .expect("ambiguous host record");
+    }
+    create_running_attach_session(
+        &daemon,
+        &ambiguous_env,
+        "terminal-ambiguous",
+        "session-ambiguous",
+        "convoy-ambiguous",
+        "work",
+        "watcher",
+    )
+    .await;
+    create_running_attach_session(&daemon, &local_env, "terminal-local", "session-local", "convoy-local", "work", "watcher").await;
+
+    let rows = daemon.fleet_list_internal().await.expect("one ambiguous alias must not fail the fleet listing").rows;
+    let hosts_by_convoy = rows.into_iter().map(|row| (row.convoy, row.host)).collect::<BTreeMap<_, _>>();
+
+    assert_eq!(hosts_by_convoy.get("convoy-ambiguous"), Some(&HostName::new("shared-host")));
+    assert_eq!(hosts_by_convoy.get("convoy-local"), Some(&daemon.host_name));
 }
 
 #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -360,7 +360,7 @@ struct ResourceDeleteArgs {
     /// Collect a read-only replica from this origin root
     #[arg(long, value_name = "ORIGIN_ROOT")]
     replica: Option<String>,
-    /// Route the deletion to a peer host
+    /// Delete the authoritative record on this peer host (including incorrectly authored residue)
     #[arg(long)]
     host: Option<String>,
 }


### PR DESCRIPTION
Closes #1465.

## What changed

- resolve a placement policy's host reference against Host resource identity as soon as the placement target is built
- preserve exact Host IDs, while accepting a unique display-name alias and converting it to the canonical Host ID
- reject unknown and ambiguous aliases instead of carrying hostname-like strings into admission
- add a regression matching the live topology: a UUID-keyed healthy local Host, a stale foreign replica, and a policy persisted with the local display name
- clarify that `resource delete --host` deletes the authoritative record on the selected peer, which is the cleanup path for incorrectly authored residue

## Live-store finding

On udder, the policy stored `host_ref = "udder"`, but the authoritative Host resource name is its UUID. The self-targeted admission check compared those strings directly, so the local-only capacity path never ran. The stale row visible on udder is foreign-origin and is not a failure of the self-origin suppression added in #1467.

Kiwi's local-only store was checked separately: it genuinely authors a Host row for udder under kiwi's node ID. That is residue, not list-envelope misclassification, and is deliberately not treated as admission authority by this change.

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- focused core, remote-placement, vessel-placement, and resource-backend regression suites
