### PR TITLE
fix: make contained Claude OAuth crews headless

### DIFF
--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -327,6 +327,8 @@ pub struct AgentRequirement {
     pub model: Option<String>,
 }
 
+const CLAUDE_CODE_ADAPTER_ID: &str = "claude-code";
+
 pub struct CapabilityTable {
     requirements: BTreeMap<String, AgentRequirement>,
 }
@@ -371,7 +373,7 @@ impl AgentRequirement {
     /// contained Claude session must never fall through to interactive login.
     pub fn contained_credential_delivery_slot(&self) -> Option<&'static str> {
         match self.adapter.as_str() {
-            "claude-code" => Some("claude"),
+            CLAUDE_CODE_ADAPTER_ID => Some("claude"),
             _ => None,
         }
     }
@@ -428,7 +430,7 @@ enum AdapterFlavor {
 impl AdapterFlavor {
     fn id(&self) -> &'static str {
         match self {
-            Self::ClaudeCode { .. } => "claude-code",
+            Self::ClaudeCode { .. } => CLAUDE_CODE_ADAPTER_ID,
             Self::Codex { .. } => "codex",
         }
     }
@@ -486,10 +488,9 @@ impl AgentAdapter for CliAgentAdapter {
     async fn prepare(&self, cwd: &ExecutionEnvironmentPath, brief: &TerminalBrief) -> Result<(), String> {
         match &self.flavor {
             AdapterFlavor::ClaudeCode { state_config } => {
-                let state_config = state_config.as_ref().ok_or_else(|| {
-                    "cannot determine Claude state path because neither CLAUDE_CONFIG_DIR nor HOME was detected".to_string()
-                })?;
-                seed_claude_headless_state(&*self.runner, cwd.as_path(), state_config).await?;
+                if let Some(state_config) = state_config {
+                    seed_claude_headless_state(&*self.runner, cwd.as_path(), state_config).await?;
+                }
                 let mut settings = crate::agents::claude_code_hook_settings();
                 settings["skipDangerousModePermissionPrompt"] = serde_json::Value::Bool(true);
                 let settings =
@@ -665,10 +666,7 @@ impl AgentAdapterRegistry {
     pub fn discover(env: &EnvironmentBag, runner: Arc<dyn CommandRunner>) -> Self {
         let mut registry = Self::default();
         if let Some(binary) = env.find_binary("claude") {
-            let state_path = env
-                .find_env_var("CLAUDE_CONFIG_DIR")
-                .map(|config_dir| PathBuf::from(config_dir).join(".claude.json"))
-                .or_else(|| env.find_env_var("HOME").map(|home| PathBuf::from(home).join(".claude.json")));
+            let state_path = env.find_env_var("CLAUDE_CONFIG_DIR").map(|config_dir| PathBuf::from(config_dir).join(".claude.json"));
             registry.insert(Arc::new(CliAgentAdapter {
                 binary: binary.as_path().display().to_string(),
                 runner: Arc::clone(&runner),
@@ -1281,6 +1279,32 @@ mod tests {
         let canonical_workspace = workspace_root.canonicalize().expect("canonical workspace").display().to_string();
         assert_eq!(state["hasCompletedOnboarding"], true);
         assert_eq!(state["projects"][canonical_workspace]["hasTrustDialogAccepted"], true);
+    }
+
+    #[tokio::test]
+    async fn host_direct_claude_does_not_mutate_global_state() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        let home = temp.path().join("home");
+        std::fs::create_dir_all(&workspace).expect("workspace");
+        std::fs::create_dir_all(&home).expect("home");
+        let global_state = home.join(".claude.json");
+        std::fs::write(&global_state, r#"{"existing":true}"#).expect("global Claude state");
+        let env = EnvironmentBag::new()
+            .with(EnvironmentAssertion::env_var("HOME", home.display().to_string()))
+            .with(EnvironmentAssertion::binary("claude", "/tools/claude"));
+        let registry = AgentAdapterRegistry::discover(&env, Arc::new(ProcessCommandRunner));
+        let brief =
+            flotilla_resources::TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "brief".into(), copies: Vec::new() };
+
+        registry
+            .get("claude-code")
+            .expect("Claude adapter")
+            .prepare(&ExecutionEnvironmentPath::new(&workspace), &brief)
+            .await
+            .expect("prepare host-direct Claude");
+
+        assert_eq!(std::fs::read_to_string(global_state).expect("global Claude state"), r#"{"existing":true}"#);
     }
 
     #[test]

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -365,6 +365,18 @@ impl CapabilityTable {
     }
 }
 
+impl AgentRequirement {
+    /// Credential delivery slot required for a contained invocation of this
+    /// adapter. Host-direct sessions may retain ambient authentication, but a
+    /// contained Claude session must never fall through to interactive login.
+    pub fn contained_credential_delivery_slot(&self) -> Option<&'static str> {
+        match self.adapter.as_str() {
+            "claude-code" => Some("claude"),
+            _ => None,
+        }
+    }
+}
+
 impl Default for CapabilityTable {
     fn default() -> Self {
         Self::seeded()
@@ -402,15 +414,12 @@ struct CliAgentAdapter {
 /// different thing seeded before it will run unattended, so the differences are
 /// named here rather than inferred from an id string.
 enum AdapterFlavor {
-    /// `--dangerously-skip-permissions` clears Claude Code's directory-trust and
-    /// tool-approval gates outright, so there is no persisted trust to pre-seed
-    /// for either a convoy checkout or a multi-repo workspace root. What a
-    /// managed session *does* need is Flotilla's hooks: without them the crew
-    /// runs, but no phase or attention signal ever leaves the pane. `--settings`
-    /// layers them on for this invocation only, leaving the user's own settings
-    /// untouched — which also means a crew works on a host where nobody has run
-    /// `flotilla hooks install`.
-    ClaudeCode,
+    /// Claude requires onboarding, workspace trust, and bypass-mode consent
+    /// even when credentials and `--dangerously-skip-permissions` are already
+    /// present. Managed sessions seed the first two into Claude's mutable state
+    /// and carry the documented bypass-consent setting alongside Flotilla's
+    /// hooks in the invocation-only `--settings` overlay.
+    ClaudeCode { state_config: Option<ClaudeStateConfig> },
     /// Codex gates on a persisted per-project trust level, so the workspace has
     /// to be marked trusted in its config before launch.
     Codex { trust_config: Option<CodexTrustConfig> },
@@ -419,14 +428,14 @@ enum AdapterFlavor {
 impl AdapterFlavor {
     fn id(&self) -> &'static str {
         match self {
-            Self::ClaudeCode => "claude-code",
+            Self::ClaudeCode { .. } => "claude-code",
             Self::Codex { .. } => "codex",
         }
     }
 
     fn autonomy_args(&self) -> &'static [&'static str] {
         match self {
-            Self::ClaudeCode => &["--dangerously-skip-permissions"],
+            Self::ClaudeCode { .. } => &["--dangerously-skip-permissions"],
             Self::Codex { .. } => &["--dangerously-bypass-approvals-and-sandbox"],
         }
     }
@@ -435,7 +444,7 @@ impl AdapterFlavor {
     /// teardown, beyond the brief itself.
     fn managed_files(&self) -> &'static [&'static str] {
         match self {
-            Self::ClaudeCode => &[CLAUDE_MANAGED_SETTINGS_PATH],
+            Self::ClaudeCode { .. } => &[CLAUDE_MANAGED_SETTINGS_PATH],
             Self::Codex { .. } => &[],
         }
     }
@@ -447,11 +456,17 @@ struct CodexTrustConfig {
     lock: Arc<Mutex<()>>,
 }
 
+#[derive(Clone)]
+struct ClaudeStateConfig {
+    path: PathBuf,
+    lock: Arc<Mutex<()>>,
+}
+
 impl CliAgentAdapter {
     fn command(&self, request: &AgentLaunchRequest) -> String {
         let mut args = vec![Arg::Literal(self.binary.clone())];
         args.extend(self.flavor.autonomy_args().iter().map(|arg| Arg::Literal((*arg).into())));
-        if matches!(self.flavor, AdapterFlavor::ClaudeCode) {
+        if matches!(&self.flavor, AdapterFlavor::ClaudeCode { .. }) {
             args.extend([Arg::Literal("--settings".into()), Arg::Literal(CLAUDE_MANAGED_SETTINGS_PATH.into())]);
         }
         if let Some(model) = &request.model {
@@ -470,9 +485,15 @@ impl AgentAdapter for CliAgentAdapter {
 
     async fn prepare(&self, cwd: &ExecutionEnvironmentPath, brief: &TerminalBrief) -> Result<(), String> {
         match &self.flavor {
-            AdapterFlavor::ClaudeCode => {
-                let settings = serde_json::to_string_pretty(&crate::agents::claude_code_hook_settings())
-                    .map_err(|error| format!("render Claude Code settings overlay: {error}"))?;
+            AdapterFlavor::ClaudeCode { state_config } => {
+                let state_config = state_config.as_ref().ok_or_else(|| {
+                    "cannot determine Claude state path because neither CLAUDE_CONFIG_DIR nor HOME was detected".to_string()
+                })?;
+                seed_claude_headless_state(&*self.runner, cwd.as_path(), state_config).await?;
+                let mut settings = crate::agents::claude_code_hook_settings();
+                settings["skipDangerousModePermissionPrompt"] = serde_json::Value::Bool(true);
+                let settings =
+                    serde_json::to_string_pretty(&settings).map_err(|error| format!("render Claude Code settings overlay: {error}"))?;
                 self.runner.write_file(&cwd.as_path().join(CLAUDE_MANAGED_SETTINGS_PATH), &settings).await?;
             }
             AdapterFlavor::Codex { trust_config } => {
@@ -491,10 +512,10 @@ impl AgentAdapter for CliAgentAdapter {
     }
 
     fn classify_screen_attention(&self, screen: &str) -> Option<TerminalAttentionState> {
-        match self.flavor {
+        match &self.flavor {
             // Claude Code reports its own permission prompts through the hook
             // path, which is more precise than matching rendered text.
-            AdapterFlavor::ClaudeCode => None,
+            AdapterFlavor::ClaudeCode { .. } => None,
             AdapterFlavor::Codex { .. } => codex_screen_needs_input(screen).then_some(TerminalAttentionState::NeedsInput),
         }
     }
@@ -550,6 +571,40 @@ async fn seed_codex_workspace_trust(runner: &dyn CommandRunner, cwd: &Path, conf
     }
     project["trust_level"] = value("trusted");
     runner.write_file(&config.path, &document.to_string()).await
+}
+
+async fn seed_claude_headless_state(runner: &dyn CommandRunner, cwd: &Path, config: &ClaudeStateConfig) -> Result<(), String> {
+    let _guard = config.lock.lock().await;
+    let output = runner
+        .run_output("pwd", &["-P"], cwd, &ChannelLabel::Noop)
+        .await
+        .map_err(|error| format!("resolve canonical Claude workspace {}: {error}", cwd.display()))?;
+    if !output.success {
+        return Err(format!("resolve canonical Claude workspace {}: {}", cwd.display(), output.stderr.trim()));
+    }
+    let canonical_cwd = output.stdout.trim();
+    if canonical_cwd.is_empty() {
+        return Err(format!("resolve canonical Claude workspace {}: `pwd -P` returned an empty path", cwd.display()));
+    }
+
+    let source = runner.ensure_file(&config.path, "{}").await?;
+    let mut state = serde_json::from_str::<serde_json::Value>(&source)
+        .map_err(|error| format!("parse Claude state {}: {error}", config.path.display()))?;
+    let root = state.as_object_mut().ok_or_else(|| format!("Claude state {} is not a JSON object", config.path.display()))?;
+    root.insert("hasCompletedOnboarding".to_string(), serde_json::Value::Bool(true));
+    let projects = root
+        .entry("projects")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| format!("Claude state {} has a non-object `projects` value", config.path.display()))?;
+    let project = projects
+        .entry(canonical_cwd)
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| format!("Claude state {} has a non-object project entry for {canonical_cwd}", config.path.display()))?;
+    project.insert("hasTrustDialogAccepted".to_string(), serde_json::Value::Bool(true));
+    let rendered = serde_json::to_string_pretty(&state).map_err(|error| format!("render Claude state: {error}"))?;
+    runner.write_file(&config.path, &rendered).await
 }
 
 async fn ensure_flotilla_git_exclude(runner: &dyn CommandRunner, cwd: &Path) -> Result<(), String> {
@@ -610,10 +665,16 @@ impl AgentAdapterRegistry {
     pub fn discover(env: &EnvironmentBag, runner: Arc<dyn CommandRunner>) -> Self {
         let mut registry = Self::default();
         if let Some(binary) = env.find_binary("claude") {
+            let state_path = env
+                .find_env_var("CLAUDE_CONFIG_DIR")
+                .map(|config_dir| PathBuf::from(config_dir).join(".claude.json"))
+                .or_else(|| env.find_env_var("HOME").map(|home| PathBuf::from(home).join(".claude.json")));
             registry.insert(Arc::new(CliAgentAdapter {
                 binary: binary.as_path().display().to_string(),
                 runner: Arc::clone(&runner),
-                flavor: AdapterFlavor::ClaudeCode,
+                flavor: AdapterFlavor::ClaudeCode {
+                    state_config: state_path.map(|path| ClaudeStateConfig { path, lock: Arc::new(Mutex::new(())) }),
+                },
             }));
         }
         if let Some(binary) = env.find_binary("codex") {
@@ -1153,8 +1214,12 @@ mod tests {
     async fn claude_prepare_writes_a_settings_overlay_the_launch_command_loads() {
         let temp = tempfile::tempdir().expect("tempdir");
         let workspace = temp.path().join("workspace");
+        let claude_config = temp.path().join("claude-config");
         std::fs::create_dir_all(&workspace).expect("workspace");
-        let env = EnvironmentBag::new().with(EnvironmentAssertion::binary("claude", "/tools/claude"));
+        std::fs::create_dir_all(&claude_config).expect("Claude config");
+        let env = EnvironmentBag::new()
+            .with(EnvironmentAssertion::env_var("CLAUDE_CONFIG_DIR", claude_config.display().to_string()))
+            .with(EnvironmentAssertion::binary("claude", "/tools/claude"));
         let registry = AgentAdapterRegistry::discover(&env, Arc::new(ProcessCommandRunner));
         let claude = registry.get("claude-code").expect("claude adapter");
         let brief =
@@ -1172,9 +1237,14 @@ mod tests {
                 .expect("parse settings");
         assert_eq!(settings["hooks"]["SessionStart"][0]["hooks"][0]["command"], "flotilla hook claude-code session-start");
         assert_eq!(settings["hooks"]["Notification"][0]["matcher"], "permission_prompt");
-        // The overlay carries hooks only: anything else would silently override
-        // the user's own settings for the managed session.
-        assert_eq!(settings.as_object().expect("settings object").keys().collect::<Vec<_>>(), vec!["hooks"]);
+        assert_eq!(settings["skipDangerousModePermissionPrompt"], true);
+
+        let state: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(claude_config.join(".claude.json")).expect("read Claude state"))
+                .expect("parse Claude state");
+        let canonical_workspace = workspace.canonicalize().expect("canonical workspace").display().to_string();
+        assert_eq!(state["hasCompletedOnboarding"], true);
+        assert_eq!(state["projects"][canonical_workspace]["hasTrustDialogAccepted"], true);
 
         claude.cleanup(&ExecutionEnvironmentPath::new(&workspace), &brief).await.expect("cleanup");
         assert!(!workspace.join(".flotilla/claude-settings.json").exists(), "settings overlay should be removed");
@@ -1182,16 +1252,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn claude_needs_no_workspace_trust_seeding_for_any_checkout_shape() {
-        // `--dangerously-skip-permissions` clears the directory-trust gate, so
-        // unlike Codex there is nothing to pre-seed — and preparing a workspace
-        // root that is not a git checkout (the multi-repo shape from #1002) must
-        // still succeed.
+    async fn claude_seeds_headless_state_for_a_multi_repo_workspace() {
         let temp = tempfile::tempdir().expect("tempdir");
         let workspace_root = temp.path().join("multi-repo-workspace");
+        let claude_config = temp.path().join("claude-config");
         std::fs::create_dir_all(workspace_root.join("repo-a")).expect("repo a");
         std::fs::create_dir_all(workspace_root.join("repo-b")).expect("repo b");
-        let env = EnvironmentBag::new().with(EnvironmentAssertion::binary("claude", "/tools/claude"));
+        std::fs::create_dir_all(&claude_config).expect("Claude config");
+        let env = EnvironmentBag::new()
+            .with(EnvironmentAssertion::env_var("CLAUDE_CONFIG_DIR", claude_config.display().to_string()))
+            .with(EnvironmentAssertion::binary("claude", "/tools/claude"));
         let registry = AgentAdapterRegistry::discover(&env, Arc::new(ProcessCommandRunner));
         let brief =
             flotilla_resources::TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "brief".into(), copies: Vec::new() };
@@ -1205,6 +1275,12 @@ mod tests {
 
         assert_eq!(std::fs::read_to_string(workspace_root.join(".flotilla/briefs/coder.md")).expect("brief"), "brief");
         assert!(workspace_root.join(".flotilla/claude-settings.json").exists());
+        let state: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(claude_config.join(".claude.json")).expect("Claude state"))
+                .expect("parse Claude state");
+        let canonical_workspace = workspace_root.canonicalize().expect("canonical workspace").display().to_string();
+        assert_eq!(state["hasCompletedOnboarding"], true);
+        assert_eq!(state["projects"][canonical_workspace]["hasTrustDialogAccepted"], true);
     }
 
     #[test]

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -4324,6 +4324,47 @@ async fn validate_workflow_credentials(
     workflow: &WorkflowTemplateSpec,
     placement: Option<&ResourceObject<PlacementPolicy>>,
 ) -> Result<(), String> {
+    let specs = backend
+        .clone()
+        .definitions::<CredentialSpec>(namespace)
+        .list()
+        .await
+        .map_err(|error| format!("list credential specs: {error}"))?
+        .into_iter()
+        .map(|spec| (spec.metadata.name, spec.spec.consumer))
+        .collect::<BTreeMap<_, _>>();
+    let capabilities = CapabilityTable::seeded();
+    for vessel in workflow.vessels.iter().filter(|vessel| vessel.stance == flotilla_resources::Stance::Contained) {
+        for crew in &vessel.crew {
+            let CrewSource::Agent { selector, .. } = &crew.source else {
+                continue;
+            };
+            let requirement = capabilities.resolve_selector(selector)?;
+            let Some(delivery_slot) = requirement.contained_credential_delivery_slot() else {
+                continue;
+            };
+            let has_granted_credential =
+                vessel.credential_refs.iter().any(|name| specs.get(name).is_some_and(|consumer| consumer.delivery_slot() == delivery_slot));
+            if has_granted_credential {
+                continue;
+            }
+            let compatible = specs
+                .iter()
+                .filter(|(_, consumer)| consumer.delivery_slot() == delivery_slot)
+                .map(|(name, _)| name.as_str())
+                .collect::<Vec<_>>();
+            let credential = match compatible.as_slice() {
+                [name] => format!("credential `{name}`"),
+                [] => format!("a `{delivery_slot}` credential"),
+                names => format!("one of credentials `{}`", names.join("`, `")),
+            };
+            return Err(format!(
+                "contained agent adapter `{}` requires {credential}, but no matching CredentialGrant selected it",
+                requirement.adapter
+            ));
+        }
+    }
+
     let required = workflow
         .vessels
         .iter()

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -7536,6 +7536,74 @@ async fn contained_workflow_grants_default_deny_and_admission_names_an_unheld_cr
 }
 
 #[tokio::test]
+async fn contained_claude_requires_and_accepts_a_project_selected_oauth_grant() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(NodeId::new("root-a"));
+    backend
+        .clone()
+        .definitions::<CredentialSpec>("flotilla")
+        .create(&empty_input_meta("claude-max"), &CredentialSpecSpec {
+            consumer: CredentialConsumer::ClaudeOauth { account_email: "ops@example.com".to_string() },
+            source: CredentialSource::Env { name: "CLAUDE_MAX_TOKEN".to_string() },
+            lifecycle: CredentialLifecycle::Static,
+            placement: CredentialPlacementRequirements::default(),
+        })
+        .await
+        .expect("create Claude credential declaration");
+    let workflow = WorkflowTemplateSpec::builder()
+        .vessels(vec![VesselRequirement::builder()
+            .name("work".to_string())
+            .stance(Stance::Contained)
+            .crew(vec![CrewSpec::builder()
+                .role("coder".to_string())
+                .source(CrewSource::Agent {
+                    selector: Selector { capability: "code".to_string(), adapter: Some("claude-code".to_string()), model: None },
+                    prompt: None,
+                    brief_template: None,
+                })
+                .build()])
+            .build()])
+        .build();
+
+    let mut without_grant = workflow.clone();
+    resolve_workflow_credentials(&backend, "flotilla", Some("flotilla"), &[], &mut without_grant)
+        .await
+        .expect("resolve default-deny grants");
+    let error = validate_workflow_credentials(&backend, "flotilla", &without_grant, None)
+        .await
+        .expect_err("contained Claude must not reach interactive login without OAuth");
+    assert_eq!(
+        error,
+        "contained agent adapter `claude-code` requires credential `claude-max`, but no matching CredentialGrant selected it"
+    );
+
+    backend
+        .clone()
+        .definitions::<CredentialGrant>("flotilla")
+        .create(
+            &empty_input_meta("claude-max-contained"),
+            &CredentialGrantSpec::builder()
+                .selector(
+                    CredentialGrantSelector::builder().stance(Stance::Contained).projects(BTreeSet::from(["flotilla".to_string()])).build(),
+                )
+                .credentials(BTreeSet::from(["claude-max".to_string()]))
+                .build(),
+        )
+        .await
+        .expect("create project-selected Claude grant");
+    let mut with_grant = workflow;
+    resolve_workflow_credentials(&backend, "flotilla", Some("flotilla"), &[], &mut with_grant)
+        .await
+        .expect("resolve matching Claude grant");
+    assert_eq!(with_grant.vessels[0].credential_refs, BTreeSet::from(["claude-max".to_string()]));
+
+    create_docker_placement(&backend, "docker-claude", "host-a", BTreeSet::from(["claude-max".to_string()])).await;
+    let placement = backend.using::<PlacementPolicy>("flotilla").get("docker-claude").await.expect("get placement");
+    validate_workflow_credentials(&backend, "flotilla", &with_grant, Some(&placement))
+        .await
+        .expect("matching held OAuth grant admits contained Claude");
+}
+
+#[tokio::test]
 async fn credential_grant_repository_selector_becomes_the_vessel_credential_scope() {
     let backend = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(NodeId::new("root-a"));
     let granted_repository = RepositoryKey("github.com-flotilla-org-flotilla".to_string());

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -48,11 +48,13 @@ use flotilla_protocol::{
 use flotilla_resources::{
     apply_status_patch, controller_patches as convoy_controller_patches, implement_review_workflow_spec,
     single_agent_contained_workflow_spec, Checkout as ResourceCheckout, CheckoutPhase as ResourceCheckoutPhase,
-    CheckoutSpec as ResourceCheckoutSpec, Convoy as ResourceConvoy, ConvoyPhase, DockerCheckoutStrategy,
-    DockerPerVesselPlacementPolicySpec, Host as ResourceHost, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec,
-    HostStatus, InputMeta, LifecycleAuthority, ObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project, ProjectRepositorySpec,
-    ProjectSpec, Regard, RegardExpiryPolicy, RegardSource, Repository, RepositoryRelation, RepositorySpec, ResourceBackend, ResourceError,
-    Stance, TypedResolver, WatchEvent, WatchStart, WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate, AGENT_ADAPTERS_CAPABILITY,
+    CheckoutSpec as ResourceCheckoutSpec, Convoy as ResourceConvoy, ConvoyPhase, CredentialConsumer, CredentialGrant,
+    CredentialGrantSelector, CredentialGrantSpec, CredentialLifecycle, CredentialPlacementRequirements, CredentialSource, CredentialSpec,
+    CredentialSpecSpec, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Host as ResourceHost,
+    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputMeta, LifecycleAuthority,
+    ObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project, ProjectRepositorySpec, ProjectSpec, Regard, RegardExpiryPolicy,
+    RegardSource, Repository, RepositoryRelation, RepositorySpec, ResourceBackend, ResourceError, Stance, TypedResolver, WatchEvent,
+    WatchStart, WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate, AGENT_ADAPTERS_CAPABILITY, HELD_CREDENTIALS_CAPABILITY,
     REPO_KEY_LABEL, REPO_LABEL,
 };
 use futures::StreamExt;
@@ -1334,6 +1336,38 @@ async fn fork_stance_refuses_reviewless_dispatch_and_admits_implement_review() {
             .expect("workflow create");
     }
     create_test_contained_policy(&backend, "flotilla-test", BTreeSet::from(["codex".to_string(), "claude-code".to_string()])).await;
+    backend
+        .clone()
+        .definitions::<CredentialSpec>("flotilla")
+        .create(&InputMeta::builder().name("claude-max".to_string()).build(), &CredentialSpecSpec {
+            consumer: CredentialConsumer::ClaudeOauth { account_email: "test@example.com".to_string() },
+            source: CredentialSource::Env { name: "TEST_CLAUDE_TOKEN".to_string() },
+            lifecycle: CredentialLifecycle::Static,
+            placement: CredentialPlacementRequirements::default(),
+        })
+        .await
+        .expect("Claude credential create");
+    backend
+        .clone()
+        .definitions::<CredentialGrant>("flotilla")
+        .create(
+            &InputMeta::builder().name("claude-max-contained".to_string()).build(),
+            &CredentialGrantSpec::builder()
+                .selector(
+                    CredentialGrantSelector::builder().stance(Stance::Contained).projects(BTreeSet::from(["zellij".to_string()])).build(),
+                )
+                .credentials(BTreeSet::from(["claude-max".to_string()]))
+                .build(),
+        )
+        .await
+        .expect("Claude credential grant create");
+    let hosts = backend.clone().using::<ResourceHost>("flotilla");
+    let host = hosts.get("host-test").await.expect("test placement host");
+    let mut status = host.status.expect("test placement host status");
+    status.ready = true;
+    status.heartbeat_at = Some(chrono::Utc::now());
+    status.capabilities.insert(HELD_CREDENTIALS_CAPABILITY.to_string(), serde_json::json!(["claude-max"]));
+    hosts.update_status("host-test", &host.metadata.resource_version, &status).await.expect("publish held Claude credential");
     backend
         .clone()
         .using::<Project>("flotilla")

--- a/crates/flotilla-daemon/src/credential.rs
+++ b/crates/flotilla-daemon/src/credential.rs
@@ -1163,12 +1163,21 @@ interactions:
             .expect("explicit Claude config dir")
             .is_empty());
 
+        assert!(
+            store.prepare("env-without-grant", &BTreeSet::new(), runner.clone()).await.expect("prepare without a grant").is_empty(),
+            "an ungranted session must receive no credential environment"
+        );
         let delivered = store.prepare("env-a", &credential_refs, runner.clone()).await.expect("prepare claude-oauth credential");
 
-        assert_eq!(delivered, vec![
-            ("CLAUDE_CODE_OAUTH_TOKEN".to_string(), secret.to_string()),
-            ("CLAUDE_CONFIG_DIR".to_string(), "/run/flotilla/credentials/claude-max/claude".to_string()),
-        ]);
+        assert_eq!(delivered.len(), 2);
+        assert!(
+            delivered.iter().any(|(name, value)| name == "CLAUDE_CODE_OAUTH_TOKEN" && value == secret),
+            "the OAuth token must be delivered under CLAUDE_CODE_OAUTH_TOKEN"
+        );
+        assert!(
+            delivered.iter().any(|(name, value)| name == "CLAUDE_CONFIG_DIR" && value == "/run/flotilla/credentials/claude-max/claude"),
+            "the isolated Claude config directory must be delivered"
+        );
         let calls = runner.calls.lock().expect("calls lock");
         assert!(calls.iter().any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/run/flotilla/credentials/claude-max/claude"]));
         assert!(calls.iter().any(|(cmd, args, input)| {


### PR DESCRIPTION
## Summary

- require a compatible granted Claude credential before admitting a contained `claude-code` crew
- seed Claude's non-secret onboarding and workspace-trust state before launch
- suppress the documented bypass-mode confirmation through the managed per-invocation settings overlay
- retain `CLAUDE_CODE_OAUTH_TOKEN` as process-only credential delivery and cover no-grant/default-deny behavior without printing material

## Root cause

OAuth material delivery already existed in the credential adapter, but admission allowed contained Claude sessions to start with no matching credential grant. Separately, a fresh isolated `CLAUDE_CONFIG_DIR` had no onboarding or workspace-trust state, so interactive first-run dialogs appeared before the prompt even when a token was available.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- real-TTY Claude 2.1.223 probe with a fresh isolated config: reached the composer directly; an intentionally invalid token produced a named 401 at the prompt without onboarding, login, trust, or bypass-confirmation dialogs

Closes #1487
