### PR TITLE
Add coordinated fleet candidate builds

### DIFF
--- a/.forgejo/workflows/fleet-candidates.yml
+++ b/.forgejo/workflows/fleet-candidates.yml
@@ -47,7 +47,7 @@ jobs:
           git -C orchestration checkout --detach FETCH_HEAD
 
       - name: Restore dependency and compiler caches
-        uses: https://code.forgejo.org/actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
+        uses: https://code.forgejo.org/actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: |
             .fleet-cache/toolchains
@@ -73,6 +73,18 @@ jobs:
           path: dist/
           retention-days: 7
           if-no-files-found: error
+
+      - name: Save dependency and compiler caches
+        if: always()
+        uses: https://code.forgejo.org/actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c
+        with:
+          path: |
+            .fleet-cache/toolchains
+            .fleet-cache/cargo
+            sources/flotilla/target
+            sources/cleat/target
+            sources/cleat/.tools/ghostty-src/.zig-cache
+          key: fleet-linux-v1-${{ inputs.flotilla_sha }}-${{ inputs.cleat_sha }}
 
   darwin:
     name: Darwin arm64 candidate

--- a/.forgejo/workflows/fleet-candidates.yml
+++ b/.forgejo/workflows/fleet-candidates.yml
@@ -21,6 +21,7 @@ concurrency:
 
 env:
   CARGO_INCREMENTAL: "0"
+  FLEET_ORCHESTRATION_SHA: ${{ forgejo.sha }}
   FLEET_FLOTILLA_SHA: ${{ inputs.flotilla_sha }}
   FLEET_CLEAT_SHA: ${{ inputs.cleat_sha }}
 
@@ -42,8 +43,8 @@ jobs:
 
           git init orchestration
           git -C orchestration remote add origin https://github.com/flotilla-org/flotilla.git
-          git -C orchestration fetch --depth=1 origin "$FORGEJO_SHA"
-          test "$(git -C orchestration rev-parse FETCH_HEAD)" = "$FORGEJO_SHA"
+          git -C orchestration fetch --depth=1 origin "$FLEET_ORCHESTRATION_SHA"
+          test "$(git -C orchestration rev-parse FETCH_HEAD)" = "$FLEET_ORCHESTRATION_SHA"
           git -C orchestration checkout --detach FETCH_HEAD
 
       - name: Restore dependency and compiler caches
@@ -97,8 +98,8 @@ jobs:
           set -euo pipefail
           git init orchestration
           git -C orchestration remote add origin https://github.com/flotilla-org/flotilla.git
-          git -C orchestration fetch --depth=1 origin "$FORGEJO_SHA"
-          test "$(git -C orchestration rev-parse FETCH_HEAD)" = "$FORGEJO_SHA"
+          git -C orchestration fetch --depth=1 origin "$FLEET_ORCHESTRATION_SHA"
+          test "$(git -C orchestration rev-parse FETCH_HEAD)" = "$FLEET_ORCHESTRATION_SHA"
           git -C orchestration checkout --detach FETCH_HEAD
 
       - name: Verify the credential-free worker

--- a/.forgejo/workflows/fleet-candidates.yml
+++ b/.forgejo/workflows/fleet-candidates.yml
@@ -1,0 +1,112 @@
+name: Build fleet candidates
+
+on:
+  workflow_dispatch:
+    inputs:
+      flotilla_sha:
+        description: Exact 40-character commit from flotilla-org/flotilla
+        required: true
+        type: string
+      cleat_sha:
+        description: Exact 40-character commit from flotilla-org/cleat
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fleet-candidates-${{ inputs.flotilla_sha }}-${{ inputs.cleat_sha }}
+  cancel-in-progress: false
+
+env:
+  CARGO_INCREMENTAL: "0"
+  FLEET_FLOTILLA_SHA: ${{ inputs.flotilla_sha }}
+  FLEET_CLEAT_SHA: ${{ inputs.cleat_sha }}
+
+jobs:
+  linux:
+    name: Linux x86_64 candidate
+    runs-on: debian-12
+    timeout-minutes: 120
+    steps:
+      - name: Bootstrap the pinned worker environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install --no-install-recommends --yes \
+            build-essential ca-certificates clang cmake curl git nodejs \
+            patchelf pkg-config python3 xz-utils
+
+          git init orchestration
+          git -C orchestration remote add origin https://github.com/flotilla-org/flotilla.git
+          git -C orchestration fetch --depth=1 origin "$FORGEJO_SHA"
+          test "$(git -C orchestration rev-parse FETCH_HEAD)" = "$FORGEJO_SHA"
+          git -C orchestration checkout --detach FETCH_HEAD
+
+      - name: Restore dependency and compiler caches
+        uses: https://code.forgejo.org/actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
+        with:
+          path: |
+            .fleet-cache/toolchains
+            .fleet-cache/cargo
+            sources/flotilla/target
+            sources/cleat/target
+            sources/cleat/.tools/ghostty-src/.zig-cache
+          key: fleet-linux-v1-${{ inputs.flotilla_sha }}-${{ inputs.cleat_sha }}
+          restore-keys: |
+            fleet-linux-v1-
+
+      - name: Build and verify the coordinated candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          source orchestration/ci/fleet-candidates/setup-linux-toolchain.sh
+          orchestration/ci/fleet-candidates/build-candidate.sh
+
+      - name: Upload seven-day Linux candidate
+        uses: https://code.forgejo.org/actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        with:
+          name: fleet-candidate-linux-x86_64-gnu2.36
+          path: dist/
+          retention-days: 7
+          if-no-files-found: error
+
+  darwin:
+    name: Darwin arm64 candidate
+    runs-on: darwin-aarch64
+    timeout-minutes: 120
+    steps:
+      - name: Check out the orchestration scripts
+        shell: /bin/bash -e {0}
+        run: |
+          set -euo pipefail
+          git init orchestration
+          git -C orchestration remote add origin https://github.com/flotilla-org/flotilla.git
+          git -C orchestration fetch --depth=1 origin "$FORGEJO_SHA"
+          test "$(git -C orchestration rev-parse FETCH_HEAD)" = "$FORGEJO_SHA"
+          git -C orchestration checkout --detach FETCH_HEAD
+
+      - name: Verify the credential-free worker
+        shell: /bin/bash -e {0}
+        run: |
+          set -euo pipefail
+          test "$(uname -s)" = Darwin
+          test "$(uname -m)" = arm64
+          security find-identity -v -p codesigning | grep -Eq '^[[:space:]]*0 valid identities found[[:space:]]*$'
+          test -z "${FLEET_CODESIGN_IDENTITY:-}"
+          test -z "${FORGEJO_ADMIN_TOKEN:-}"
+
+      - name: Build and verify the coordinated candidate
+        shell: /bin/bash -e {0}
+        run: orchestration/ci/fleet-candidates/build-candidate.sh
+
+      - name: Upload seven-day Darwin candidate
+        uses: https://code.forgejo.org/actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        with:
+          name: fleet-candidate-darwin-aarch64
+          path: dist/
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
         run: |
           scripts/test-prune-target.sh
           scripts/test-cargo-sweep-mtime.sh
+      - name: Test fleet candidate workflow contract
+        run: ci/fleet-candidates/test-workflow.sh
       - name: Check Rust formatting
         run: cargo +nightly-2026-03-12 fmt --check
 

--- a/ci/fleet-candidates/README.md
+++ b/ci/fleet-candidates/README.md
@@ -1,0 +1,31 @@
+# On-demand fleet candidates
+
+`.forgejo/workflows/fleet-candidates.yml` is the first credential-free half of
+the coordinated fleet release path. A human starts one workflow with exact
+40-character Flotilla and Cleat commits. The workflow fetches those public
+canonical commits from GitHub, builds both projects on the real lab Linux and
+Darwin runners, verifies the resulting programs, and retains unsigned
+run-scoped bundles for seven days.
+
+The build workers receive no durable release credential or signing identity.
+Forgejo's per-run artifact token expires with the workflow. These candidates
+are therefore useful for installation and investigation, but they are not a
+completed release and cannot update a fleet pin.
+
+Each artifact contains a tar archive, adjacent SHA-256 and JSON metadata, and
+an `install.sh` inside the archive. The installer defaults to `~/.local` and
+accepts another prefix as its first argument. Cleat's current dynamic
+`libghostty-vt` dependency is included under `lib/` with a relative runtime
+search path. The Darwin Cleat binary is ad-hoc signed after that path is
+rewritten so macOS can execute it; this is not a durable release signature.
+
+Run the local structural contract with:
+
+```sh
+ci/fleet-candidates/test-workflow.sh
+```
+
+The later trusted half must consume these exact bytes, sign the Darwin
+derivatives, run pristine-runtime proofs, publish the complete cohort, copy it
+offsite, and only then write an immutable completed generation. It must not
+rebuild either project.

--- a/ci/fleet-candidates/build-candidate.sh
+++ b/ci/fleet-candidates/build-candidate.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+require_sha() {
+  local name="$1"
+  local value="$2"
+  if [[ ${#value} -ne 40 || "$value" == *[!0-9a-fA-F]* ]]; then
+    printf '%s must be an exact 40-character hexadecimal commit: %s\n' "$name" "$value" >&2
+    return 1
+  fi
+  printf '%s' "$value" | tr 'A-F' 'a-f'
+}
+
+fetch_exact() {
+  local repository="$1"
+  local commit="$2"
+  local destination="$3"
+
+  mkdir -p "$destination"
+  if [[ ! -d "$destination/.git" ]]; then
+    git -C "$destination" init
+    git -C "$destination" remote add origin "$repository"
+  else
+    git -C "$destination" remote set-url origin "$repository"
+  fi
+  git -C "$destination" fetch --depth=1 origin "$commit"
+  test "$(git -C "$destination" rev-parse FETCH_HEAD)" = "$commit"
+  git -C "$destination" checkout --detach --force FETCH_HEAD
+  git -C "$destination" clean -ffdx -e target/ -e .tools/
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+main() {
+flotilla_sha="$(require_sha FLEET_FLOTILLA_SHA "${FLEET_FLOTILLA_SHA:-}")"
+cleat_sha="$(require_sha FLEET_CLEAT_SHA "${FLEET_CLEAT_SHA:-}")"
+
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64)
+    platform="linux-x86_64-gnu2.36"
+    ghostty_library="libghostty-vt.so"
+    ;;
+  Darwin-arm64)
+    platform="darwin-aarch64"
+    ghostty_library="libghostty-vt.dylib"
+    ;;
+  *)
+    printf 'unsupported fleet candidate platform: %s-%s\n' "$(uname -s)" "$(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+test "$(cargo --version)" = "cargo 1.97.1 (c980f4866 2026-06-30)"
+test "$(zig version)" = "0.15.2"
+if [[ "$platform" == darwin-aarch64 ]]; then
+  xcodebuild -version | grep -Fx 'Xcode 26.6'
+  security find-identity -v -p codesigning | grep -Eq '^[[:space:]]*0 valid identities found[[:space:]]*$'
+fi
+
+source_root="$PWD/sources"
+flotilla_root="$source_root/flotilla"
+cleat_root="$source_root/cleat"
+output_root="$PWD/dist"
+bundle_name="fleet-candidate-$platform"
+bundle="$output_root/$bundle_name"
+if [[ "$PWD" == / || "$output_root" != "$PWD/dist" ]]; then
+  echo 'refusing an unsafe output directory' >&2
+  exit 1
+fi
+
+fetch_exact https://github.com/flotilla-org/flotilla.git "$flotilla_sha" "$flotilla_root"
+fetch_exact https://github.com/flotilla-org/cleat.git "$cleat_sha" "$cleat_root"
+
+(
+  cd "$flotilla_root"
+  export FLOTILLA_BUILD_ID="${flotilla_sha:0:12}"
+  cargo build --locked --release --bin flotilla --bin flotillad
+)
+
+(
+  cd "$cleat_root"
+  ./tools/prepare-ghostty-vt.sh
+  cargo build -p cleat --locked --features ghostty-vt --release
+)
+
+rm -rf "$output_root"
+mkdir -p "$bundle/bin" "$bundle/lib"
+install -m 0755 "$flotilla_root/target/release/flotilla" "$bundle/bin/flotilla"
+install -m 0755 "$flotilla_root/target/release/flotillad" "$bundle/bin/flotillad"
+install -m 0755 "$cleat_root/target/release/cleat" "$bundle/bin/cleat"
+
+if [[ -f "$cleat_root/.tools/ghostty-install/lib/$ghostty_library" ]]; then
+  install -m 0755 "$cleat_root/.tools/ghostty-install/lib/$ghostty_library" "$bundle/lib/$ghostty_library"
+fi
+
+if [[ "$platform" == linux-x86_64-gnu2.36 ]]; then
+  if ldd "$bundle/bin/cleat" | grep -q "$ghostty_library"; then
+    test -f "$bundle/lib/$ghostty_library"
+    # The literal ELF loader token must reach patchelf unchanged.
+    # shellcheck disable=SC2016
+    patchelf --set-rpath '$ORIGIN/../lib' "$bundle/bin/cleat"
+    # shellcheck disable=SC2016
+    readelf -d "$bundle/bin/cleat" | grep -Fq '$ORIGIN/../lib'
+  else
+    rm -f "$bundle/lib/$ghostty_library"
+  fi
+else
+  dependency="$(otool -L "$bundle/bin/cleat" | awk '/libghostty-vt\.dylib/{print $1; exit}')"
+  if [[ -n "$dependency" ]]; then
+    test -f "$bundle/lib/$ghostty_library"
+    install_name_tool -change "$dependency" "@rpath/$ghostty_library" "$bundle/bin/cleat"
+    install_name_tool -add_rpath '@executable_path/../lib' "$bundle/bin/cleat"
+    codesign --force --sign - "$bundle/bin/cleat"
+    otool -L "$bundle/bin/cleat" | grep -Fq "@rpath/$ghostty_library"
+    codesign --verify --strict "$bundle/bin/cleat"
+  else
+    rm -f "$bundle/lib/$ghostty_library"
+  fi
+fi
+
+cp "$(dirname "$0")/install-candidate.sh" "$bundle/install.sh"
+chmod 0755 "$bundle/install.sh"
+
+wire_generation="${flotilla_sha:0:12}"
+"$bundle/bin/flotilla" --version | grep -F "wire=$wire_generation"
+"$bundle/bin/flotillad" --version | grep -F "wire=$wire_generation"
+"$bundle/bin/cleat" launch --help | grep -q -- --tag
+
+export FLEET_BUNDLE="$bundle"
+export FLEET_PLATFORM="$platform"
+export FLEET_FLOTILLA_SHA="$flotilla_sha"
+export FLEET_CLEAT_SHA="$cleat_sha"
+python3 - <<'PY'
+import hashlib
+import json
+import os
+from pathlib import Path
+
+bundle = Path(os.environ["FLEET_BUNDLE"])
+files = []
+for path in sorted(bundle.rglob("*")):
+    if not path.is_file() or path.name == "manifest.json":
+        continue
+    files.append(
+        {
+            "path": str(path.relative_to(bundle)),
+            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+            "size_bytes": path.stat().st_size,
+        }
+    )
+
+manifest = {
+    "schema_version": 1,
+    "kind": "unsigned-fleet-candidate",
+    "platform": os.environ["FLEET_PLATFORM"],
+    "sources": {
+        "flotilla": os.environ["FLEET_FLOTILLA_SHA"],
+        "cleat": os.environ["FLEET_CLEAT_SHA"],
+    },
+    "build_profile": "release",
+    "signed": False,
+    "files": files,
+}
+(bundle / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+PY
+
+archive="$output_root/$bundle_name.tar.gz"
+tar -C "$output_root" -czf "$archive" "$bundle_name"
+archive_sha="$(sha256_file "$archive")"
+printf '%s  %s\n' "$archive_sha" "$(basename "$archive")" >"$archive.sha256"
+
+export FLEET_ARCHIVE="$archive"
+export FLEET_ARCHIVE_SHA="$archive_sha"
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+archive = Path(os.environ["FLEET_ARCHIVE"])
+metadata = {
+    "schema_version": 1,
+    "kind": "unsigned-fleet-candidate-archive",
+    "platform": os.environ["FLEET_PLATFORM"],
+    "sources": {
+        "flotilla": os.environ["FLEET_FLOTILLA_SHA"],
+        "cleat": os.environ["FLEET_CLEAT_SHA"],
+    },
+    "artifact": archive.name,
+    "sha256": os.environ["FLEET_ARCHIVE_SHA"],
+    "size_bytes": archive.stat().st_size,
+    "signed": False,
+}
+archive.with_suffix(archive.suffix + ".json").write_text(
+    json.dumps(metadata, indent=2, sort_keys=True) + "\n"
+)
+PY
+
+rm -rf "$bundle"
+printf 'built %s (%s)\n' "$archive" "$archive_sha"
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  main "$@"
+fi

--- a/ci/fleet-candidates/build-candidate.sh
+++ b/ci/fleet-candidates/build-candidate.sh
@@ -95,20 +95,25 @@ install -m 0755 "$flotilla_root/target/release/flotilla" "$bundle/bin/flotilla"
 install -m 0755 "$flotilla_root/target/release/flotillad" "$bundle/bin/flotillad"
 install -m 0755 "$cleat_root/target/release/cleat" "$bundle/bin/cleat"
 
-if [[ -f "$cleat_root/.tools/ghostty-install/lib/$ghostty_library" ]]; then
+if [[ "$platform" == darwin-aarch64 && -f "$cleat_root/.tools/ghostty-install/lib/$ghostty_library" ]]; then
   install -m 0755 "$cleat_root/.tools/ghostty-install/lib/$ghostty_library" "$bundle/lib/$ghostty_library"
 fi
 
 if [[ "$platform" == linux-x86_64-gnu2.36 ]]; then
-  if ldd "$bundle/bin/cleat" | grep -q "$ghostty_library"; then
-    test -f "$bundle/lib/$ghostty_library"
+  dependency="$(patchelf --print-needed "$bundle/bin/cleat" | awk '/^libghostty-vt\.so/{print; exit}')"
+  if [[ -n "$dependency" ]]; then
+    ghostty_source="$cleat_root/.tools/ghostty-install/lib/$dependency"
+    if [[ ! -f "$ghostty_source" ]]; then
+      ghostty_source="$cleat_root/.tools/ghostty-install/lib/$ghostty_library"
+    fi
+    test -f "$ghostty_source"
+    install -m 0755 "$ghostty_source" "$bundle/lib/$dependency"
     # The literal ELF loader token must reach patchelf unchanged.
     # shellcheck disable=SC2016
     patchelf --set-rpath '$ORIGIN/../lib' "$bundle/bin/cleat"
     # shellcheck disable=SC2016
     readelf -d "$bundle/bin/cleat" | grep -Fq '$ORIGIN/../lib'
-  else
-    rm -f "$bundle/lib/$ghostty_library"
+    ldd "$bundle/bin/cleat" | grep -F "$dependency" | grep -Fvq 'not found'
   fi
 else
   dependency="$(otool -L "$bundle/bin/cleat" | awk '/libghostty-vt\.dylib/{print $1; exit}')"

--- a/ci/fleet-candidates/install-candidate.sh
+++ b/ci/fleet-candidates/install-candidate.sh
@@ -51,6 +51,8 @@ for source in "$bundle_root"/lib/*; do
   name="$(basename "$source")"
   install -m 0755 "$source" "$prefix/lib/.$name.new"
 done
+# Deliberately no empty-glob guard: a candidate without binaries is invalid,
+# so installation must fail rather than report success without installing them.
 for source in "$bundle_root"/bin/*; do
   name="$(basename "$source")"
   install -m 0755 "$source" "$prefix/bin/.$name.new"
@@ -60,6 +62,7 @@ for source in "$bundle_root"/lib/*; do
   name="$(basename "$source")"
   mv -f "$prefix/lib/.$name.new" "$prefix/lib/$name"
 done
+# As above, reaching this loop without staged binaries must fail closed.
 for source in "$bundle_root"/bin/*; do
   name="$(basename "$source")"
   mv -f "$prefix/bin/.$name.new" "$prefix/bin/$name"

--- a/ci/fleet-candidates/install-candidate.sh
+++ b/ci/fleet-candidates/install-candidate.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bundle_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+prefix="${1:-${FLEET_INSTALL_PREFIX:-$HOME/.local}}"
+
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64) expected_platform="linux-x86_64-gnu2.36" ;;
+  Darwin-arm64) expected_platform="darwin-aarch64" ;;
+  *)
+    printf 'unsupported install platform: %s-%s\n' "$(uname -s)" "$(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+actual_platform="$(python3 - "$bundle_root" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+bundle = Path(sys.argv[1])
+manifest = json.loads((bundle / "manifest.json").read_text())
+expected_files = {entry["path"] for entry in manifest["files"]}
+actual_files = {
+    str(path.relative_to(bundle))
+    for path in bundle.rglob("*")
+    if path.is_file() and path.name != "manifest.json"
+}
+if actual_files != expected_files:
+    raise SystemExit("candidate files do not match the manifest")
+for entry in manifest["files"]:
+    path = bundle / entry["path"]
+    if not path.is_file():
+        raise SystemExit(f"candidate file is missing: {entry['path']}")
+    if path.stat().st_size != entry["size_bytes"]:
+        raise SystemExit(f"candidate size mismatch: {entry['path']}")
+    if hashlib.sha256(path.read_bytes()).hexdigest() != entry["sha256"]:
+        raise SystemExit(f"candidate checksum mismatch: {entry['path']}")
+print(manifest["platform"])
+PY
+)"
+if [[ "$actual_platform" != "$expected_platform" ]]; then
+  printf 'candidate is for %s, not %s\n' "$actual_platform" "$expected_platform" >&2
+  exit 1
+fi
+
+mkdir -p "$prefix/bin" "$prefix/lib"
+for source in "$bundle_root"/lib/*; do
+  [[ -e "$source" ]] || continue
+  name="$(basename "$source")"
+  install -m 0755 "$source" "$prefix/lib/.$name.new"
+done
+for source in "$bundle_root"/bin/*; do
+  name="$(basename "$source")"
+  install -m 0755 "$source" "$prefix/bin/.$name.new"
+done
+for source in "$bundle_root"/lib/*; do
+  [[ -e "$source" ]] || continue
+  name="$(basename "$source")"
+  mv -f "$prefix/lib/.$name.new" "$prefix/lib/$name"
+done
+for source in "$bundle_root"/bin/*; do
+  name="$(basename "$source")"
+  mv -f "$prefix/bin/.$name.new" "$prefix/bin/$name"
+done
+
+printf 'installed unsigned fleet candidate to %s\n' "$prefix"
+printf 'restart any running flotillad and cleat processes before use\n'

--- a/ci/fleet-candidates/setup-linux-toolchain.sh
+++ b/ci/fleet-candidates/setup-linux-toolchain.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# This file is sourced by the Linux workflow so its PATH and toolchain homes
+# remain in effect for the build step.
+set -euo pipefail
+
+toolchain_root="$PWD/.fleet-cache/toolchains"
+export CARGO_HOME="$PWD/.fleet-cache/cargo"
+export RUSTUP_HOME="$toolchain_root/rustup"
+rust_toolchain="1.97.1"
+rustup_version="1.28.2"
+rustup_sha256="20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c"
+zig_version="0.15.2"
+zig_sha256="02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239"
+zig_root="$toolchain_root/zig-$zig_version"
+
+mkdir -p "$CARGO_HOME" "$RUSTUP_HOME" "$toolchain_root"
+
+if [[ ! -x "$CARGO_HOME/bin/rustup" ]]; then
+  rustup_installer="$toolchain_root/rustup-init"
+  curl --proto '=https' --tlsv1.2 --fail --show-error --silent \
+    "https://static.rust-lang.org/rustup/archive/$rustup_version/x86_64-unknown-linux-gnu/rustup-init" \
+    -o "$rustup_installer"
+  printf '%s  %s\n' "$rustup_sha256" "$rustup_installer" | sha256sum --check --status
+  chmod 0755 "$rustup_installer"
+  "$rustup_installer" -y --no-modify-path --profile minimal \
+    --default-toolchain "$rust_toolchain"
+fi
+
+export PATH="$CARGO_HOME/bin:$zig_root:$PATH"
+if ! rustup toolchain list | grep -Eq "^${rust_toolchain}(-x86_64-unknown-linux-gnu)?[[:space:]]"; then
+  rustup toolchain install "$rust_toolchain" --profile minimal
+fi
+rustup default "$rust_toolchain"
+
+if [[ ! -x "$zig_root/zig" ]]; then
+  zig_archive="$toolchain_root/zig-$zig_version.tar.xz"
+  curl --proto '=https' --tlsv1.2 --fail --show-error --silent \
+    "https://ziglang.org/download/$zig_version/zig-x86_64-linux-$zig_version.tar.xz" \
+    -o "$zig_archive"
+  printf '%s  %s\n' "$zig_sha256" "$zig_archive" | sha256sum --check --status
+  rm -rf "$zig_root"
+  mkdir -p "$zig_root"
+  tar -xJf "$zig_archive" --strip-components=1 -C "$zig_root"
+fi
+
+test "$(rustc --version)" = "rustc 1.97.1 (8bab26f4f 2026-07-14)"
+test "$(zig version)" = "$zig_version"

--- a/ci/fleet-candidates/test-workflow.sh
+++ b/ci/fleet-candidates/test-workflow.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+workflow="$repo_root/.forgejo/workflows/fleet-candidates.yml"
+builder="$repo_root/ci/fleet-candidates/build-candidate.sh"
+setup="$repo_root/ci/fleet-candidates/setup-linux-toolchain.sh"
+installer="$repo_root/ci/fleet-candidates/install-candidate.sh"
+
+bash -n "$builder" "$setup" "$installer"
+
+grep -Fq 'workflow_dispatch:' "$workflow"
+if grep -Eq '^[[:space:]]+(push|pull_request):' "$workflow"; then
+  echo 'fleet candidate workflow must be manual-only' >&2
+  exit 1
+fi
+grep -Fq 'runs-on: debian-12' "$workflow"
+grep -Fq 'runs-on: darwin-aarch64' "$workflow"
+grep -Fq 'retention-days: 7' "$workflow"
+grep -Fq 'actions/cache@6f8efc29b200d32929f49075959781ed54ec270c' "$workflow"
+test "$(grep -Fc 'actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32' "$workflow")" -eq 2
+
+# shellcheck disable=SC1090,SC1091
+source "$builder"
+valid_sha=0123456789abcdef0123456789abcdef01234567
+test "$(require_sha TEST_SHA "$valid_sha")" = "$valid_sha"
+if require_sha TEST_SHA main >/dev/null 2>&1; then
+  echo 'accepted a floating source ref' >&2
+  exit 1
+fi
+
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/fleet-candidate-test.XXXXXX")"
+trap 'rm -rf "$test_root"' EXIT
+bundle="$test_root/bundle"
+prefix="$test_root/prefix"
+mkdir -p "$bundle/bin" "$bundle/lib"
+printf '#!/bin/sh\nexit 0\n' >"$bundle/bin/cleat"
+printf 'test library\n' >"$bundle/lib/libghostty-vt.dylib"
+cp "$installer" "$bundle/install.sh"
+chmod 0755 "$bundle/bin/cleat" "$bundle/install.sh"
+export TEST_BUNDLE="$bundle"
+python3 - <<'PY'
+import hashlib
+import json
+import os
+import platform
+from pathlib import Path
+
+bundle = Path(os.environ["TEST_BUNDLE"])
+system = platform.system()
+machine = platform.machine()
+if (system, machine) == ("Darwin", "arm64"):
+    target = "darwin-aarch64"
+elif (system, machine) == ("Linux", "x86_64"):
+    target = "linux-x86_64-gnu2.36"
+else:
+    raise SystemExit(f"unsupported test platform: {system}-{machine}")
+files = []
+for path in sorted(bundle.rglob("*")):
+    if path.is_file():
+        files.append({
+            "path": str(path.relative_to(bundle)),
+            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+            "size_bytes": path.stat().st_size,
+        })
+(bundle / "manifest.json").write_text(json.dumps({"platform": target, "files": files}))
+PY
+"$bundle/install.sh" "$prefix" >/dev/null
+cmp "$bundle/bin/cleat" "$prefix/bin/cleat"
+cmp "$bundle/lib/libghostty-vt.dylib" "$prefix/lib/libghostty-vt.dylib"
+
+echo 'fleet candidate workflow contract passed'

--- a/ci/fleet-candidates/test-workflow.sh
+++ b/ci/fleet-candidates/test-workflow.sh
@@ -17,7 +17,8 @@ fi
 grep -Fq 'runs-on: debian-12' "$workflow"
 grep -Fq 'runs-on: darwin-aarch64' "$workflow"
 grep -Fq 'retention-days: 7' "$workflow"
-grep -Fq 'actions/cache@6f8efc29b200d32929f49075959781ed54ec270c' "$workflow"
+grep -Fq 'actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c' "$workflow"
+grep -Fq 'actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c' "$workflow"
 test "$(grep -Fc 'actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32' "$workflow")" -eq 2
 
 # shellcheck disable=SC1090,SC1091

--- a/ci/fleet-candidates/test-workflow.sh
+++ b/ci/fleet-candidates/test-workflow.sh
@@ -16,6 +16,16 @@ if grep -Eq '^[[:space:]]+(push|pull_request):' "$workflow"; then
 fi
 grep -Fq 'runs-on: debian-12' "$workflow"
 grep -Fq 'runs-on: darwin-aarch64' "$workflow"
+# The literals below are workflow syntax and shell source, not expressions for
+# this contract test to expand.
+# shellcheck disable=SC2016
+grep -Fq 'FLEET_ORCHESTRATION_SHA: ${{ forgejo.sha }}' "$workflow"
+# shellcheck disable=SC2016
+test "$(grep -Fc 'git -C orchestration fetch --depth=1 origin "$FLEET_ORCHESTRATION_SHA"' "$workflow")" -eq 2
+if grep -F 'git -C orchestration fetch' "$workflow" | grep -Fq 'FLEET_FLOTILLA_SHA'; then
+  echo 'orchestration checkout must not use the selected Flotilla source SHA' >&2
+  exit 1
+fi
 grep -Fq 'retention-days: 7' "$workflow"
 grep -Fq 'actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c' "$workflow"
 grep -Fq 'actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c' "$workflow"


### PR DESCRIPTION
## What changed

- add a manual Forgejo workflow that builds exact Flotilla and Cleat commits together on the real `debian-12` and `darwin-aarch64` runners
- package Flotilla, Flotillad, Cleat, and Cleat's current dynamic Ghostty runtime into seven-day unsigned candidate artifacts
- include SHA-256 metadata, a complete per-file manifest, and a manifest-verifying installer
- pin the Linux Rustup, Rust, Zig, cache-action, and artifact-action inputs

## Why

Ordinary PR and main CI should not build durable fleet artifacts that are never deployed. This provides the credential-free first half of an explicit coordinated release: exact source inputs go in and installable, run-scoped candidate bytes come out. Signing, durable publication, offsite promotion, and movement of the fleet `current` pointer remain separate trusted steps and cannot happen here.

Cleat currently links Ghostty dynamically, so the bundle deliberately carries `libghostty-vt` and rewrites Cleat to find it relative to the installed binary. Darwin receives only the ad-hoc signature required after editing its load commands, not a Developer ID release signature.

## Validation

Static/local checks:

- `shellcheck ci/fleet-candidates/*.sh`
- `ci/fleet-candidates/test-workflow.sh`
- `ci/fork-actions/test-fork-actions.sh`
- installed `forgejo-runner v12.13.2 validate --workflow --path .forgejo/workflows/fleet-candidates.yml`

[Lab Forgejo run 41](https://forgejo.lab.flotilla.work/lab/flotilla/actions/runs/41) exercised exact PR head `c873ab32` with Flotilla `ae548a56cd42604a479aa6506c00ffbe436b2ef1` and Cleat `4e78c7c83873916dcb2342a51001bdfed3d63eda`:

- Linux x86_64 candidate passed in 8m07s
- Darwin arm64 candidate passed in 7m57s on a disposable Comte VM
- both stored archives independently matched their published SHA-256 files and exact-source metadata
- the Linux archive contains the required SONAME `lib/libghostty-vt.so.0`; its bundled installer was exercised in a clean prefix, all three installed binaries started, and Cleat resolved Ghostty from the installed sibling `lib/`

Effective cross-run compiler caching, including Darwin, remains follow-up #1486; it is not required for artifact correctness.
