### PR TITLE
ci: move compose integration off the PR critical path

### DIFF
--- a/.github/workflows/compose-integration.yml
+++ b/.github/workflows/compose-integration.yml
@@ -4,22 +4,21 @@ on:
   schedule:
     - cron: "17 3 * * *"
   workflow_dispatch:
+  push:
+    branches:
+      - main
+  # Compose runs are off the PR critical path (~20 min, catches concentrated
+  # in multi-daemon PRs — see #1477). Opt a PR in with the `compose` label,
+  # or rely on the post-merge push run before a fleet bump.
   pull_request:
-    paths:
-      - ".github/workflows/compose-integration.yml"
-      - ".dockerignore"
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "assets/**"
-      - "src/**"
-      - "crates/**"
-      - "tests/integration/**"
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: read
 
 jobs:
   wedge-regressions:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'compose')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -62,6 +61,7 @@ jobs:
         run: docker compose -f tests/integration/docker-compose.yml logs --no-color
 
   hub-spoke:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'compose')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/compose-integration.yml
+++ b/.github/workflows/compose-integration.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
   # Compose runs are off the PR critical path (~20 min, catches concentrated
-  # in multi-daemon PRs — see #1477). Opt a PR in with the `compose` label,
+  # in multi-daemon PRs — see PR #1478). Opt a PR in with the `compose` label,
   # or rely on the post-merge push run before a fleet bump.
   pull_request:
     types: [opened, synchronize, reopened, labeled]


### PR DESCRIPTION
Evidence (last 60 compose runs): ~20 minutes per PR run — triple the next-longest gate, on every code PR — with exactly 2 failures, both on the store-federation branch during its development. Catch value is real but concentrated in multi-daemon PRs; everywhere else it's pure latency. The #1471 convergence harness is the incoming PR-speed gate for that layer.

Changes:
- `pull_request` no longer runs compose by default; the two jobs run on a PR only when it carries the `compose` label (label created; opt in for deep replication/federation PRs).
- Added `push` on `main`: the post-merge run gives a signal in time to gate fleet bumps on it when a merge touched multi-daemon paths.
- Nightly cron and `workflow_dispatch` unchanged.

Tracking discussion: filed from the operator's observation that PR-level compose wasn't paying for its wait.

https://claude.ai/code/session_01P3eF4i73CQk8zWVKBVArKp
