### PR TITLE
fix: small batch — #1466, #1469, #1462

### DIFF
--- a/crates/flotilla-daemon/src/server/remote_commands.rs
+++ b/crates/flotilla-daemon/src/server/remote_commands.rs
@@ -208,6 +208,8 @@ impl RemoteCommandRouter {
                         | CommandAction::CrewComplete { .. }
                         | CommandAction::CrewFail { .. }
                         | CommandAction::CrewHandoff { .. }
+                        | CommandAction::ResourceApply { .. }
+                        | CommandAction::ResourceDelete { .. }
                         | CommandAction::ResourceStatusPatch { .. }
                         | CommandAction::ResourceWatch { .. }
                 )

--- a/crates/flotilla-daemon/tests/project_cli.rs
+++ b/crates/flotilla-daemon/tests/project_cli.rs
@@ -18,7 +18,7 @@ use flotilla_core::{
         SOURCE_ENTRY_PATH_ANNOTATION, SOURCE_REPOSITORY_ANNOTATION, VERIFICATION_PROJECT_ANNOTATION,
     },
     project_declaration::{BOOTSTRAP_COMMIT_ANNOTATION, BOOTSTRAP_PATH_ANNOTATION, BOOTSTRAP_REPOSITORY_ANNOTATION},
-    providers::discovery::test_support::fake_discovery,
+    providers::discovery::test_support::{fake_discovery, git_process_discovery, init_git_repo_with_remote},
     repository_inspection::{LocalCheckoutInspection, ProjectDeclarationInspection, RepositoryInspection, RepositoryInspector},
 };
 use flotilla_daemon::runtime::{DaemonRuntime, RuntimeOptions};
@@ -28,6 +28,7 @@ use flotilla_resources::{
     ProjectRepositoryRole, ProjectSpec, Repository, RepositoryKey, RepositorySpec, RepositoryStatus, ResourceBackend, Stance,
     WorkflowTemplate, WorkflowTemplateSpec, MANAGED_BY_LABEL,
 };
+use tracing::instrument::WithSubscriber;
 #[derive(Clone)]
 struct LogCaptureWriter(Arc<Mutex<Vec<u8>>>);
 
@@ -645,19 +646,19 @@ async fn tracking_repo_materializes_whole_repo_project() {
     }]);
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test]
 async fn tracked_repo_reconciles_generator_owned_project_fields_and_preserves_custom_fields() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let config = test_config(tmp.path().join("config"));
     let checkout_path = tmp.path().join("tracked");
-    std::fs::create_dir(&checkout_path).expect("checkout dir");
+    init_git_repo_with_remote(&checkout_path, "https://github.com/org/tracked.git");
     let repository_spec = RepositorySpec::remote("https://github.com/org/tracked.git").expect("repository spec");
     let repository_key = repository_spec.key();
     let backend = ResourceBackend::InMemory(InMemoryBackend::default());
     let daemon = InProcessDaemon::new_with_resource_backend(
         vec![checkout_path],
         config,
-        fake_discovery(false),
+        git_process_discovery(false),
         HostName::new("local"),
         backend.clone(),
     )
@@ -674,10 +675,6 @@ async fn tracked_repo_reconciles_generator_owned_project_fields_and_preserves_cu
         .with_max_level(tracing::Level::WARN)
         .with_writer(move || writer.clone())
         .finish();
-    // Capture from before drift is introduced: the daemon's background poll may
-    // reconcile it before the explicit call below. The current-thread runtime
-    // keeps this thread-local subscriber active across each await.
-    let log_guard = tracing::subscriber::set_default(subscriber);
     projects
         .create(
             &InputMeta::builder()
@@ -700,8 +697,7 @@ async fn tracked_repo_reconciles_generator_owned_project_fields_and_preserves_cu
         .await
         .expect("stale whole-repository Project should be created");
 
-    daemon.materialize_tracked_repo_projects().await.expect("tracked Project reconciliation should succeed");
-    drop(log_guard);
+    daemon.materialize_tracked_repo_projects().with_subscriber(subscriber).await.expect("tracked Project reconciliation should succeed");
 
     let reconciled = projects.get("tracked").await.expect("tracked Project should remain");
     assert_eq!(reconciled.spec.display_name, "My Tracked Repository");
@@ -717,8 +713,11 @@ async fn tracked_repo_reconciles_generator_owned_project_fields_and_preserves_cu
     assert_eq!(reconciled.metadata.labels.get(MANAGED_BY_LABEL).map(String::as_str), Some("whole-repository-project"));
     assert_eq!(reconciled.metadata.labels.get("example.com/preserved").map(String::as_str), Some("true"));
     let logs = String::from_utf8(log_output.lock().expect("log capture lock should be healthy").clone()).expect("logs should be utf-8");
-    assert!(logs.contains("stored generator-owned whole-repository Project fields diverged; overwriting"), "{logs}");
-    assert!(logs.contains("tracked"), "{logs}");
+    assert!(
+        logs.contains("stored generator-owned whole-repository Project fields diverged; overwriting"),
+        "expected generator-field divergence warning; captured logs: {logs:?}"
+    );
+    assert!(logs.contains("tracked"), "expected warning to identify project `tracked`; captured logs: {logs:?}");
 
     daemon.materialize_tracked_repo_projects().await.expect("steady-state reconciliation should succeed");
     let unchanged = projects.get("tracked").await.expect("tracked Project should remain");

--- a/crates/flotilla-daemon/tests/request_session_pair.rs
+++ b/crates/flotilla-daemon/tests/request_session_pair.rs
@@ -276,6 +276,66 @@ async fn in_memory_request_client_routes_remote_command_result() {
 }
 
 #[tokio::test]
+async fn resource_mutations_targeting_a_peer_modify_only_the_peer_store() {
+    let leader = empty_daemon_named("leader").await;
+    let follower = empty_daemon_named("follower").await;
+    let topology = spawn_in_memory_request_topology_stateful(leader, follower).await.expect("spawn stateful topology");
+    let follower_node_id = topology.follower.node_id().clone();
+    let namespace = "flotilla";
+    let name = "remote-template";
+    let leader_templates = topology.leader.resource_backend().using::<WorkflowTemplate>(namespace);
+    let follower_templates = topology.follower.resource_backend().using::<WorkflowTemplate>(namespace);
+
+    let mut events = topology.leader.subscribe();
+    let apply_id = topology
+        .client
+        .execute(Command {
+            node_id: Some(follower_node_id.clone()),
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ResourceApply {
+                namespace: namespace.to_string(),
+                document: serde_json::json!({
+                    "kind": "WorkflowTemplate",
+                    "metadata": {"name": name},
+                    "spec": {"vessels": []},
+                }),
+            },
+        })
+        .await
+        .expect("dispatch peer resource apply");
+
+    assert!(matches!(await_command_result(&mut events, apply_id).await, CommandValue::ResourceObject(_)));
+    assert!(
+        matches!(leader_templates.get(name).await, Err(ResourceError::NotFound { .. })),
+        "peer-targeted apply must not create the resource in the caller's store"
+    );
+    follower_templates.get(name).await.expect("peer-targeted apply should create the resource in the peer store");
+
+    let delete_id = topology
+        .client
+        .execute(Command {
+            node_id: Some(follower_node_id),
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ResourceDelete {
+                namespace: namespace.to_string(),
+                kind: "workflowtemplates".to_string(),
+                name: name.to_string(),
+                replica_origin: None,
+            },
+        })
+        .await
+        .expect("dispatch peer resource delete");
+
+    assert!(matches!(await_command_result(&mut events, delete_id).await, CommandValue::ResourceDeleted(_)));
+    assert!(
+        matches!(follower_templates.get(name).await, Err(ResourceError::NotFound { .. })),
+        "peer-targeted delete should remove the resource from the peer store"
+    );
+}
+
+#[tokio::test]
 async fn hostless_convoy_delete_routes_to_remote_home() {
     let leader = empty_daemon_named("leader").await;
     let follower = empty_daemon_named("follower").await;

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,9 +6,20 @@ The daemon's canonical structured log is
 `$XDG_STATE_HOME/flotilla/log/flotillad.jsonl`, or
 `~/.local/state/flotilla/log/flotillad.jsonl` when `XDG_STATE_HOME` is unset.
 Older size-rotated generations use numeric suffixes such as
-`flotillad.jsonl.1`. Detached daemons write their normal tracing output only
-to this JSON-lines log; `daemon-panic.log` under the configuration directory
-is reserved for panics and errors that occur before tracing initializes.
+`flotillad.jsonl.1` through `flotillad.jsonl.4` with the default configuration.
+For example, show warnings from the peer subsystem with:
+
+```bash
+jq -c 'select(.level == "WARN" and (.target | startswith("flotilla_daemon::peer")))' \
+  ~/.local/state/flotilla/log/flotillad.jsonl
+```
+
+Detached daemons write their normal tracing output only to this JSON-lines
+log. A legacy `~/.local/state/flotilla/daemon.log`, when present, contains only
+whatever stdout or stderr the host's launch command redirected there, such as
+startup failures or panics; it is not the structured daemon log and may be
+stale. The current built-in launcher sends that same pre-tracing and panic tail
+to `~/.config/flotilla/daemon-panic.log` instead.
 
 ## Cargo target cache policy
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2244,13 +2244,14 @@ mod tests {
             }) if kind == "convoys" && name == "demo" && namespace == "ops"
         ));
 
-        let delete = Cli::try_parse_from(["flotilla", "resource", "delete", "workflowtemplates", "scratch", "--namespace", "ops"])
-            .expect("resource delete should parse");
+        let delete =
+            Cli::try_parse_from(["flotilla", "resource", "delete", "workflowtemplates", "scratch", "--namespace", "ops", "--host", "feta"])
+                .expect("resource delete should parse");
         assert!(matches!(
             delete.command,
             Some(SubCommand::Resource {
-                command: ResourceSubCommand::Delete(ResourceDeleteArgs { kind, name, namespace, replica: None, host: None })
-            }) if kind == "workflowtemplates" && name == "scratch" && namespace == "ops"
+                command: ResourceSubCommand::Delete(ResourceDeleteArgs { kind, name, namespace, replica: None, host: Some(host) })
+            }) if kind == "workflowtemplates" && name == "scratch" && namespace == "ops" && host == "feta"
         ));
 
         let collect =
@@ -2267,13 +2268,13 @@ mod tests {
             }) if origin == "retired-root" && host == "feta"
         ));
 
-        let apply = Cli::try_parse_from(["flotilla", "resource", "apply", "-f", "demand.yaml", "--namespace", "ops"])
+        let apply = Cli::try_parse_from(["flotilla", "resource", "apply", "-f", "demand.yaml", "--namespace", "ops", "--host", "feta"])
             .expect("resource apply should parse");
         assert!(matches!(
             apply.command,
             Some(SubCommand::Resource {
-                command: ResourceSubCommand::Apply(ResourceApplyArgs { file, namespace, host: None })
-            }) if file.as_path() == Path::new("demand.yaml") && namespace == "ops"
+                command: ResourceSubCommand::Apply(ResourceApplyArgs { file, namespace, host: Some(host) })
+            }) if file.as_path() == Path::new("demand.yaml") && namespace == "ops" && host == "feta"
         ));
 
         let patch_status =


### PR DESCRIPTION
## Summary

- route `resource apply --host` and `resource delete --host` through the peer-forwarding path, with two-daemon coverage proving only the peer authority changes
- remove the `project_cli` logging race by initializing a real Git checkout before daemon startup, then scope log capture to the explicit reconciliation and add diagnostic assertion messages
- document structured daemon JSONL locations, rotation, filtering, and the legacy launch-redirect log

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- flaky test: 20 isolated runs plus the full `project_cli` binary with `--test-threads=16`

Closes #1466
Closes #1469
Closes #1462
