### PR TITLE
ci: cache dependency artifacts only, trim test debuginfo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ env:
   # Cached dependency artifacts pay off across runs; short-lived incremental
   # generations cost more to upload and store than they save in CI.
   CARGO_INCREMENTAL: "0"
+  # CI needs file:line in backtraces, not full debuginfo — this halves
+  # target size and link time for test binaries.
+  CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
 
 jobs:
   fmt:
@@ -41,23 +44,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: actions/cache@v4
+      # Caches dependency artifacts only (workspace-member artifacts are
+      # pruned before save) — the previous whole-target cache reached 4.5GB
+      # and thrashed the repo's 10GB cache pool against compose's blobs.
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-clippy-v2-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-clippy-v2-
+          shared-key: "clippy"
       - run: cargo clippy --workspace --all-targets --locked -- -D warnings
-      - name: Remove incremental state before caching
-        if: always()
-        run: |
-          if [ -d target ]; then
-            find target -type d -name incremental -prune -exec rm -rf {} +
-          fi
 
   test:
     name: Test
@@ -66,20 +59,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v4
+      # Caches dependency artifacts only (workspace-member artifacts are
+      # pruned before save) — the previous whole-target cache reached 4.5GB
+      # and thrashed the repo's 10GB cache pool against compose's blobs.
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-test-v2-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-test-v2-
+          shared-key: "test"
       - run: cargo test --workspace --locked
-      - name: Remove incremental state before caching
-        if: always()
-        run: |
-          if [ -d target ]; then
-            find target -type d -name incremental -prune -exec rm -rf {} +
-          fi


### PR DESCRIPTION
The Test job's cache entry reached **4.46GB** (whole `target/` keyed on Cargo.lock), and the repo cache pool sits at **9.88GB of the 10GB limit across 145 entries** — cargo caches and compose buildkit blobs evict each other, so runs oscillate between multi-minute restores and cold rebuilds.

Changes:
- Replace the hand-rolled `actions/cache` blocks in Clippy/Test with `Swatinem/rust-cache@v2` (per-job shared keys): it caches dependency artifacts only, pruning workspace-member artifacts before save — the bulk of the 4.5GB was our own debuginfo-laden test binaries, which recompile every run regardless.
- Drop the now-redundant incremental-cleanup steps (rust-cache prunes; `CARGO_INCREMENTAL=0` already makes them no-ops).
- `CARGO_PROFILE_DEV_DEBUG=line-tables-only` for CI: backtraces keep file:line, target size and test-binary link time drop substantially.

Expected effect: cargo cache entries around 1–1.5GB, restores in tens of seconds, and enough pool headroom that compose blobs stop evicting the cargo caches.

https://claude.ai/code/session_01P3eF4i73CQk8zWVKBVArKp
