### PR TITLE
fix: keep failed convoys visible until reaped

### DIFF
--- a/crates/flotilla-core/src/aggregator_projection.rs
+++ b/crates/flotilla-core/src/aggregator_projection.rs
@@ -153,7 +153,7 @@ impl AggregatorProjectionState {
     }
 
     pub async fn result_set(&self) -> ResultSet {
-        hide_terminal_convoys(self.convoys.read().await.result_set())
+        self.convoys.read().await.result_set()
     }
 
     pub async fn convoy_result_set(&self, scope: &Option<QueryScope>) -> ResultSet {
@@ -168,7 +168,7 @@ impl AggregatorProjectionState {
     }
 
     pub async fn local_result_set(&self) -> ResultSet {
-        hide_terminal_convoys(self.convoys.read().await.local_result_set())
+        self.convoys.read().await.local_result_set()
     }
 
     pub async fn independents_result_set(&self, scope: &Option<QueryScope>) -> ResultSet {
@@ -433,15 +433,6 @@ fn convoy_phase_represents_issues(phase: ConvoyPhase) -> bool {
     matches!(phase, ConvoyPhase::Pending | ConvoyPhase::Active | ConvoyPhase::Interrupted | ConvoyPhase::Anchored | ConvoyPhase::Landing)
 }
 
-fn hide_terminal_convoys(mut set: ResultSet) -> ResultSet {
-    if let Rows::Convoys { rows, .. } = &mut set.rows {
-        rows.retain(|row| {
-            !matches!(row.phase, ConvoyPhase::Landed | ConvoyPhase::Failed | ConvoyPhase::Cancelled | ConvoyPhase::Abandoned)
-        });
-    }
-    set
-}
-
 fn convoy_matches_scope(row: &ConvoyRow, scope: &QueryScope) -> bool {
     row.resource.namespace == scope.namespace
         && row
@@ -687,21 +678,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn default_convoy_result_set_hides_terminal_records() {
+    async fn convoy_result_set_includes_terminal_records_until_they_are_deleted() {
         let state = AggregatorProjectionState::new();
         let active = convoy_row("flotilla", "active", "roadmap");
         let mut landing = convoy_row("flotilla", "landing", "roadmap");
         landing.phase = ConvoyPhase::Landing;
         let mut landed = convoy_row("flotilla", "landed", "roadmap");
         landed.phase = ConvoyPhase::Landed;
+        let mut failed = convoy_row("flotilla", "failed", "roadmap");
+        failed.phase = ConvoyPhase::Failed;
         {
             let mut convoys = state.write().await;
-            convoys.local_rows = [active.clone(), landing.clone(), landed].into_iter().map(|row| (row.resource.clone(), row)).collect();
+            convoys.local_rows = [active.clone(), landing.clone(), landed.clone(), failed.clone()]
+                .into_iter()
+                .map(|row| (row.resource.clone(), row))
+                .collect();
         }
 
         let result = state.result_set_for(&QueryId::Convoys { scope: None }).await.expect("convoy result set");
 
-        assert_eq!(result.rows.as_convoys().expect("convoy rows"), &[active, landing]);
+        assert_eq!(result.rows.as_convoys().expect("convoy rows"), &[active, failed, landed, landing]);
     }
 
     #[tokio::test]

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -3157,7 +3157,7 @@ async fn fleet_health_keeps_link_heartbeat_and_generation_disagreements_visible(
 }
 
 #[tokio::test]
-async fn fleet_list_hides_local_crewless_terminal_convoys() {
+async fn fleet_list_shows_local_crewless_failed_convoys_with_failure_state() {
     let temp = tempfile::tempdir().expect("create tempdir");
     let config_base = temp.path().join("config");
     std::fs::create_dir_all(&config_base).expect("create config dir");
@@ -3172,7 +3172,12 @@ async fn fleet_list_hides_local_crewless_terminal_convoys() {
 
     let response = daemon.fleet_list_internal().await.expect("fleet list should succeed");
 
-    assert!(response.rows.is_empty());
+    assert_eq!(response.rows.len(), 1);
+    let row = &response.rows[0];
+    assert_eq!(row.convoy, "convoy-failed");
+    assert_eq!(row.vessel, "-");
+    assert_eq!(row.crew, "-");
+    assert_eq!(row.crew_state, "failed: missing input 'topic'");
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -1120,7 +1120,12 @@ impl Aggregator {
 
     async fn rebuild_local_projection(&mut self) {
         self.refresh_origin_hosts().await;
-        let effective_convoys = self.effective_convoy_reads();
+        // A deletion timestamp begins finalizer-driven reaping; it does not
+        // mean the Convoy or its child resources have left the store yet.
+        // Keep the parent row projected until the watch emits Deleted so
+        // vessels, checkouts, and sessions never appear parentless during
+        // teardown.
+        let effective_convoys = self.effective_convoy_reads_including_deleted();
         let salience_changed = self.rebuild_salience_projection().await;
         let presentation_keys = effective_convoys
             .values()
@@ -3042,6 +3047,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn failed_convoy_remains_projected_until_reaping_finishes() {
+        let state = AggregatorProjectionState::new();
+        let (event_tx, _) = broadcast::channel(1);
+        let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), event_tx);
+        let mut convoy = convoy_object("failed-convoy").await;
+        convoy.status = Some(ConvoyStatus {
+            phase: ResourceConvoyPhase::Failed,
+            message: Some("acceptance criteria not met".to_string()),
+            ..Default::default()
+        });
+        aggregator.apply_convoy_event_from(LocalSource::Durable, WatchEvent::Added(convoy.clone())).await;
+
+        convoy.metadata.deletion_timestamp = Some(Utc::now());
+        aggregator.apply_convoy_event_from(LocalSource::Durable, WatchEvent::Modified(convoy.clone())).await;
+
+        let result = state.result_set().await;
+        let rows = result.rows.as_convoys().expect("convoy rows");
+        assert!(
+            matches!(rows, [row] if row.name == "failed-convoy" && row.phase == ConvoyPhase::Failed),
+            "a terminal convoy must remain visible while its finalizers reap child resources: {rows:?}"
+        );
+
+        aggregator.apply_convoy_event_from(LocalSource::Durable, WatchEvent::Deleted(convoy)).await;
+
+        let result = state.result_set().await;
+        assert!(result.rows.as_convoys().expect("convoy rows").is_empty(), "a reaped convoy must leave the projection");
+    }
+
+    #[tokio::test]
     async fn reclaim_refusal_demand_marks_convoy_for_attention_with_reason() {
         let state = AggregatorProjectionState::new();
         let (event_tx, mut event_rx) = broadcast::channel(8);
@@ -3177,7 +3211,8 @@ mod tests {
         let durable_convoys = ScriptedSource::new(vec![empty_list()], vec![Ok(watch_events(vec![
             WatchEvent::Added(convoy),
             WatchEvent::Added(unrelated_convoy),
-            WatchEvent::Modified(deleting_convoy),
+            WatchEvent::Modified(deleting_convoy.clone()),
+            WatchEvent::Deleted(deleting_convoy),
         ]))]);
         let durable_presentations = ScriptedSource::new(vec![empty_list()], vec![Ok(pending_watch())]);
         let observed_convoys = ScriptedSource::new(vec![empty_list()], vec![Ok(pending_watch())]);
@@ -3234,7 +3269,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn deleting_convoy_is_hidden_from_rows_but_retained_for_salience() {
+    async fn deleting_convoy_remains_in_rows_and_salience_until_deleted() {
         let state = AggregatorProjectionState::new();
         let (event_tx, _) = broadcast::channel(4);
         let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), event_tx);
@@ -3250,7 +3285,8 @@ mod tests {
             Some(TerminalAttention { state: TerminalAttentionState::Idle, as_of: now, source: TerminalAttentionSource::Hook });
         aggregator.apply_session_event_from(LocalSource::Durable, WatchEvent::Added(session)).await;
 
-        assert!(state.result_set().await.rows.as_convoys().expect("convoy rows").is_empty());
+        let result = state.result_set().await;
+        assert_eq!(result.rows.as_convoys().expect("convoy rows")[0].name, "convoy-a");
         assert!(!aggregator.salience_facts_at(now).attention[0].work_unsettled);
     }
 

--- a/crates/flotilla-daemon/src/aggregator.rs
+++ b/crates/flotilla-daemon/src/aggregator.rs
@@ -3269,7 +3269,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn deleting_convoy_remains_in_rows_and_salience_until_deleted() {
+    async fn soft_deleting_convoy_remains_in_rows_and_salience() {
         let state = AggregatorProjectionState::new();
         let (event_tx, _) = broadcast::channel(4);
         let mut aggregator = Aggregator::new(state.clone(), HostName::new("local"), event_tx);

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -1136,12 +1136,7 @@ async fn projection_parity_condition(
     projection: &AggregatorProjectionState,
 ) -> Result<Option<HostCondition>, String> {
     let stored = backend.using::<Convoy>(namespace).list().await.map_err(|error| error.to_string())?;
-    let expected = stored
-        .items
-        .into_iter()
-        .filter(|convoy| !convoy.status.as_ref().is_some_and(|status| status.phase.is_terminal()))
-        .map(|convoy| convoy.metadata.name)
-        .collect::<BTreeSet<_>>();
+    let expected = stored.items.into_iter().map(|convoy| convoy.metadata.name).collect::<BTreeSet<_>>();
     let projected = match projection.local_result_set().await.rows {
         Rows::Convoys { rows, .. } => rows.into_iter().map(|row| row.resource.name).collect::<BTreeSet<_>>(),
         rows => return Err(format!("local convoy projection returned unexpected rows: {rows:?}")),
@@ -1151,7 +1146,7 @@ async fn projection_parity_condition(
         return Ok(None);
     }
     let message = format!(
-        "durable store has {} live convoys but the local aggregator projection has {}; missing: {}",
+        "durable store has {} convoys but the local aggregator projection has {}; missing: {}",
         expected.len(),
         projected.len(),
         missing.join(", ")
@@ -5800,11 +5795,20 @@ mod tests {
     #[tokio::test]
     async fn projection_parity_reports_and_clears_missing_local_convoys() {
         let backend = ResourceBackend::InMemory(Default::default());
-        backend
-            .using::<Convoy>(NAMESPACE)
-            .create(&empty_meta("convoy-a"), &ConvoySpec::builder().workflow_ref("workflow".to_string()).build())
+        let convoys = backend.using::<Convoy>(NAMESPACE);
+        let meta = InputMeta::builder().name("convoy-a".to_string()).finalizers(vec!["flotilla.work/test-finalizer".to_string()]).build();
+        let created = convoys
+            .create(&meta, &ConvoySpec::builder().workflow_ref("workflow".to_string()).build())
             .await
             .expect("create durable convoy");
+        let failed = convoys
+            .update_status(&created.metadata.name, &created.metadata.resource_version, &ConvoyStatus {
+                phase: ConvoyPhase::Failed,
+                ..Default::default()
+            })
+            .await
+            .expect("mark durable convoy failed");
+        convoys.delete(&failed.metadata.name).await.expect("begin durable convoy reaping");
         let projection = AggregatorProjectionState::new();
 
         let degraded = projection_parity_condition(&backend, NAMESPACE, &projection)

--- a/crates/flotilla-daemon/tests/aggregator.rs
+++ b/crates/flotilla-daemon/tests/aggregator.rs
@@ -869,8 +869,8 @@ async fn subscribe_queries_replays_result_set_after_seq() {
         heartbeat_interval: Duration::from_secs(300),
         controller_resync_interval: Duration::from_secs(300),
         // This test exercises query replay, not convoy reconciliation. Keeping
-        // controllers stopped prevents the intentionally incomplete fixtures
-        // from being failed and hidden from the default active-convoy query.
+        // controllers stopped prevents unrelated status transitions in the
+        // intentionally incomplete fixtures.
         start_controllers: false,
         ..RuntimeOptions::default()
     };


### PR DESCRIPTION
## What changed

- keep terminal Convoys in the store-backed Convoys result set instead of filtering them by phase
- retain soft-deleting Convoy rows until finalizer-driven reaping emits the actual delete event
- include every stored Convoy in projection parity monitoring
- make `flotilla ls` regression coverage assert a local Failed Convoy renders its failure state

## Why

The Convoys query filtered terminal phases and the Aggregator also dropped resources as soon as `deletion_timestamp` appeared. A Failed Convoy therefore vanished while its finalizers were still reaping vessels, checkouts, and sessions, leaving those child rows looking parentless at the point where operator attention mattered most.

Deletion timestamps begin teardown; they do not mean the resource has left the store. The projection now follows store lifetime and removes a Convoy only after the resource watch reports deletion.

## Impact

Failed and other terminal-but-unreaped Convoys remain visible in the TUI and `flotilla ls`. Failed rows retain their existing error-tone rendering and failure message. Child resource rows keep a visible parent throughout teardown.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1476
