### PR TITLE
feat: split portfolio DAG generated state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
         run: |
           scripts/test-prune-target.sh
           scripts/test-cargo-sweep-mtime.sh
+      - name: Test portfolio DAG scripts
+        run: |
+          python3 -m unittest scripts.tests.test_dag_fetch
+          node scripts/tests/dag_board_test.mjs
       - name: Check Rust formatting
         run: cargo +nightly-2026-03-12 fmt --check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,17 @@ jobs:
         run: |
           scripts/test-prune-target.sh
           scripts/test-cargo-sweep-mtime.sh
-      - name: Test portfolio DAG scripts
-        run: |
-          python3 -m unittest scripts.tests.test_dag_fetch
-          node scripts/tests/dag_board_test.mjs
       - name: Check Rust formatting
         run: cargo +nightly-2026-03-12 fmt --check
+
+  dag-scripts:
+    name: DAG scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          python3 -m unittest scripts.tests.test_dag_fetch
+          node scripts/tests/dag_board_test.mjs
 
   clippy:
     name: Clippy

--- a/docs/portfolio-dag.md
+++ b/docs/portfolio-dag.md
@@ -1,0 +1,71 @@
+# Portfolio DAG board
+
+The portfolio board keeps tracker and fleet facts separate from operator
+judgment:
+
+- `scripts/dag-fetch` replaces only the generated JSON layer. It reads GitHub
+  issues and pull requests for `flotilla-org/flotilla` and
+  `flotilla-org/andamento`, plus exact issue associations from Flotilla convoy
+  resources.
+- `scripts/flotilla-tickets-dag.authored.json` owns the pulse, detail notes,
+  display metadata for groups and shapes, and any edges that are judgments
+  rather than native GitHub dependencies.
+- `scripts/flotilla-tickets-dag.html` merges both layers in the browser.
+  Generated status always wins. A detail note with a different
+  `statusAtAuthoring` is rendered with a prominent stale warning.
+
+## Refresh and view
+
+The default generated output preserves the original desk-board location. Copy
+the board assets only after moving the legacy HTML's `pulse`, ticket `detail`
+cards, shapes, group presentation, and non-native edges into
+`flotilla-tickets-dag.authored.json`:
+
+```bash
+scripts/dag-fetch
+cp scripts/flotilla-tickets-dag.html scripts/dag-board.mjs ~/dev/
+python3 -m http.server --directory ~/dev 8000
+```
+
+Then open `http://localhost:8000/flotilla-tickets-dag.html`. To work entirely
+from the checkout instead:
+
+```bash
+scripts/dag-fetch --output scripts/flotilla-tickets-dag.generated.json
+python3 -m http.server 8000
+```
+
+Open `http://localhost:8000/scripts/flotilla-tickets-dag.html`. The page also
+accepts `?generated=URL&authored=URL` for alternate layer locations.
+
+On a new board, the empty authored-layer template can be copied explicitly:
+
+```bash
+cp scripts/flotilla-tickets-dag.authored.json ~/dev/
+```
+
+Never run that command over a populated authored layer: fetches intentionally
+do not read or write authored JSON.
+
+The authored ticket map is keyed by the exact reference, for example:
+
+```json
+{
+  "tickets": {
+    "flotilla-org/flotilla#1091": {
+      "detail": "Why this ticket matters right now.",
+      "statusAtAuthoring": "at-sea",
+      "shape": "diamond"
+    }
+  }
+}
+```
+
+When editing a detail, set `statusAtAuthoring` to the status visible at that
+moment (`landed`, `at-sea`, `ready`, or `blocked`). Do not update it during a
+mechanical refresh: the mismatch is what exposes drift.
+
+`dag-fetch` deliberately includes no wall-clock generation timestamp. Its
+`asOf` value is the greatest stable source timestamp, and all maps and lists
+are sorted before serialization. With unchanged source observations, repeated
+runs therefore produce byte-identical output.

--- a/scripts/dag-board.mjs
+++ b/scripts/dag-board.mjs
@@ -1,0 +1,153 @@
+const STATUS_ORDER = { "at-sea": 0, blocked: 1, ready: 2, landed: 3 };
+
+export function noteIsStale(generatedTicket, authoredTicket = {}) {
+  return Boolean(
+    authoredTicket.detail &&
+      authoredTicket.statusAtAuthoring &&
+      authoredTicket.statusAtAuthoring !== generatedTicket.status,
+  );
+}
+
+export function mergeLayers(generated, authored) {
+  const authoredTickets = authored.tickets || {};
+  const tickets = (generated.tickets || []).map((ticket) => {
+    const annotation = authoredTickets[ticket.ref] || {};
+    return {
+      ...annotation,
+      ...ticket,
+      detail: annotation.detail || "",
+      noteStale: noteIsStale(ticket, annotation),
+    };
+  });
+
+  const groups = {};
+  for (const [name, refs] of Object.entries(generated.groups || {})) {
+    groups[name] = { name, label: name, ticketRefs: [...refs], ...(authored.groups?.[name] || {}) };
+  }
+  for (const [name, group] of Object.entries(authored.groups || {})) {
+    groups[name] ||= { name, label: name, ticketRefs: [], ...group };
+  }
+
+  const edges = [
+    ...(generated.dependencyEdges || []).map((edge) => ({ ...edge, source: "generated" })),
+    ...(authored.edges || []).map((edge) => ({ ...edge, source: "authored" })),
+  ];
+  const uniqueEdges = [...new Map(edges.map((edge) => [`${edge.from}\0${edge.to}\0${edge.label || ""}`, edge])).values()];
+
+  return {
+    ...generated,
+    pulse: authored.pulse || "",
+    tickets: tickets.sort(
+      (left, right) =>
+        (STATUS_ORDER[left.status] ?? 99) - (STATUS_ORDER[right.status] ?? 99) || left.ref.localeCompare(right.ref),
+    ),
+    groups,
+    edges: uniqueEdges,
+  };
+}
+
+function element(tag, attributes = {}, children = []) {
+  const node = document.createElement(tag);
+  for (const [name, value] of Object.entries(attributes)) {
+    if (name === "className") node.className = value;
+    else if (name === "text") node.textContent = value;
+    else if (name === "style") Object.assign(node.style, value);
+    else node.setAttribute(name, value);
+  }
+  for (const child of children) node.append(child);
+  return node;
+}
+
+function ticketCard(ticket, edges) {
+  const title = element("a", { href: ticket.url, text: ticket.title, target: "_blank", rel: "noreferrer" });
+  const header = element("header", {}, [
+    element("span", { className: `shape shape-${ticket.shape || "card"}`, "aria-hidden": "true" }),
+    element("div", {}, [element("small", { text: ticket.ref }), title]),
+    element("span", { className: `status status-${ticket.status}`, text: ticket.status }),
+  ]);
+  const children = [header];
+  if (ticket.detail) {
+    const noteClass = ticket.noteStale ? "detail stale" : "detail";
+    const note = element("div", { className: noteClass });
+    if (ticket.noteStale) {
+      note.append(
+        element("strong", {
+          className: "stale-label",
+          text: `STALE NOTE · was ${ticket.statusAtAuthoring}, now ${ticket.status}`,
+        }),
+      );
+    }
+    note.append(element("p", { text: ticket.detail }));
+    children.push(note);
+  }
+  if (ticket.convoys?.length) {
+    const convoyText = ticket.convoys
+      .map((convoy) => `${convoy.name} on ${convoy.host || "unknown host"} · ${convoy.phase}`)
+      .join("; ");
+    children.push(element("p", { className: "meta", text: `⚓ ${convoyText}` }));
+  }
+  if (ticket.pullRequests?.length) {
+    children.push(
+      element("p", {
+        className: "meta",
+        text: ticket.pullRequests.map((pr) => `PR ${pr.ref?.split("#").at(-1) || "?"}: ${pr.state}, CI ${pr.ci}`).join("; "),
+      }),
+    );
+  }
+  const incoming = edges.filter((edge) => edge.to === ticket.ref);
+  if (incoming.length) {
+    children.push(
+      element("p", {
+        className: "dependencies",
+        text: `Depends on ${incoming.map((edge) => edge.from).join(", ")}`,
+      }),
+    );
+  }
+  return element("article", { className: `ticket ticket-${ticket.status}` }, children);
+}
+
+export function renderBoard(root, board) {
+  root.replaceChildren();
+  if (board.pulse) {
+    root.append(
+      element("section", { className: "pulse" }, [element("span", { text: "PULSE" }), element("p", { text: board.pulse })]),
+    );
+  }
+  const summary = element("section", { className: "summary", "aria-label": "Status summary" });
+  for (const status of ["at-sea", "blocked", "ready", "landed"]) {
+    summary.append(
+      element("div", {}, [
+        element("strong", { text: board.tickets.filter((ticket) => ticket.status === status).length }),
+        element("span", { text: status }),
+      ]),
+    );
+  }
+  root.append(summary);
+
+  const columns = element("section", { className: "columns" });
+  const groupedRefs = new Set(Object.values(board.groups).flatMap((group) => group.ticketRefs));
+  const groupEntries = Object.entries(board.groups);
+  const uncategorized = board.tickets.filter((ticket) => !groupedRefs.has(ticket.ref)).map((ticket) => ticket.ref);
+  if (uncategorized.length) groupEntries.push(["uncategorized", { label: "Uncategorized", ticketRefs: uncategorized }]);
+
+  for (const [name, group] of groupEntries.sort((left, right) => left[1].label.localeCompare(right[1].label))) {
+    const refs = new Set(group.ticketRefs);
+    const tickets = board.tickets.filter((ticket) => refs.has(ticket.ref));
+    if (!tickets.length) continue;
+    const column = element("section", { className: "group", "data-group": name });
+    column.style.setProperty("--group-color", group.color || "#8b9bb4");
+    column.append(element("h2", { text: group.label }), ...tickets.map((ticket) => ticketCard(ticket, board.edges)));
+    columns.append(column);
+  }
+  root.append(columns);
+}
+
+export async function loadBoard({ authoredUrl, generatedUrl }) {
+  const load = async (url) => {
+    const response = await fetch(url, { cache: "no-store" });
+    if (!response.ok) throw new Error(`${url}: ${response.status} ${response.statusText}`);
+    return response.json();
+  };
+  const [generated, authored] = await Promise.all([load(generatedUrl), load(authoredUrl)]);
+  return mergeLayers(generated, authored);
+}

--- a/scripts/dag-board.mjs
+++ b/scripts/dag-board.mjs
@@ -130,7 +130,7 @@ export function renderBoard(root, board) {
   const groupedRefs = new Set(Object.values(board.groups).flatMap((group) => group.ticketRefs));
   const groupEntries = Object.entries(board.groups);
   const uncategorized = board.tickets.filter((ticket) => !groupedRefs.has(ticket.ref)).map((ticket) => ticket.ref);
-  if (uncategorized.length) groupEntries.push(["uncategorized", { label: "Uncategorized", ticketRefs: uncategorized }]);
+  if (uncategorized.length) groupEntries.push(["__ungrouped__", { label: "Uncategorized", ticketRefs: uncategorized }]);
 
   for (const [name, group] of groupEntries.sort((left, right) => left[1].label.localeCompare(right[1].label))) {
     const refs = new Set(group.ticketRefs);

--- a/scripts/dag-board.mjs
+++ b/scripts/dag-board.mjs
@@ -20,7 +20,9 @@ export function mergeLayers(generated, authored) {
     };
   });
 
-  const groups = {};
+  // Label names are external keys; a null prototype keeps names such as
+  // `__proto__` as ordinary own properties.
+  const groups = Object.create(null);
   for (const [name, refs] of Object.entries(generated.groups || {})) {
     groups[name] = { name, label: name, ticketRefs: [...refs], ...(authored.groups?.[name] || {}) };
   }

--- a/scripts/dag-fetch
+++ b/scripts/dag-fetch
@@ -98,8 +98,19 @@ def convoy_facts() -> dict[str, list[dict[str, Any]]]:
         status = obj.get("status", {})
         provenance = record.get("provenance", {})
         rows = rows_by_convoy.get(name, [])
-        row = min(rows, key=lambda item: json.dumps(item, sort_keys=True)) if rows else {}
-        host = row.get("host") or status.get("placement_decision", {}).get("target_host", {}).get("display_name")
+        freshness = {"stale": 1, "current": 2, "local": 3}
+        row = (
+            max(
+                rows,
+                key=lambda item: (
+                    freshness.get(item.get("staleness", {}).get("kind", ""), 0),
+                    json.dumps(item, sort_keys=True),
+                ),
+            )
+            if rows
+            else {}
+        )
+        host = status.get("placement_decision", {}).get("target_host", {}).get("display_name") or row.get("host")
         # Ages and sync timestamps advance even when the observation does not
         # change. Persist the semantic category only so refreshes stay stable.
         staleness = {"kind": (row.get("staleness") or {}).get("kind") or provenance.get("source", "unknown")}

--- a/scripts/dag-fetch
+++ b/scripts/dag-fetch
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Materialize the deterministic facts used by the portfolio DAG board."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+REPOSITORIES = ("flotilla-org/andamento", "flotilla-org/flotilla")
+ISSUE_FIELDS = (
+    "number,title,state,url,updatedAt,closedAt,labels,blockedBy,blocking,"
+    "closedByPullRequestsReferences"
+)
+PR_FIELDS = "number,state,url,mergedAt,mergeStateStatus,statusCheckRollup"
+
+
+def command_json(arguments: list[str]) -> Any:
+    try:
+        result = subprocess.run(arguments, check=True, stdout=subprocess.PIPE, text=True)
+    except FileNotFoundError as error:
+        raise SystemExit(f"required command not found: {arguments[0]}") from error
+    except subprocess.CalledProcessError as error:
+        raise SystemExit(f"command failed ({error.returncode}): {' '.join(arguments)}") from error
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise SystemExit(f"command returned invalid JSON: {' '.join(arguments)}: {error}") from error
+
+
+def github_ref(url: str) -> str | None:
+    parts = urlparse(url).path.strip("/").split("/")
+    if len(parts) >= 4 and parts[2] in {"issues", "pull"}:
+        return f"{parts[0]}/{parts[1]}#{parts[3]}"
+    return None
+
+
+def check_state(checks: list[dict[str, Any]]) -> str:
+    if not checks:
+        return "none"
+    pending = {"EXPECTED", "IN_PROGRESS", "PENDING", "QUEUED", "REQUESTED", "WAITING"}
+    acceptable = {"NEUTRAL", "SKIPPED", "SUCCESS"}
+    states = [str(check.get("status") or check.get("state") or "").upper() for check in checks]
+    if any(state in pending for state in states):
+        return "pending"
+    conclusions = [str(check.get("conclusion") or check.get("state") or "").upper() for check in checks]
+    if any(conclusion and conclusion not in acceptable for conclusion in conclusions):
+        return "failure"
+    return "success" if all(conclusion in acceptable for conclusion in conclusions) else "unknown"
+
+
+def convoy_facts() -> dict[str, list[dict[str, Any]]]:
+    resources = command_json(["flotilla", "resource", "list", "convoys", "--json"])
+    fleet_list = command_json(["flotilla", "ls", "--json"])
+    rows_by_convoy: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in fleet_list.get("rows", []):
+        if row.get("convoy"):
+            rows_by_convoy[row["convoy"]].append(row)
+
+    # A peer can expose the same convoy through more than one provenance. Prefer
+    # local authority, then the newest replica, without depending on input order.
+    records: dict[str, tuple[tuple[bool, str, str], dict[str, Any]]] = {}
+    for record in resources.get("records", []):
+        obj = record.get("object", {})
+        name = obj.get("metadata", {}).get("name")
+        if not name:
+            continue
+        provenance = record.get("provenance", {})
+        rank = (
+            provenance.get("source") == "local",
+            provenance.get("lastSyncedAt", ""),
+            obj.get("metadata", {}).get("resourceVersion", ""),
+        )
+        old = records.get(name)
+        if old is None or rank > old[0]:
+            records[name] = (rank, record)
+
+    by_issue: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for name, (_, record) in sorted(records.items()):
+        obj = record["object"]
+        status = obj.get("status", {})
+        provenance = record.get("provenance", {})
+        rows = rows_by_convoy.get(name, [])
+        row = min(rows, key=lambda item: json.dumps(item, sort_keys=True)) if rows else {}
+        host = row.get("host") or status.get("placement_decision", {}).get("target_host", {}).get("display_name")
+        # Ages and sync timestamps advance even when the observation does not
+        # change. Persist the semantic category only so refreshes stay stable.
+        staleness = {"kind": (row.get("staleness") or {}).get("kind") or provenance.get("source", "unknown")}
+        fact = {
+            "name": name,
+            "phase": status.get("phase", "Unknown"),
+            "host": host,
+            "staleness": staleness,
+        }
+        for carried in obj.get("spec", {}).get("issues") or []:
+            reference = carried.get("reference", {})
+            source = reference.get("source", {})
+            if source.get("service", "").rstrip("/") != "https://github.com":
+                continue
+            scope, issue_id = source.get("scope"), reference.get("id")
+            if scope in REPOSITORIES and issue_id is not None:
+                by_issue[f"{scope}#{issue_id}"].append(fact)
+    return {ref: sorted(facts, key=lambda fact: fact["name"]) for ref, facts in sorted(by_issue.items())}
+
+
+def fetch_repository(repository: str) -> tuple[list[dict[str, Any]], dict[int, dict[str, Any]]]:
+    issues = command_json(
+        ["gh", "issue", "list", "-R", repository, "--state", "all", "--limit", "10000", "--json", ISSUE_FIELDS]
+    )
+    pull_requests = command_json(
+        ["gh", "pr", "list", "-R", repository, "--state", "all", "--limit", "10000", "--json", PR_FIELDS]
+    )
+    return issues, {pull_request["number"]: pull_request for pull_request in pull_requests}
+
+
+def generated_layer() -> dict[str, Any]:
+    convoys = convoy_facts()
+    tickets: list[dict[str, Any]] = []
+    edges: set[tuple[str, str]] = set()
+    groups: dict[str, list[str]] = defaultdict(list)
+    timestamps: list[str] = []
+
+    for repository in REPOSITORIES:
+        issues, pull_requests = fetch_repository(repository)
+        for issue in issues:
+            ref = f"{repository}#{issue['number']}"
+            carried_by = convoys.get(ref, [])
+            open_blockers = [node for node in issue.get("blockedBy", {}).get("nodes", []) if node.get("state") == "OPEN"]
+            if issue["state"] == "CLOSED":
+                status = "landed"
+            elif any(convoy["phase"].lower() == "active" for convoy in carried_by):
+                status = "at-sea"
+            elif carried_by or open_blockers:
+                status = "blocked"
+            else:
+                status = "ready"
+
+            labels = sorted(label["name"] for label in issue.get("labels", []))
+            for label in labels:
+                groups[label].append(ref)
+            for blocker in issue.get("blockedBy", {}).get("nodes", []):
+                blocker_ref = github_ref(blocker.get("url", ""))
+                if blocker_ref:
+                    edges.add((blocker_ref, ref))
+
+            prs = []
+            for closing_ref in issue.get("closedByPullRequestsReferences", []):
+                pr_repository = closing_ref.get("repository", {})
+                slug = f"{pr_repository.get('owner', {}).get('login')}/{pr_repository.get('name')}"
+                details = pull_requests.get(closing_ref.get("number")) if slug == repository else None
+                pr = {
+                    "ref": github_ref(closing_ref["url"]),
+                    "url": closing_ref["url"],
+                    "state": str(details.get("state", "unknown")).lower() if details else "unknown",
+                    "ci": check_state(details.get("statusCheckRollup", [])) if details else "unknown",
+                }
+                if details and details.get("mergeStateStatus"):
+                    pr["mergeState"] = details["mergeStateStatus"].lower()
+                prs.append(pr)
+
+            timestamps.extend(value for value in (issue.get("updatedAt"), issue.get("closedAt")) if value)
+            tickets.append(
+                {
+                    "ref": ref,
+                    "repository": repository,
+                    "number": issue["number"],
+                    "title": issue["title"],
+                    "url": issue["url"],
+                    "status": status,
+                    "trackerState": issue["state"].lower(),
+                    "updatedAt": issue["updatedAt"],
+                    "labels": labels,
+                    "blockedBy": sorted(
+                        filter(None, (github_ref(node.get("url", "")) for node in issue.get("blockedBy", {}).get("nodes", [])))
+                    ),
+                    "pullRequests": sorted(prs, key=lambda pr: pr["url"]),
+                    "convoys": carried_by,
+                }
+            )
+
+    return {
+        "schemaVersion": 1,
+        "asOf": max(timestamps, default=None),
+        "repositories": list(REPOSITORIES),
+        "tickets": sorted(tickets, key=lambda ticket: (ticket["repository"], ticket["number"])),
+        "dependencyEdges": [{"from": source, "to": target} for source, target in sorted(edges)],
+        "groups": {label: sorted(refs) for label, refs in sorted(groups.items())},
+    }
+
+
+def write_json(path: Path, value: Any) -> None:
+    path = path.expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent, text=True)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as temporary:
+            temporary.write(content)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        os.replace(temporary_name, path)
+    finally:
+        if os.path.exists(temporary_name):
+            os.unlink(temporary_name)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("~/dev/flotilla-tickets-dag.generated.json"),
+        help="generated JSON path (default: %(default)s)",
+    )
+    args = parser.parse_args()
+    write_json(args.output, generated_layer())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dag-fetch
+++ b/scripts/dag-fetch
@@ -16,7 +16,7 @@ from urllib.parse import urlparse
 
 REPOSITORIES = ("flotilla-org/andamento", "flotilla-org/flotilla")
 ISSUE_FIELDS = (
-    "number,title,state,url,updatedAt,closedAt,labels,blockedBy,blocking,"
+    "number,title,state,url,updatedAt,closedAt,labels,blockedBy,"
     "closedByPullRequestsReferences"
 )
 PR_FIELDS = "number,state,url,mergedAt,mergeStateStatus,statusCheckRollup"
@@ -24,11 +24,13 @@ PR_FIELDS = "number,state,url,mergedAt,mergeStateStatus,statusCheckRollup"
 
 def command_json(arguments: list[str]) -> Any:
     try:
-        result = subprocess.run(arguments, check=True, stdout=subprocess.PIPE, text=True)
+        result = subprocess.run(arguments, check=True, stdout=subprocess.PIPE, text=True, timeout=300)
     except FileNotFoundError as error:
         raise SystemExit(f"required command not found: {arguments[0]}") from error
     except subprocess.CalledProcessError as error:
         raise SystemExit(f"command failed ({error.returncode}): {' '.join(arguments)}") from error
+    except subprocess.TimeoutExpired as error:
+        raise SystemExit(f"command timed out after 300 seconds: {' '.join(arguments)}") from error
     try:
         return json.loads(result.stdout)
     except json.JSONDecodeError as error:

--- a/scripts/dag-fetch
+++ b/scripts/dag-fetch
@@ -56,6 +56,14 @@ def check_state(checks: list[dict[str, Any]]) -> str:
     return "success" if all(conclusion in acceptable for conclusion in conclusions) else "unknown"
 
 
+def resource_version_rank(value: Any) -> tuple[bool, int, str]:
+    text = str(value or "")
+    try:
+        return True, int(text), ""
+    except ValueError:
+        return False, 0, text
+
+
 def convoy_facts() -> dict[str, list[dict[str, Any]]]:
     resources = command_json(["flotilla", "resource", "list", "convoys", "--json"])
     fleet_list = command_json(["flotilla", "ls", "--json"])
@@ -66,7 +74,7 @@ def convoy_facts() -> dict[str, list[dict[str, Any]]]:
 
     # A peer can expose the same convoy through more than one provenance. Prefer
     # local authority, then the newest replica, without depending on input order.
-    records: dict[str, tuple[tuple[bool, str, str], dict[str, Any]]] = {}
+    records: dict[str, tuple[tuple[Any, ...], dict[str, Any]]] = {}
     for record in resources.get("records", []):
         obj = record.get("object", {})
         name = obj.get("metadata", {}).get("name")
@@ -76,7 +84,7 @@ def convoy_facts() -> dict[str, list[dict[str, Any]]]:
         rank = (
             provenance.get("source") == "local",
             provenance.get("lastSyncedAt", ""),
-            obj.get("metadata", {}).get("resourceVersion", ""),
+            resource_version_rank(obj.get("metadata", {}).get("resourceVersion")),
         )
         old = records.get(name)
         if old is None or rank > old[0]:

--- a/scripts/flotilla-tickets-dag.authored.json
+++ b/scripts/flotilla-tickets-dag.authored.json
@@ -1,0 +1,7 @@
+{
+  "edges": [],
+  "groups": {},
+  "pulse": "",
+  "schemaVersion": 1,
+  "tickets": {}
+}

--- a/scripts/flotilla-tickets-dag.html
+++ b/scripts/flotilla-tickets-dag.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Flotilla portfolio DAG</title>
+    <style>
+      :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; background: #0c111b; color: #e9eef8; }
+      * { box-sizing: border-box; }
+      body { margin: 0; background: radial-gradient(circle at top, #18243a 0, #0c111b 34rem); }
+      body > header { padding: 2.4rem clamp(1rem, 4vw, 4rem) 1rem; display: flex; align-items: end; justify-content: space-between; gap: 2rem; }
+      h1 { margin: 0; font-size: clamp(1.7rem, 4vw, 3.3rem); letter-spacing: -.04em; }
+      #as-of { color: #9aa8bc; font-variant-numeric: tabular-nums; }
+      main { padding: 0 clamp(1rem, 4vw, 4rem) 4rem; }
+      .pulse { margin: 1rem 0 1.5rem; border: 1px solid #486384; border-left: 4px solid #70b8ff; border-radius: .8rem; background: #111c2d; padding: 1rem 1.2rem; display: grid; grid-template-columns: auto 1fr; gap: 1rem; }
+      .pulse span { color: #70b8ff; font-weight: 800; letter-spacing: .13em; font-size: .75rem; }
+      .pulse p { margin: 0; line-height: 1.55; white-space: pre-wrap; }
+      .summary { display: flex; gap: .7rem; margin-bottom: 1.2rem; flex-wrap: wrap; }
+      .summary div { min-width: 7.5rem; border: 1px solid #2b3950; border-radius: .7rem; background: #101827; padding: .65rem .9rem; }
+      .summary strong { display: block; font-size: 1.45rem; }
+      .summary span { color: #9aa8bc; text-transform: uppercase; letter-spacing: .08em; font-size: .7rem; }
+      .columns { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 22rem), 1fr)); align-items: start; gap: 1rem; }
+      .group { border-top: 3px solid var(--group-color); border-radius: .7rem; background: #0a0f18aa; padding: .8rem; }
+      .group h2 { margin: .15rem .2rem .8rem; font-size: .9rem; text-transform: uppercase; letter-spacing: .08em; color: var(--group-color); }
+      .ticket { margin: .7rem 0; border: 1px solid #2a3850; border-left: 4px solid #8290a5; border-radius: .65rem; background: #121a29; padding: .9rem; box-shadow: 0 .5rem 1.3rem #0004; }
+      .ticket-at-sea { border-left-color: #57b7ff; } .ticket-blocked { border-left-color: #ff6d7a; }
+      .ticket-ready { border-left-color: #f0c75e; } .ticket-landed { border-left-color: #62cf98; opacity: .76; }
+      .ticket header { display: grid; grid-template-columns: auto 1fr auto; gap: .65rem; align-items: start; }
+      .ticket small { display: block; color: #8b9ab0; margin-bottom: .24rem; }
+      .ticket a { color: #f1f5fc; font-weight: 680; text-decoration: none; line-height: 1.35; }
+      .ticket a:hover { text-decoration: underline; }
+      .shape { width: .68rem; height: .68rem; margin-top: .2rem; border: 2px solid #91a5c0; border-radius: 2px; }
+      .shape-diamond { transform: rotate(45deg); } .shape-circle { border-radius: 50%; }
+      .status { border-radius: 2rem; background: #202d42; color: #c6d2e4; padding: .18rem .5rem; white-space: nowrap; font-size: .65rem; text-transform: uppercase; letter-spacing: .06em; }
+      .detail { margin-top: .8rem; padding: .7rem .8rem; border-radius: .45rem; background: #1a2435; color: #d6deeb; line-height: 1.45; }
+      .detail p { margin: 0; white-space: pre-wrap; }
+      .detail.stale { border: 2px solid #ff7a86; background: #351b25; }
+      .stale-label { display: block; margin-bottom: .45rem; color: #ff9aa3; font-size: .72rem; letter-spacing: .08em; }
+      .meta, .dependencies { margin: .65rem 0 0; color: #9fb0c8; font-size: .78rem; line-height: 1.4; }
+      .dependencies { color: #cab879; }
+      #error { margin: 2rem clamp(1rem, 4vw, 4rem); border: 2px solid #ff6d7a; border-radius: .7rem; background: #351b25; padding: 1rem; white-space: pre-wrap; }
+      @media (max-width: 650px) { body > header { align-items: start; flex-direction: column; } }
+    </style>
+  </head>
+  <body>
+    <header><h1>Portfolio DAG</h1><div id="as-of">Loading generated facts…</div></header>
+    <div id="error" hidden></div>
+    <main id="board"></main>
+    <script type="module">
+      import { loadBoard, renderBoard } from "./dag-board.mjs";
+      const parameters = new URLSearchParams(location.search);
+      const generatedUrl = parameters.get("generated") || "./flotilla-tickets-dag.generated.json";
+      const authoredUrl = parameters.get("authored") || "./flotilla-tickets-dag.authored.json";
+      try {
+        const board = await loadBoard({ generatedUrl, authoredUrl });
+        renderBoard(document.querySelector("#board"), board);
+        document.querySelector("#as-of").textContent = board.asOf ? `Facts as of ${board.asOf}` : "No timestamped facts";
+      } catch (error) {
+        const target = document.querySelector("#error");
+        target.hidden = false;
+        target.textContent = `Could not load the board layers. Run scripts/dag-fetch and serve this directory over HTTP.\n\n${error}`;
+        document.querySelector("#as-of").textContent = "Load failed";
+      }
+    </script>
+  </body>
+</html>

--- a/scripts/tests/dag_board_test.mjs
+++ b/scripts/tests/dag_board_test.mjs
@@ -8,7 +8,10 @@ const generated = {
     { ref: "flotilla-org/flotilla#11", status: "ready", title: "Next" },
   ],
   dependencyEdges: [{ from: "flotilla-org/flotilla#10", to: "flotilla-org/flotilla#11" }],
-  groups: { infrastructure: ["flotilla-org/flotilla#10"] },
+  groups: Object.fromEntries([
+    ["infrastructure", ["flotilla-org/flotilla#10"]],
+    ["__proto__", ["flotilla-org/flotilla#11"]],
+  ]),
 };
 const authored = {
   pulse: "The authored narrative stays authored.",
@@ -26,6 +29,7 @@ assert.equal(annotated.status, "landed", "generated status wins");
 assert.equal(annotated.detail, authored.tickets["flotilla-org/flotilla#10"].detail);
 assert.equal(annotated.noteStale, true);
 assert.equal(board.groups.infrastructure.label, "Infrastructure");
+assert.equal(Object.hasOwn(board.groups, "__proto__"), true, "external labels remain own properties");
 assert.equal(board.edges.length, 2);
 assert.equal(noteIsStale({ status: "ready" }, { detail: "new", statusAtAuthoring: "ready" }), false);
 assert.equal(noteIsStale({ status: "ready" }, { detail: "old" }), false, "legacy notes without a status are not guessed stale");

--- a/scripts/tests/dag_board_test.mjs
+++ b/scripts/tests/dag_board_test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+
+import { mergeLayers, noteIsStale } from "../dag-board.mjs";
+
+const generated = {
+  tickets: [
+    { ref: "flotilla-org/flotilla#10", status: "landed", title: "Done" },
+    { ref: "flotilla-org/flotilla#11", status: "ready", title: "Next" },
+  ],
+  dependencyEdges: [{ from: "flotilla-org/flotilla#10", to: "flotilla-org/flotilla#11" }],
+  groups: { infrastructure: ["flotilla-org/flotilla#10"] },
+};
+const authored = {
+  pulse: "The authored narrative stays authored.",
+  tickets: {
+    "flotilla-org/flotilla#10": { detail: "Expected to be underway.", statusAtAuthoring: "at-sea", shape: "diamond" },
+  },
+  groups: { infrastructure: { label: "Infrastructure", color: "#123456" } },
+  edges: [{ from: "flotilla-org/flotilla#11", to: "flotilla-org/flotilla#10", label: "authored" }],
+};
+
+const board = mergeLayers(generated, authored);
+const annotated = board.tickets.find((ticket) => ticket.ref === "flotilla-org/flotilla#10");
+assert.equal(board.pulse, authored.pulse);
+assert.equal(annotated.status, "landed", "generated status wins");
+assert.equal(annotated.detail, authored.tickets["flotilla-org/flotilla#10"].detail);
+assert.equal(annotated.noteStale, true);
+assert.equal(board.groups.infrastructure.label, "Infrastructure");
+assert.equal(board.edges.length, 2);
+assert.equal(noteIsStale({ status: "ready" }, { detail: "new", statusAtAuthoring: "ready" }), false);
+assert.equal(noteIsStale({ status: "ready" }, { detail: "old" }), false, "legacy notes without a status are not guessed stale");

--- a/scripts/tests/test_dag_fetch.py
+++ b/scripts/tests/test_dag_fetch.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+FETCH = ROOT / "scripts" / "dag-fetch"
+
+
+class DagFetchTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+
+        self._write_command(
+            "gh",
+            {
+                "issue flotilla-org/flotilla": [
+                    {
+                        "number": 12,
+                        "title": "Blocked work",
+                        "state": "OPEN",
+                        "url": "https://github.com/flotilla-org/flotilla/issues/12",
+                        "updatedAt": "2026-08-10T12:00:00Z",
+                        "closedAt": None,
+                        "labels": [{"name": "testing"}],
+                        "blockedBy": {
+                            "nodes": [
+                                {
+                                    "number": 11,
+                                    "state": "OPEN",
+                                    "url": "https://github.com/flotilla-org/flotilla/issues/11",
+                                }
+                            ],
+                            "totalCount": 1,
+                        },
+                        "blocking": {"nodes": [], "totalCount": 0},
+                        "closedByPullRequestsReferences": [],
+                    },
+                    {
+                        "number": 10,
+                        "title": "Landed work",
+                        "state": "CLOSED",
+                        "url": "https://github.com/flotilla-org/flotilla/issues/10",
+                        "updatedAt": "2026-08-09T12:00:00Z",
+                        "closedAt": "2026-08-09T12:00:00Z",
+                        "labels": [{"name": "infrastructure"}],
+                        "blockedBy": {"nodes": [], "totalCount": 0},
+                        "blocking": {"nodes": [], "totalCount": 0},
+                        "closedByPullRequestsReferences": [
+                            {
+                                "number": 20,
+                                "url": "https://github.com/flotilla-org/flotilla/pull/20",
+                                "repository": {"name": "flotilla", "owner": {"login": "flotilla-org"}},
+                            }
+                        ],
+                    },
+                ],
+                "issue flotilla-org/andamento": [
+                    {
+                        "number": 3,
+                        "title": "Ready work",
+                        "state": "OPEN",
+                        "url": "https://github.com/flotilla-org/andamento/issues/3",
+                        "updatedAt": "2026-08-08T12:00:00Z",
+                        "closedAt": None,
+                        "labels": [],
+                        "blockedBy": {"nodes": [], "totalCount": 0},
+                        "blocking": {"nodes": [], "totalCount": 0},
+                        "closedByPullRequestsReferences": [],
+                    }
+                ],
+                "pr flotilla-org/flotilla": [
+                    {
+                        "number": 20,
+                        "state": "MERGED",
+                        "url": "https://github.com/flotilla-org/flotilla/pull/20",
+                        "mergedAt": "2026-08-09T12:00:00Z",
+                        "mergeStateStatus": "CLEAN",
+                        "statusCheckRollup": [
+                            {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"}
+                        ],
+                    }
+                ],
+                "pr flotilla-org/andamento": [],
+            },
+        )
+        self._write_command(
+            "flotilla",
+            {
+                "resource": {
+                    "records": [
+                        {
+                            "object": {
+                                "metadata": {
+                                    "name": "exact-association",
+                                    "annotations": {"flotilla.work/last-synced-at": "2026-08-10T12:30:00Z"},
+                                },
+                                "spec": {
+                                    "issues": [
+                                        {
+                                            "reference": {
+                                                "id": "3",
+                                                "source": {
+                                                    "service": "https://github.com",
+                                                    "scope": "flotilla-org/andamento",
+                                                },
+                                            }
+                                        }
+                                    ]
+                                },
+                                "status": {
+                                    "phase": "Active",
+                                    "placement_decision": {"target_host": {"display_name": "kiwi"}},
+                                },
+                            },
+                            "provenance": {"source": "replica", "lastSyncedAt": "2026-08-10T12:30:00Z"},
+                        }
+                    ]
+                },
+                "ls": {
+                    "rows": [
+                        {
+                            "convoy": "exact-association",
+                            "host": "kiwi",
+                            "staleness": {"kind": "current", "last_synced_at": "2026-08-10T12:30:00Z"},
+                        }
+                    ]
+                },
+            },
+        )
+
+    def _write_command(self, name, payload):
+        path = self.bin / name
+        if name == "gh":
+            body = f"""#!/usr/bin/env python3
+import json, sys
+data = json.loads({json.dumps(payload)!r})
+kind = sys.argv[1]
+repo = sys.argv[sys.argv.index('-R') + 1]
+print(json.dumps(data[kind + ' ' + repo]))
+"""
+        else:
+            body = f"""#!/usr/bin/env python3
+import json, sys
+data = json.loads({json.dumps(payload)!r})
+print(json.dumps(data['resource' if sys.argv[1] == 'resource' else 'ls']))
+"""
+        path.write_text(body)
+        path.chmod(0o755)
+
+    def test_fetch_joins_generated_facts_and_is_byte_stable(self):
+        output = self.root / "generated.json"
+        env = os.environ | {"PATH": f"{self.bin}:{os.environ['PATH']}"}
+
+        subprocess.run([FETCH, "--output", output], check=True, env=env)
+        first = output.read_bytes()
+        subprocess.run([FETCH, "--output", output], check=True, env=env)
+
+        self.assertEqual(first, output.read_bytes())
+        generated = json.loads(first)
+        tickets = {ticket["ref"]: ticket for ticket in generated["tickets"]}
+        self.assertEqual(tickets["flotilla-org/flotilla#10"]["status"], "landed")
+        self.assertEqual(tickets["flotilla-org/flotilla#12"]["status"], "blocked")
+        self.assertEqual(tickets["flotilla-org/andamento#3"]["status"], "at-sea")
+        self.assertEqual(tickets["flotilla-org/andamento#3"]["convoys"][0]["host"], "kiwi")
+        self.assertEqual(tickets["flotilla-org/andamento#3"]["convoys"][0]["staleness"], {"kind": "current"})
+        self.assertEqual(tickets["flotilla-org/flotilla#10"]["pullRequests"][0]["ci"], "success")
+        self.assertEqual(
+            generated["dependencyEdges"],
+            [{"from": "flotilla-org/flotilla#11", "to": "flotilla-org/flotilla#12"}],
+        )
+        self.assertEqual(generated["groups"]["testing"], ["flotilla-org/flotilla#12"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_dag_fetch.py
+++ b/scripts/tests/test_dag_fetch.py
@@ -150,7 +150,12 @@ class DagFetchTest(unittest.TestCase):
                         }
                     ]
                 },
-                "ls": {"rows": []},
+                "ls": {
+                    "rows": [
+                        {"convoy": "exact-association", "host": "aaa", "staleness": {"kind": "stale"}},
+                        {"convoy": "exact-association", "host": "zzz", "staleness": {"kind": "current"}},
+                    ]
+                },
             },
         )
 
@@ -188,7 +193,7 @@ print(json.dumps(data['resource' if sys.argv[1] == 'resource' else 'ls']))
         self.assertEqual(tickets["flotilla-org/flotilla#12"]["status"], "blocked")
         self.assertEqual(tickets["flotilla-org/andamento#3"]["status"], "at-sea")
         self.assertEqual(tickets["flotilla-org/andamento#3"]["convoys"][0]["host"], "newer-host")
-        self.assertEqual(tickets["flotilla-org/andamento#3"]["convoys"][0]["staleness"], {"kind": "replica"})
+        self.assertEqual(tickets["flotilla-org/andamento#3"]["convoys"][0]["staleness"], {"kind": "current"})
         self.assertEqual(tickets["flotilla-org/flotilla#10"]["pullRequests"][0]["ci"], "success")
         self.assertEqual(
             generated["dependencyEdges"],

--- a/scripts/tests/test_dag_fetch.py
+++ b/scripts/tests/test_dag_fetch.py
@@ -103,6 +103,7 @@ class DagFetchTest(unittest.TestCase):
                                 "metadata": {
                                     "name": "exact-association",
                                     "annotations": {"flotilla.work/last-synced-at": "2026-08-10T12:30:00Z"},
+                                    "resourceVersion": "9",
                                 },
                                 "spec": {
                                     "issues": [
@@ -123,18 +124,33 @@ class DagFetchTest(unittest.TestCase):
                                 },
                             },
                             "provenance": {"source": "replica", "lastSyncedAt": "2026-08-10T12:30:00Z"},
-                        }
-                    ]
-                },
-                "ls": {
-                    "rows": [
+                        },
                         {
-                            "convoy": "exact-association",
-                            "host": "kiwi",
-                            "staleness": {"kind": "current", "last_synced_at": "2026-08-10T12:30:00Z"},
+                            "object": {
+                                "metadata": {"name": "exact-association", "resourceVersion": "10"},
+                                "spec": {
+                                    "issues": [
+                                        {
+                                            "reference": {
+                                                "id": "3",
+                                                "source": {
+                                                    "service": "https://github.com",
+                                                    "scope": "flotilla-org/andamento",
+                                                },
+                                            }
+                                        }
+                                    ]
+                                },
+                                "status": {
+                                    "phase": "Active",
+                                    "placement_decision": {"target_host": {"display_name": "newer-host"}},
+                                },
+                            },
+                            "provenance": {"source": "replica", "lastSyncedAt": "2026-08-10T12:30:00Z"},
                         }
                     ]
                 },
+                "ls": {"rows": []},
             },
         )
 
@@ -171,8 +187,8 @@ print(json.dumps(data['resource' if sys.argv[1] == 'resource' else 'ls']))
         self.assertEqual(tickets["flotilla-org/flotilla#10"]["status"], "landed")
         self.assertEqual(tickets["flotilla-org/flotilla#12"]["status"], "blocked")
         self.assertEqual(tickets["flotilla-org/andamento#3"]["status"], "at-sea")
-        self.assertEqual(tickets["flotilla-org/andamento#3"]["convoys"][0]["host"], "kiwi")
-        self.assertEqual(tickets["flotilla-org/andamento#3"]["convoys"][0]["staleness"], {"kind": "current"})
+        self.assertEqual(tickets["flotilla-org/andamento#3"]["convoys"][0]["host"], "newer-host")
+        self.assertEqual(tickets["flotilla-org/andamento#3"]["convoys"][0]["staleness"], {"kind": "replica"})
         self.assertEqual(tickets["flotilla-org/flotilla#10"]["pullRequests"][0]["ci"], "success")
         self.assertEqual(
             generated["dependencyEdges"],


### PR DESCRIPTION
Closes #1091.

## Summary

- add `scripts/dag-fetch`, a deterministic materializer for GitHub issue/dependency/PR facts and exact `Convoy.spec.issues` associations
- add a board that merges generated facts with a separately authored pulse/detail/group/shape/edge layer and visibly marks notes when `statusAtAuthoring` drifts
- normalize fleet staleness to its semantic category and sort all output so unchanged observations serialize byte-for-byte identically
- document refresh, deployment, and safe authored-layer handling

## Status semantics

- closed issue → `landed`
- open issue carried by an Active convoy → `at-sea`
- open issue with an open native blocker or only non-Active convoy records → `blocked`
- remaining open issue → `ready`

## Legacy authored seed

The dispatch references the untracked personal file `~/dev/flotilla-tickets-dag.html`. It was not present in the vessel checkout, anywhere under the stated home path, or in reachable/dangling Git data, so this PR includes an explicit empty authored-layer template rather than inventing the operator's pulse or detail judgments. The deployment docs require migrating any populated personal authored layer before replacing the legacy HTML and explicitly warn against copying the empty template over it.

## Verification

- `python3 -m unittest scripts.tests.test_dag_fetch`
- `node scripts/tests/dag_board_test.mjs`
- live fetch twice with unchanged observations followed by byte-for-byte `cmp` (878 tickets, 42 dependency edges)
- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
