### PR TITLE
fix: seed contained Claude from crew credentials

### DIFF
--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -13,7 +13,7 @@ use toml_edit::{value, DocumentMut, Item, Table};
 
 use crate::{
     path_context::ExecutionEnvironmentPath,
-    providers::{discovery::EnvironmentBag, ChannelLabel, CommandRunner},
+    providers::{discovery::EnvironmentBag, terminal::TerminalEnvVars, ChannelLabel, CommandRunner},
 };
 
 pub const TRUSTED_IMPLICIT_STANCE: &str = "trusted-implicit";
@@ -389,6 +389,17 @@ impl Default for CapabilityTable {
 pub trait AgentAdapter: Send + Sync {
     fn id(&self) -> &'static str;
     async fn prepare(&self, cwd: &ExecutionEnvironmentPath, brief: &TerminalBrief) -> Result<(), String>;
+    /// Prepare an invocation with the environment selected for this particular
+    /// crew process. Credential-backed paths are deliberately resolved here,
+    /// rather than from the environment in which adapter discovery happened.
+    async fn prepare_with_environment(
+        &self,
+        cwd: &ExecutionEnvironmentPath,
+        brief: &TerminalBrief,
+        _environment: &TerminalEnvVars,
+    ) -> Result<(), String> {
+        self.prepare(cwd, brief).await
+    }
     async fn cleanup(&self, _cwd: &ExecutionEnvironmentPath, _brief: &TerminalBrief) -> Result<(), String> {
         Ok(())
     }
@@ -421,7 +432,7 @@ enum AdapterFlavor {
     /// present. Managed sessions seed the first two into Claude's mutable state
     /// and carry the documented bypass-consent setting alongside Flotilla's
     /// hooks in the invocation-only `--settings` overlay.
-    ClaudeCode { state_config: Option<ClaudeStateConfig> },
+    ClaudeCode { state_config: Option<ClaudeStateConfig>, state_lock: Arc<Mutex<()>> },
     /// Codex gates on a persisted per-project trust level, so the workspace has
     /// to be marked trusted in its config before launch.
     Codex { trust_config: Option<CodexTrustConfig> },
@@ -486,9 +497,21 @@ impl AgentAdapter for CliAgentAdapter {
     }
 
     async fn prepare(&self, cwd: &ExecutionEnvironmentPath, brief: &TerminalBrief) -> Result<(), String> {
+        self.prepare_with_environment(cwd, brief, &Vec::new()).await
+    }
+
+    async fn prepare_with_environment(
+        &self,
+        cwd: &ExecutionEnvironmentPath,
+        brief: &TerminalBrief,
+        environment: &TerminalEnvVars,
+    ) -> Result<(), String> {
         match &self.flavor {
-            AdapterFlavor::ClaudeCode { state_config } => {
-                if let Some(state_config) = state_config {
+            AdapterFlavor::ClaudeCode { state_config, state_lock } => {
+                let invocation_state = environment.iter().find(|(name, _)| name == "CLAUDE_CONFIG_DIR").map(|(_, config_dir)| {
+                    ClaudeStateConfig { path: PathBuf::from(config_dir).join(".claude.json"), lock: Arc::clone(state_lock) }
+                });
+                if let Some(state_config) = invocation_state.as_ref().or(state_config.as_ref()) {
                     seed_claude_headless_state(&*self.runner, cwd.as_path(), state_config).await?;
                 }
                 let mut settings = crate::agents::claude_code_hook_settings();
@@ -667,11 +690,13 @@ impl AgentAdapterRegistry {
         let mut registry = Self::default();
         if let Some(binary) = env.find_binary("claude") {
             let state_path = env.find_env_var("CLAUDE_CONFIG_DIR").map(|config_dir| PathBuf::from(config_dir).join(".claude.json"));
+            let state_lock = Arc::new(Mutex::new(()));
             registry.insert(Arc::new(CliAgentAdapter {
                 binary: binary.as_path().display().to_string(),
                 runner: Arc::clone(&runner),
                 flavor: AdapterFlavor::ClaudeCode {
-                    state_config: state_path.map(|path| ClaudeStateConfig { path, lock: Arc::new(Mutex::new(())) }),
+                    state_config: state_path.map(|path| ClaudeStateConfig { path, lock: Arc::clone(&state_lock) }),
+                    state_lock,
                 },
             }));
         }
@@ -1215,15 +1240,19 @@ mod tests {
         let claude_config = temp.path().join("claude-config");
         std::fs::create_dir_all(&workspace).expect("workspace");
         std::fs::create_dir_all(&claude_config).expect("Claude config");
-        let env = EnvironmentBag::new()
-            .with(EnvironmentAssertion::env_var("CLAUDE_CONFIG_DIR", claude_config.display().to_string()))
-            .with(EnvironmentAssertion::binary("claude", "/tools/claude"));
+        let env = EnvironmentBag::new().with(EnvironmentAssertion::binary("claude", "/tools/claude"));
         let registry = AgentAdapterRegistry::discover(&env, Arc::new(ProcessCommandRunner));
         let claude = registry.get("claude-code").expect("claude adapter");
         let brief =
             flotilla_resources::TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "brief".into(), copies: Vec::new() };
 
-        claude.prepare(&ExecutionEnvironmentPath::new(&workspace), &brief).await.expect("prepare claude workspace");
+        claude
+            .prepare_with_environment(&ExecutionEnvironmentPath::new(&workspace), &brief, &vec![(
+                "CLAUDE_CONFIG_DIR".to_string(),
+                claude_config.display().to_string(),
+            )])
+            .await
+            .expect("prepare claude workspace");
 
         // The launch command names this path relatively, so it must resolve
         // against the session's working directory.

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -2778,11 +2778,11 @@ impl TerminalRuntime for TerminalControllerRuntime {
                     .agent_adapters
                     .get(&requirement.adapter)
                     .ok_or_else(|| format!("agent adapter {} unavailable for environment {}", requirement.adapter, spec.env_ref))?;
-                adapter.prepare(&cwd, brief).await?;
+                adapter.prepare_with_environment(&cwd, brief, &credential_env).await?;
                 for copy_root in &brief.copies {
                     let copy_root = ExecutionEnvironmentPath::new(copy_root);
                     if copy_root != cwd {
-                        adapter.prepare(&copy_root, brief).await?;
+                        adapter.prepare_with_environment(&copy_root, brief, &credential_env).await?;
                     }
                 }
                 let plan = adapter.launch(&AgentLaunchRequest {
@@ -3016,6 +3016,7 @@ mod tests {
     };
 
     use flotilla_core::{
+        agent_adapter::AgentAdapterRegistry,
         config::ConfigStore,
         daemon::DaemonHandle,
         in_process::DEFAULT_PROVISIONING_NAMESPACE as NAMESPACE,
@@ -3025,7 +3026,7 @@ mod tests {
                     fake_discovery_with_provider_set, git_process_discovery, DiscoveryMockRunner, FakeDiscoveryProviders, FakeTerminalPool,
                     MergedPrProcessRunner, TestEnvVars,
                 },
-                EnvironmentAssertion, EnvironmentBag,
+                EnvironmentAssertion, EnvironmentBag, ProviderCategory, ProviderDescriptor,
             },
             environment::{EnvironmentHandle, EnvironmentProvider, ProvisionedEnvironment, ProvisionedMount, ProvisionedMountMode},
             ChannelLabel, CommandOutput, CommandRunner, ProcessCommandRunner,
@@ -3477,6 +3478,46 @@ mod tests {
 
         async fn exists(&self, cmd: &str, args: &[&str]) -> bool {
             ProcessCommandRunner.exists(cmd, args).await
+        }
+    }
+
+    struct CredentialInteriorRunner(DiscoveryMockRunner);
+
+    #[async_trait]
+    impl CommandRunner for CredentialInteriorRunner {
+        async fn run(&self, cmd: &str, args: &[&str], cwd: &Path, label: &ChannelLabel) -> Result<String, String> {
+            self.0.run(cmd, args, cwd, label).await
+        }
+
+        async fn run_output(&self, cmd: &str, args: &[&str], cwd: &Path, label: &ChannelLabel) -> Result<CommandOutput, String> {
+            self.0.run_output(cmd, args, cwd, label).await
+        }
+
+        async fn run_with_input(
+            &self,
+            _cmd: &str,
+            _args: &[&str],
+            _cwd: &Path,
+            _label: &ChannelLabel,
+            _input: &[u8],
+        ) -> Result<String, String> {
+            Ok("ok".to_string())
+        }
+
+        async fn exists(&self, cmd: &str, args: &[&str]) -> bool {
+            self.0.exists(cmd, args).await
+        }
+
+        async fn path_exists(&self, path: &Path) -> Result<bool, String> {
+            self.0.path_exists(path).await
+        }
+
+        async fn ensure_file(&self, path: &Path, content: &str) -> Result<String, String> {
+            self.0.ensure_file(path, content).await
+        }
+
+        async fn write_file(&self, path: &Path, content: &str) -> Result<(), String> {
+            self.0.write_file(path, content).await
         }
     }
 
@@ -7070,6 +7111,121 @@ mod tests {
         .await;
 
         run_stage4a_flow_reaches_running_and_completes_convoy(daemon, config, repo_default_dir, repo, CompletionAction::Delete).await;
+    }
+
+    #[tokio::test]
+    async fn contained_claude_launch_uses_granted_invocation_environment_without_ambient_config() {
+        let temp = TempDir::new().expect("tempdir");
+        let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+        fs::create_dir_all(config.base_path()).expect("config directory");
+        fs::write(config.base_path().join("daemon.toml"), "machine_id = \"contained-claude-test\"\n").expect("daemon config");
+        let daemon = in_memory_daemon(Vec::new(), Arc::clone(&config)).await;
+        let backend = daemon.resource_backend();
+        backend
+            .clone()
+            .definitions::<CredentialSpec>(NAMESPACE)
+            .create(&empty_meta("claude-max"), &CredentialSpecSpec {
+                consumer: CredentialConsumer::ClaudeOauth { account_email: "test@example.com".to_string() },
+                source: CredentialSource::Env { name: "TEST_CLAUDE_TOKEN".to_string() },
+                lifecycle: CredentialLifecycle::Static,
+                placement: CredentialPlacementRequirements::default(),
+            })
+            .await
+            .expect("Claude credential declaration");
+
+        let runner: Arc<dyn CommandRunner> = Arc::new(CredentialInteriorRunner(
+            DiscoveryMockRunner::builder()
+                .tool_exists("claude", true)
+                .on_run("mkdir", &["-p", "/run/flotilla/credentials/claude-max/claude"], Ok(String::new()))
+                .build(),
+        ));
+        let bag = EnvironmentBag::new().with(EnvironmentAssertion::binary("claude", "/usr/local/bin/claude"));
+        assert!(bag.find_env_var("CLAUDE_CONFIG_DIR").is_none(), "the contained discovery environment must reproduce udder");
+        let pool = Arc::new(FakeTerminalPool::new());
+        let mut contained_registry = ProviderRegistry::new();
+        contained_registry.agent_adapters = AgentAdapterRegistry::discover(&bag, Arc::clone(&runner));
+        contained_registry.terminal_pools.insert(
+            "fake-terminals",
+            ProviderDescriptor::named(ProviderCategory::TerminalPool, "fake-terminals"),
+            pool.clone(),
+        );
+        let contained_registry = Arc::new(contained_registry);
+        let env_id = EnvironmentId::new("contained-claude");
+        let handle: EnvironmentHandle = Arc::new(TestInteriorEnvironment {
+            id: env_id.clone(),
+            image: ImageId::new("contained-image"),
+            runner: Arc::clone(&runner),
+            env_vars: HashMap::from([("HOME".to_string(), "/home/crew".to_string())]),
+            destroyed: Arc::new(AtomicBool::new(false)),
+        });
+        daemon
+            .register_provisioned_environment(env_id.clone(), handle, bag.clone(), Some(Arc::clone(&contained_registry)))
+            .expect("register contained environment");
+
+        let credential_store = Arc::new(CredentialStore::new(
+            backend,
+            NAMESPACE,
+            Arc::new(TestEnvVars::new([("TEST_CLAUDE_TOKEN", "oauth-secret-material")])),
+            bag,
+            Arc::clone(&runner),
+            config.state_dir().as_path().to_path_buf(),
+        ));
+        let state = Arc::new(
+            ControllerRuntimeState::new(
+                Arc::clone(&daemon),
+                config,
+                Arc::new(ProviderRegistry::new()),
+                None,
+                "host-test".to_string(),
+                None,
+                "host-direct-host-test".to_string(),
+            )
+            .with_credential_store(credential_store),
+        );
+        let workspace = temp.path().join("workspace");
+        fs::create_dir_all(&workspace).expect("workspace");
+        let spec = flotilla_resources::TerminalSessionSpec {
+            env_ref: env_id.to_string(),
+            role: "coder".to_string(),
+            source: TerminalSessionSource::Agent {
+                selector: Selector { capability: "code".to_string(), adapter: Some("claude-code".to_string()), model: None },
+                brief: flotilla_resources::TerminalBrief {
+                    path: ".flotilla/briefs/coder.md".to_string(),
+                    content: "Implement the issue.".to_string(),
+                    copies: Vec::new(),
+                },
+                context: Box::new(flotilla_resources::TerminalCrewContext {
+                    namespace: NAMESPACE.to_string(),
+                    convoy: "demo".to_string(),
+                    vessel_ref: "demo-work".to_string(),
+                }),
+                message: None,
+            },
+            cwd: workspace.display().to_string(),
+            pool: "fake-terminals".to_string(),
+        };
+        let tags = [flotilla_resources::TerminalSessionTag::new(CREDENTIAL_REF_SESSION_TAG, "claude-max")];
+
+        TerminalControllerRuntime { state }
+            .ensure_session("terminal-demo-work-coder", &spec, &tags)
+            .await
+            .expect("launch contained Claude with its granted credential");
+
+        let ensured = pool.ensured.lock().await;
+        let [launch] = ensured.as_slice() else {
+            panic!("expected exactly one contained Claude launch");
+        };
+        assert!(
+            launch.env_vars.iter().any(|(name, value)| name == "CLAUDE_CODE_OAUTH_TOKEN" && value == "oauth-secret-material"),
+            "the contained Claude process must receive its OAuth token"
+        );
+        assert!(
+            launch
+                .env_vars
+                .iter()
+                .any(|(name, value)| name == "CLAUDE_CONFIG_DIR" && value == "/run/flotilla/credentials/claude-max/claude"),
+            "the contained Claude process must receive its isolated config directory"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- seed Claude onboarding and workspace trust from the per-crew credential environment instead of ambient discovery state
- pass granted invocation environment into agent preparation before launch
- add a provisioning-level regression reproducing udder with no ambient `CLAUDE_CONFIG_DIR`, while asserting process-only OAuth and config delivery

## Root cause

The first fix discovered Claude state configuration before the granted crew environment existed. On udder, discovery had no ambient `CLAUDE_CONFIG_DIR`, so preparation skipped headless state seeding even though the credential adapter later selected an isolated directory for the crew process.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1487