### PR TITLE
fix: surface blocked crew attention

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -779,6 +779,10 @@ fn crew_attention(status: Option<&TerminalSessionStatus>, work_unsettled: bool, 
     })
 }
 
+fn crew_work_unsettled(phase: CrewWorkPhase) -> bool {
+    !matches!(phase, CrewWorkPhase::Done | CrewWorkPhase::HandedBack | CrewWorkPhase::Failed)
+}
+
 fn convoy_state_label(row: &ConvoyRow) -> String {
     match row.message.as_deref().filter(|message| !message.trim().is_empty()) {
         Some(message) => format!("{}: {message}", row.phase),
@@ -7072,7 +7076,7 @@ impl InProcessDaemon {
                     .as_ref()
                     .and_then(|status| status.crew_work.get(&context.vessel))
                     .and_then(|crew| crew.get(&process.role))
-                    .is_none_or(|work| !matches!(work.phase, CrewWorkPhase::Done | CrewWorkPhase::Failed));
+                    .is_none_or(|work| crew_work_unsettled(work.phase));
                 let state = match session.and_then(|session| session.status.as_ref().map(|status| status.phase)) {
                     Some(ResourceTerminalSessionPhase::Starting) => "starting",
                     Some(ResourceTerminalSessionPhase::Running) => "active",
@@ -7769,12 +7773,8 @@ impl InProcessDaemon {
                     let convoy_name = convoy_name.clone();
                     status.crew_work.into_iter().flat_map(move |(vessel, crew)| {
                         let convoy_name = convoy_name.clone();
-                        crew.into_iter().map(move |(role, work)| {
-                            (
-                                (convoy_name.clone(), vessel.clone(), role),
-                                !matches!(work.phase, CrewWorkPhase::Done | CrewWorkPhase::Failed),
-                            )
-                        })
+                        crew.into_iter()
+                            .map(move |(role, work)| ((convoy_name.clone(), vessel.clone(), role), crew_work_unsettled(work.phase)))
                     })
                 })
             })

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -7802,14 +7802,11 @@ impl InProcessDaemon {
             let role = labels.get(ROLE_LABEL).cloned().unwrap_or_else(|| session.spec.role.clone());
             let crew = match task.as_ref() {
                 Some(task) => format!("{task}/{role}"),
-                None => role,
+                None => role.clone(),
             };
             let attention = crew_attention(
                 session.status.as_ref(),
-                task.as_ref()
-                    .and_then(|task| work_unsettled.get(&(convoy.clone(), task.clone(), session.spec.role.clone())))
-                    .copied()
-                    .unwrap_or(true),
+                task.as_ref().and_then(|task| work_unsettled.get(&(convoy.clone(), task.clone(), role))).copied().unwrap_or(true),
                 Utc::now(),
             );
             let convoy_key = (session.metadata.namespace.clone(), convoy.clone());

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -22,15 +22,15 @@ use flotilla_protocol::{
     commands::{AttachMode, RepositoryIdentityChange},
     qualified_path::{HostId, QualifiedPath},
     result_set::{CheckoutRow, ConvoyChangeRequest, ConvoyRow, ResultSet, Rows},
-    AttachBinding, Command, CommandAction, CommandValue, ConvoyDispatchRegard, ConvoyExplanation, CorrelationKey, CrewCommandContext,
-    CrewListMember, CrewListResponse, DaemonEvent, DeltaEntry, DispatchQueueResponse, DispatchQueueRow, EnvironmentId, EvidenceFreshness,
-    ExplainedChangeRequest, ExplainedCheckout, ExplainedCondition, ExplainedCrewDelivery, ExplainedLeafFiring, ExplainedSettlement,
-    ExplainedSubscription, ExplainedUnmetExpectation, FleetHealthResponse, FleetHostRow, FleetHostStaleness, FleetListResponse,
-    FleetListRow, FleetObservationAgreement, FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListResponse, HostName,
-    HostProviderStatus, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId, NodeInfo, PeerConnectionState, PlacementDecision,
-    PlacementRefusal, PlacementTargetHost, PlacementViableCandidate, PrincipalRef, ProjectListEntry, ProjectListRepository,
-    ProjectListResponse, ProviderData, ProviderInfo, QueryCursor, RepoDelta, RepoDetailResponse, RepoIdentity, RepoInfo,
-    RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedAttachAction, ResolvedAttachPlan, ResourceCursor,
+    AttachBinding, Command, CommandAction, CommandValue, ConvoyDispatchRegard, ConvoyExplanation, CorrelationKey, CrewAttention,
+    CrewCommandContext, CrewListMember, CrewListResponse, DaemonEvent, DeltaEntry, DispatchQueueResponse, DispatchQueueRow, EnvironmentId,
+    EvidenceFreshness, ExplainedChangeRequest, ExplainedCheckout, ExplainedCondition, ExplainedCrewDelivery, ExplainedLeafFiring,
+    ExplainedSettlement, ExplainedSubscription, ExplainedUnmetExpectation, FleetHealthResponse, FleetHostRow, FleetHostStaleness,
+    FleetListResponse, FleetListRow, FleetObservationAgreement, FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListResponse,
+    HostName, HostProviderStatus, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId, NodeInfo, PeerConnectionState,
+    PlacementDecision, PlacementRefusal, PlacementTargetHost, PlacementViableCandidate, PrincipalRef, ProjectListEntry,
+    ProjectListRepository, ProjectListResponse, ProviderData, ProviderInfo, QueryCursor, RepoDelta, RepoDetailResponse, RepoIdentity,
+    RepoInfo, RepoProvidersResponse, RepoSnapshot, RepoSummary, RepoWorkResponse, ResolvedAttachAction, ResolvedAttachPlan, ResourceCursor,
     ResourceJsonResponse, ResourceReadEnvelope, ResourceReadRecord, ResourceRecordProvenance, ResourceRecordType, ResourceRef,
     StatusResponse, StepStatus, StreamKey, SurfaceDeclaration, SystemInfo, ToolInventory, TopologyResponse, TopologyRoute, ViewAddress,
     AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
@@ -45,17 +45,17 @@ use flotilla_resources::{
     watch_resource_kind_replica_sources, BoundChangeRequest, Checkout as ResourceCheckout, CheckoutIntegrationStatus,
     CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus, Clock,
     ConditionValue, Convoy as ResourceConvoy, ConvoyEnsure, ConvoyEnsureSpec, ConvoyEnsureStatusPatch, ConvoyIssue, ConvoyPhase,
-    ConvoyRepositorySpec, ConvoySpec, ConvoyStatusPatch, CredentialGrant, CredentialSpec, CrewCompletionPending, CrewSource,
+    ConvoyRepositorySpec, ConvoySpec, ConvoyStatusPatch, CredentialGrant, CredentialSpec, CrewCompletionPending, CrewSource, CrewWorkPhase,
     Demand as ResourceDemand, Environment as ResourceEnvironment, HoldAct, Host as ResourceHost, HostDirectPlacementPolicyCheckout,
     HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus, InMemoryBackend, InputMeta, InputValue, IntegrationCondition,
     IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable, LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec,
     PlacementPolicy, PlacementPolicySpec, Presentation as ResourcePresentation, Project, ProjectRepositoryRole, ProjectRepositorySpec,
     ProjectSpec, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance,
-    SettlementMode, SystemClock, TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession,
-    TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatusPatch,
-    TurnDeliveryRung, UnmetSettlementExpectation, Vessel, WatchEvent, WatchStart, WorkCompletionAuthority, WorkPhase as ResourceWorkPhase,
-    WorkflowTemplate, WorkflowTemplateSpec, ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL, HEARTBEAT_READY_TTL_SECS, MANAGED_BY_LABEL,
-    ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
+    SettlementMode, SystemClock, TerminalAttentionState, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
+    TerminalSession as ResourceTerminalSession, TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase,
+    TerminalSessionSource, TerminalSessionStatus, TerminalSessionStatusPatch, TurnDeliveryRung, UnmetSettlementExpectation, Vessel,
+    WatchEvent, WatchStart, WorkCompletionAuthority, WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec,
+    ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL, HEARTBEAT_READY_TTL_SECS, MANAGED_BY_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
 use futures::{FutureExt, StreamExt};
 use sha2::{Digest, Sha256};
@@ -762,6 +762,21 @@ fn session_status_label(phase: Option<ResourceTerminalSessionPhase>) -> String {
         Some(ResourceTerminalSessionPhase::Stopped) => "stopped".to_string(),
         Some(ResourceTerminalSessionPhase::Failed) => "failed".to_string(),
     }
+}
+
+fn crew_attention(status: Option<&TerminalSessionStatus>, work_unsettled: bool, now: DateTime<Utc>) -> Option<CrewAttention> {
+    let status = status.filter(|status| status.phase == ResourceTerminalSessionPhase::Running)?;
+    let attention = status.attention.as_ref()?;
+    if attention.is_stale_at(now) {
+        return Some(CrewAttention::Unobservable);
+    }
+    Some(match attention.state {
+        TerminalAttentionState::Working => CrewAttention::Working,
+        TerminalAttentionState::NeedsInput => CrewAttention::NeedsInput,
+        TerminalAttentionState::Idle if work_unsettled => CrewAttention::Stalled,
+        TerminalAttentionState::Idle => CrewAttention::Idle,
+        TerminalAttentionState::Unobservable => CrewAttention::Unobservable,
+    })
 }
 
 fn convoy_state_label(row: &ConvoyRow) -> String {
@@ -7052,6 +7067,12 @@ impl InProcessDaemon {
             .iter()
             .map(|process| {
                 let session = by_role.get(&process.role);
+                let work_unsettled = convoy
+                    .status
+                    .as_ref()
+                    .and_then(|status| status.crew_work.get(&context.vessel))
+                    .and_then(|crew| crew.get(&process.role))
+                    .is_none_or(|work| !matches!(work.phase, CrewWorkPhase::Done | CrewWorkPhase::Failed));
                 let state = match session.and_then(|session| session.status.as_ref().map(|status| status.phase)) {
                     Some(ResourceTerminalSessionPhase::Starting) => "starting",
                     Some(ResourceTerminalSessionPhase::Running) => "active",
@@ -7065,6 +7086,7 @@ impl InProcessDaemon {
                     .role(process.role.clone())
                     .kind(if matches!(process.source, CrewSource::Agent { .. }) { "agent" } else { "tool" }.to_string())
                     .state(state.to_string())
+                    .maybe_attention(crew_attention(session.and_then(|session| session.status.as_ref()), work_unsettled, Utc::now()))
                     .maybe_adapter(crew.map(|crew| crew.adapter.clone()))
                     .maybe_model(crew.and_then(|crew| crew.model.clone()))
                     .maybe_stance(crew.map(|crew| crew.stance.clone()))
@@ -7713,6 +7735,7 @@ impl InProcessDaemon {
         let terminal_sessions = self.resource_backend.clone().using::<ResourceTerminalSession>(namespace);
         let environments = self.resource_backend.clone().using::<ResourceEnvironment>(namespace);
         let checkouts = self.resource_backend.clone().using::<ResourceCheckout>(namespace);
+        let convoys = self.resource_backend.clone().using::<ResourceConvoy>(namespace);
         let observed_checkouts = self.observed_resource_backend.clone().using::<ResourceCheckout>(namespace);
 
         let session_list = terminal_sessions.list().await.map_err(|err| err.to_string())?;
@@ -7734,6 +7757,28 @@ impl InProcessDaemon {
             .into_iter()
             .map(|environment| (environment.metadata.name.clone(), environment))
             .collect();
+        let work_unsettled = convoys
+            .list()
+            .await
+            .map_err(|err| err.to_string())?
+            .items
+            .into_iter()
+            .flat_map(|convoy| {
+                let convoy_name = convoy.metadata.name;
+                convoy.status.into_iter().flat_map(move |status| {
+                    let convoy_name = convoy_name.clone();
+                    status.crew_work.into_iter().flat_map(move |(vessel, crew)| {
+                        let convoy_name = convoy_name.clone();
+                        crew.into_iter().map(move |(role, work)| {
+                            (
+                                (convoy_name.clone(), vessel.clone(), role),
+                                !matches!(work.phase, CrewWorkPhase::Done | CrewWorkPhase::Failed),
+                            )
+                        })
+                    })
+                })
+            })
+            .collect::<HashMap<_, _>>();
         let mut authority_by_convoy = HashMap::new();
         for checkout in checkouts.list().await.map_err(|err| err.to_string())?.items {
             let Some(convoy) = checkout.metadata.labels.get(CONVOY_LABEL).cloned() else {
@@ -7755,10 +7800,18 @@ impl InProcessDaemon {
             let convoy = labels.get(CONVOY_LABEL).cloned().unwrap_or_else(|| "-".to_string());
             let task = labels.get(VESSEL_LABEL).cloned();
             let role = labels.get(ROLE_LABEL).cloned().unwrap_or_else(|| session.spec.role.clone());
-            let crew = match task {
+            let crew = match task.as_ref() {
                 Some(task) => format!("{task}/{role}"),
                 None => role,
             };
+            let attention = crew_attention(
+                session.status.as_ref(),
+                task.as_ref()
+                    .and_then(|task| work_unsettled.get(&(convoy.clone(), task.clone(), session.spec.role.clone())))
+                    .copied()
+                    .unwrap_or(true),
+                Utc::now(),
+            );
             let convoy_key = (session.metadata.namespace.clone(), convoy.clone());
             let host = environment_map
                 .get(&session.spec.env_ref)
@@ -7772,6 +7825,7 @@ impl InProcessDaemon {
                     .maybe_authority(authority_by_convoy.get(&convoy).cloned().flatten())
                     .crew(crew)
                     .crew_state(session_status_label(session.status.as_ref().map(|status| status.phase)))
+                    .maybe_attention(attention)
                     .host(host)
                     .maybe_placement_decision(placement_by_convoy.get(&convoy_key).cloned())
                     .namespace(session.metadata.namespace.clone())

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -14,7 +14,7 @@ use flotilla_protocol::{
         IndependentRow, IssueRow, QueryId, ResultSet, ResultSetState, Rows, SessionPhase,
     },
     test_support::TestIssue,
-    AssociationKey, ChangeRequest, ChangeRequestStatus, Checkout, Command, CommandAction, CommandValue, ConvoyStartIntent,
+    AssociationKey, ChangeRequest, ChangeRequestStatus, Checkout, Command, CommandAction, CommandValue, ConvoyStartIntent, CrewAttention,
     CrewCommandContext, DaemonEvent, EnvironmentId, EnvironmentStatus, HostEnvironment, HostPath, HostProviderStatus, HostSummary, ImageId,
     Issue, IssueRef, IssueSource, IssueState, PlacementDecision, PlacementTargetHost, QueryCursor, QueryScope, RepoSelector, RepositoryKey,
     ResourceRef, ResultSetCondition, SystemInfo, ToolInventory, TopologyRoute, AGENT_ADAPTER_PROVIDER_CATEGORY,
@@ -30,11 +30,12 @@ use flotilla_resources::{
     HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputMeta, LifecycleAuthority,
     ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, PlacementStatus, Project,
     ProjectRepositorySpec, ProjectSpec, Regard, RegardSource, Repository, RepositorySpec, RepositoryStatus, Selector, Stance,
-    TerminalBrief, TerminalCrewContext, TerminalSession as ResourceTerminalSession, TerminalSessionPhase as ResourceTerminalSessionPhase,
-    TerminalSessionSource, TerminalSessionSpec as ResourceTerminalSessionSpec, TerminalSessionStatus as ResourceTerminalSessionStatus,
-    Vessel, VesselPhase, VesselRequirement, VesselSpec, VesselStatus, VirtualClock, WorkCompletionAuthority, WorkPhase, WorkState,
-    WorkflowSnapshot, WorkflowTemplate, WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY, CONVOY_LABEL, CREW_ORDINAL_LABEL,
-    MANAGED_BY_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
+    TerminalAttention, TerminalAttentionSource, TerminalAttentionState, TerminalBrief, TerminalCrewContext,
+    TerminalSession as ResourceTerminalSession, TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource,
+    TerminalSessionSpec as ResourceTerminalSessionSpec, TerminalSessionStatus as ResourceTerminalSessionStatus, Vessel, VesselPhase,
+    VesselRequirement, VesselSpec, VesselStatus, VirtualClock, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot,
+    WorkflowTemplate, WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY, CONVOY_LABEL, CREW_ORDINAL_LABEL, MANAGED_BY_LABEL, ROLE_LABEL,
+    VESSEL_LABEL, VESSEL_ORDINAL_LABEL, VESSEL_REF_LABEL,
 };
 
 use super::*;
@@ -2758,6 +2759,12 @@ async fn crew_list_includes_defined_latent_members_and_handoff_activates_one() {
     let env_ref = create_local_attach_environment(&daemon).await;
     create_two_agent_crew(&daemon, &env_ref).await;
     let context = CrewCommandContext { crew_id: Some("crew-coder".into()), ..Default::default() };
+    let sessions = daemon.resource_backend().using::<ResourceTerminalSession>("flotilla");
+    let coder = sessions.get("terminal-demo-implement-coder").await.expect("coder session");
+    let mut status = coder.status.expect("running coder status");
+    status.attention =
+        Some(TerminalAttention { state: TerminalAttentionState::Idle, as_of: Utc::now(), source: TerminalAttentionSource::Screen });
+    sessions.update_status("terminal-demo-implement-coder", &coder.metadata.resource_version, &status).await.expect("observe idle coder");
 
     let response = daemon
         .execute_query(
@@ -2776,6 +2783,8 @@ async fn crew_list_includes_defined_latent_members_and_handoff_activates_one() {
         ("coder", "active"),
         ("reviewer", "latent")
     ]);
+    assert_eq!(response.members[0].attention, Some(CrewAttention::Stalled));
+    assert_eq!(response.members[1].attention, None);
 
     let mut events = daemon.subscribe();
     let complete_id = daemon
@@ -3000,6 +3009,15 @@ async fn fleet_list_reports_store_backed_local_sessions_with_authority() {
     create_adopted_checkout_for_convoy(&daemon, "convoy-a").await;
     create_running_attach_session(&daemon, &env_ref, "terminal-convoy-a-implement-coder", "session-a", "convoy-a", "implement", "coder")
         .await;
+    let terminals = daemon.resource_backend().using::<ResourceTerminalSession>("flotilla");
+    let session = terminals.get("terminal-convoy-a-implement-coder").await.expect("running session");
+    let mut status = session.status.expect("session status");
+    status.attention =
+        Some(TerminalAttention { state: TerminalAttentionState::NeedsInput, as_of: Utc::now(), source: TerminalAttentionSource::Screen });
+    terminals
+        .update_status("terminal-convoy-a-implement-coder", &session.metadata.resource_version, &status)
+        .await
+        .expect("attention status");
 
     let response = daemon.fleet_list_internal().await.expect("fleet list should succeed");
 
@@ -3011,6 +3029,7 @@ async fn fleet_list_reports_store_backed_local_sessions_with_authority() {
     assert_eq!(row.authority.as_deref(), Some("adopted"));
     assert_eq!(row.crew, "implement/coder");
     assert_eq!(row.crew_state, "running");
+    assert_eq!(row.attention, Some(CrewAttention::NeedsInput));
     assert_eq!(row.host, daemon.host_name);
     assert_eq!(row.staleness, FleetStaleness::Local);
 

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -78,6 +78,14 @@ fn crew_attention_keeps_monitoring_distinct_from_lifecycle_state() {
 }
 
 #[test]
+fn handed_back_crew_is_settled_for_its_own_attention() {
+    assert!(crew_work_unsettled(CrewWorkPhase::Working));
+    assert!(!crew_work_unsettled(CrewWorkPhase::Done));
+    assert!(!crew_work_unsettled(CrewWorkPhase::HandedBack));
+    assert!(!crew_work_unsettled(CrewWorkPhase::Failed));
+}
+
+#[test]
 fn turn_delivery_session_plans_preserve_terminal_lifecycle_invariants() {
     assert_eq!(
         turn_delivery_session_plan(Some(ResourceTerminalSessionPhase::Running), "work", "coder").expect("running session"),

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -59,6 +59,25 @@ use crate::{
 };
 
 #[test]
+fn crew_attention_keeps_monitoring_distinct_from_lifecycle_state() {
+    let now = Utc::now();
+    let mut status = ResourceTerminalSessionStatus {
+        phase: ResourceTerminalSessionPhase::Running,
+        attention: Some(TerminalAttention { state: TerminalAttentionState::Idle, as_of: now, source: TerminalAttentionSource::Screen }),
+        ..Default::default()
+    };
+
+    assert_eq!(crew_attention(Some(&status), true, now), Some(CrewAttention::Stalled));
+    assert_eq!(crew_attention(Some(&status), false, now), Some(CrewAttention::Idle));
+
+    status.attention.as_mut().expect("attention").as_of = now - chrono::Duration::seconds(31);
+    assert_eq!(crew_attention(Some(&status), true, now), Some(CrewAttention::Unobservable));
+
+    status.phase = ResourceTerminalSessionPhase::Stopped;
+    assert_eq!(crew_attention(Some(&status), true, now), None);
+}
+
+#[test]
 fn turn_delivery_session_plans_preserve_terminal_lifecycle_invariants() {
     assert_eq!(
         turn_delivery_session_plan(Some(ResourceTerminalSessionPhase::Running), "work", "coder").expect("running session"),

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -2147,9 +2147,11 @@ mod tests {
     #[tokio::test]
     async fn attention_projection_is_namespace_scoped_and_tracks_idle_unsettled_sessions() {
         let state = AggregatorProjectionState::new();
-        let (event_tx, _) = broadcast::channel(4);
+        let (event_tx, mut event_rx) = broadcast::channel(4);
         let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), event_tx);
         aggregator.apply_convoy_event_from(LocalSource::Durable, WatchEvent::Added(convoy_with_vessel("convoy-a").await)).await;
+        let query = QueryId::Convoys { scope: None };
+        state.replace_subscriber(Uuid::new_v4(), &[flotilla_protocol::QueryCursor { query: query.clone(), since: None }]);
 
         let mut session = session_object("terminal-convoy-a-implement").await;
         session.metadata.labels =
@@ -2169,6 +2171,21 @@ mod tests {
         let convoy = result_set.rows.as_convoys().expect("convoy rows").first().expect("convoy row");
         assert!(convoy.vessels.first().expect("vessel row").needs_attention);
         assert!(convoy.needs_attention);
+
+        let delta = timeout(Duration::from_secs(1), async {
+            loop {
+                if let DaemonEvent::ResultDelta(delta) = event_rx.recv().await.expect("aggregator event") {
+                    if delta.query() == query {
+                        break delta;
+                    }
+                }
+            }
+        })
+        .await
+        .expect("attention result delta");
+        assert_eq!(delta.query(), query);
+        let QueryChanges::Convoys { changed, .. } = &delta.changes else { panic!("expected convoy changes") };
+        assert!(changed.iter().any(|convoy| convoy.name == "convoy-a" && convoy.needs_attention));
     }
 
     #[tokio::test]

--- a/crates/flotilla-protocol/src/commands.rs
+++ b/crates/flotilla-protocol/src/commands.rs
@@ -1562,6 +1562,7 @@ mod tests {
                     role: "coder".into(),
                     kind: "agent".into(),
                     state: "active".into(),
+                    attention: None,
                     adapter: Some("codex".into()),
                     model: None,
                     stance: Some("trusted-implicit".into()),

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -127,11 +127,12 @@ pub use provider_data::{
     RemoteAccessType, SessionStatus, TerminalStatus, WorkingTreeStatus, Workspace,
 };
 pub use query::{
-    CrewCommandContext, CrewListMember, CrewListResponse, DiscoveryEntry, DispatchQueueResponse, DispatchQueueRow, FleetHealthResponse,
-    FleetHostRow, FleetHostStaleness, FleetListResponse, FleetListRow, FleetObservationAgreement, FleetReplicaSnapshot, FleetReplicaStatus,
-    FleetStaleness, HostListEntry, HostListResponse, HostProvidersResponse, HostStatusResponse, PeerReconnectStatus, ProjectListEntry,
-    ProjectListRepository, ProjectListResponse, ProviderHealthMap, ProviderInfo, RepoDetailResponse, RepoProvidersResponse, RepoSummary,
-    RepoWorkResponse, SleepInhibitionHealth, StatusResponse, TopologyResponse, TopologyRoute, UnmetRequirementInfo,
+    CrewAttention, CrewCommandContext, CrewListMember, CrewListResponse, DiscoveryEntry, DispatchQueueResponse, DispatchQueueRow,
+    FleetHealthResponse, FleetHostRow, FleetHostStaleness, FleetListResponse, FleetListRow, FleetObservationAgreement,
+    FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListEntry, HostListResponse, HostProvidersResponse, HostStatusResponse,
+    PeerReconnectStatus, ProjectListEntry, ProjectListRepository, ProjectListResponse, ProviderHealthMap, ProviderInfo, RepoDetailResponse,
+    RepoProvidersResponse, RepoSummary, RepoWorkResponse, SleepInhibitionHealth, StatusResponse, TopologyResponse, TopologyRoute,
+    UnmetRequirementInfo,
 };
 pub use repository::{RepositoryRelation, RepositoryUpstream};
 pub use resource_ref::ResourceRef;

--- a/crates/flotilla-protocol/src/query.rs
+++ b/crates/flotilla-protocol/src/query.rs
@@ -58,11 +58,37 @@ pub struct CrewListMember {
     pub kind: String,
     pub state: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attention: Option<CrewAttention>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub adapter: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stance: Option<String>,
+}
+
+/// Live monitoring state for crew work, kept separate from terminal and
+/// workflow lifecycle state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CrewAttention {
+    Working,
+    NeedsInput,
+    Stalled,
+    Idle,
+    Unobservable,
+}
+
+impl std::fmt::Display for CrewAttention {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Working => "working",
+            Self::NeedsInput => "needs input",
+            Self::Stalled => "stalled",
+            Self::Idle => "idle",
+            Self::Unobservable => "unobservable",
+        })
+    }
 }
 
 // --- status ---
@@ -303,6 +329,8 @@ pub struct FleetListRow {
     pub authority: Option<String>,
     pub crew: String,
     pub crew_state: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attention: Option<CrewAttention>,
     pub host: HostName,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub placement_decision: Option<crate::PlacementDecision>,

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -439,7 +439,7 @@ fn format_fleet_list_human(response: &FleetListResponse) -> String {
     } else {
         let mut table = Table::new();
         table.load_preset(UTF8_FULL_CONDENSED);
-        table.set_header(vec!["Convoy", "Vessel", "Crew", "State", "Host", "Placement", "Staleness"]);
+        table.set_header(vec!["Convoy", "Vessel", "Crew", "State", "Attention", "Host", "Placement", "Staleness"]);
         for row in &response.rows {
             let vessel = match &row.authority {
                 Some(authority) => format!("{} ({authority})", row.vessel),
@@ -450,6 +450,7 @@ fn format_fleet_list_human(response: &FleetListResponse) -> String {
                 Cell::new(vessel),
                 Cell::new(&row.crew),
                 Cell::new(&row.crew_state),
+                Cell::new(row.attention.map_or_else(|| "-".to_string(), |attention| attention.to_string())),
                 Cell::new(row.host.as_str()),
                 Cell::new(row.placement_decision.as_ref().map_or_else(
                     || "-".to_string(),
@@ -518,12 +519,13 @@ fn format_fleet_list_human(response: &FleetListResponse) -> String {
 fn format_crew_list_human(response: &CrewListResponse) -> String {
     let mut table = Table::new();
     table.load_preset(UTF8_FULL_CONDENSED);
-    table.set_header(vec!["Role", "Kind", "State", "Adapter", "Model", "Stance"]);
+    table.set_header(vec!["Role", "Kind", "State", "Attention", "Adapter", "Model", "Stance"]);
     for member in &response.members {
         table.add_row(vec![
             Cell::new(&member.role),
             Cell::new(&member.kind),
             Cell::new(&member.state),
+            Cell::new(member.attention.map_or_else(|| "-".to_string(), |attention| attention.to_string())),
             Cell::new(member.adapter.as_deref().unwrap_or("-")),
             Cell::new(member.model.as_deref().unwrap_or("-")),
             Cell::new(member.stance.as_deref().unwrap_or("-")),

--- a/crates/flotilla-tui/src/cli/tests.rs
+++ b/crates/flotilla-tui/src/cli/tests.rs
@@ -532,8 +532,9 @@ mod command_result_human {
     use flotilla_protocol::{
         commands::{CheckoutStatus, CommandValue, RepositoryIdentityChange, ResourceJsonResponse},
         qualified_path::{HostId, QualifiedPath},
-        CrewListMember, CrewListResponse, FleetHealthResponse, FleetHostRow, FleetHostStaleness, FleetListResponse, FleetListRow,
-        FleetObservationAgreement, FleetReplicaStatus, FleetStaleness, HostName, NodeId, PeerConnectionState, PreparedWorkspace,
+        CrewAttention, CrewListMember, CrewListResponse, FleetHealthResponse, FleetHostRow, FleetHostStaleness, FleetListResponse,
+        FleetListRow, FleetObservationAgreement, FleetReplicaStatus, FleetStaleness, HostName, NodeId, PeerConnectionState,
+        PreparedWorkspace,
     };
 
     use crate::cli::format_command_result;
@@ -748,6 +749,7 @@ mod command_result_human {
                 .authority("adopted")
                 .crew("implement/coder")
                 .crew_state("running")
+                .attention(CrewAttention::NeedsInput)
                 .host(HostName::new("feta"))
                 .namespace("dev")
                 .staleness(FleetStaleness::Unreachable { last_sync: None, message: "connection refused".to_string() })
@@ -922,6 +924,7 @@ mod command_result_human {
                     role: "coder".into(),
                     kind: "agent".into(),
                     state: "active".into(),
+                    attention: Some(CrewAttention::Stalled),
                     adapter: Some("codex".into()),
                     model: None,
                     stance: Some("trusted-implicit".into()),
@@ -930,6 +933,7 @@ mod command_result_human {
                     role: "reviewer".into(),
                     kind: "agent".into(),
                     state: "latent".into(),
+                    attention: None,
                     adapter: None,
                     model: None,
                     stance: None,
@@ -942,6 +946,7 @@ mod command_result_human {
         assert!(output.contains("Convoy: convoy-a"));
         assert!(output.contains("coder"));
         assert!(output.contains("active"));
+        assert!(output.contains("stalled"));
         assert!(output.contains("reviewer"));
         assert!(output.contains("latent"));
         assert!(output.contains("trusted-implicit"));


### PR DESCRIPTION
## Summary

- add a typed crew attention projection separate from terminal and workflow lifecycle state
- report active crew as `working`, `needs input`, `stalled`, `idle`, or `unobservable` in `crew list` and federated `fleet list`
- derive `stalled` only from idle attention with unsettled crew work, preserving settled idle work and lifecycle phases

## Why

The terminal attention pipeline already observes hook and Cleat screen activity and emits resource/result-set events, but the crew-facing CLI collapsed every running terminal to `active` or `running`. Operators could therefore see a blocked crew member as indistinguishable from one making progress.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #1470
