### PR TITLE
fix: let contained Claude own headless config

### DIFF
--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -312,6 +312,8 @@ pub struct AgentLaunchRequest {
     pub role: String,
     pub model: Option<String>,
     pub brief: TerminalBrief,
+    pub cwd: ExecutionEnvironmentPath,
+    pub environment: TerminalEnvVars,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -432,7 +434,7 @@ enum AdapterFlavor {
     /// present. Managed sessions seed the first two into Claude's mutable state
     /// and carry the documented bypass-consent setting alongside Flotilla's
     /// hooks in the invocation-only `--settings` overlay.
-    ClaudeCode { state_config: Option<ClaudeStateConfig>, state_lock: Arc<Mutex<()>> },
+    ClaudeCode { state_config: Option<ClaudeStateConfig>, state_lock: Arc<Mutex<()>>, contained: bool },
     /// Codex gates on a persisted per-project trust level, so the workspace has
     /// to be marked trusted in its config before launch.
     Codex { trust_config: Option<CodexTrustConfig> },
@@ -507,10 +509,21 @@ impl AgentAdapter for CliAgentAdapter {
         environment: &TerminalEnvVars,
     ) -> Result<(), String> {
         match &self.flavor {
-            AdapterFlavor::ClaudeCode { state_config, state_lock } => {
-                let invocation_state = environment.iter().find(|(name, _)| name == "CLAUDE_CONFIG_DIR").map(|(_, config_dir)| {
-                    ClaudeStateConfig { path: PathBuf::from(config_dir).join(".claude.json"), lock: Arc::clone(state_lock) }
-                });
+            AdapterFlavor::ClaudeCode { state_config, state_lock, contained } => {
+                let invocation_state = if *contained {
+                    if !environment.iter().any(|(name, _)| name == "CLAUDE_CODE_OAUTH_TOKEN") {
+                        return Err("contained Claude Code requires credential environment `CLAUDE_CODE_OAUTH_TOKEN`".to_string());
+                    }
+                    let config_dir = cwd.as_path().join(".flotilla/claude");
+                    let config_dir_string = config_dir.display().to_string();
+                    self.runner.run("mkdir", &["-p", &config_dir_string], Path::new("/"), &ChannelLabel::Noop).await?;
+                    Some(ClaudeStateConfig { path: config_dir.join(".claude.json"), lock: Arc::clone(state_lock) })
+                } else {
+                    environment.iter().find(|(name, _)| name == "CLAUDE_CONFIG_DIR").map(|(_, config_dir)| ClaudeStateConfig {
+                        path: PathBuf::from(config_dir).join(".claude.json"),
+                        lock: Arc::clone(state_lock),
+                    })
+                };
                 if let Some(state_config) = invocation_state.as_ref().or(state_config.as_ref()) {
                     seed_claude_headless_state(&*self.runner, cwd.as_path(), state_config).await?;
                 }
@@ -532,6 +545,12 @@ impl AgentAdapter for CliAgentAdapter {
     }
 
     async fn cleanup(&self, cwd: &ExecutionEnvironmentPath, brief: &TerminalBrief) -> Result<(), String> {
+        if matches!(&self.flavor, AdapterFlavor::ClaudeCode { contained: true, .. }) {
+            let config_dir = cwd.as_path().join(".flotilla/claude");
+            let config_dir =
+                config_dir.to_str().ok_or_else(|| format!("contained Claude config path is not valid UTF-8: {}", config_dir.display()))?;
+            self.runner.run("rm", &["-rf", config_dir], Path::new("/"), &ChannelLabel::Noop).await?;
+        }
         remove_agent_files(&*self.runner, cwd.as_path(), brief, self.flavor.managed_files()).await
     }
 
@@ -545,7 +564,15 @@ impl AgentAdapter for CliAgentAdapter {
     }
 
     fn launch(&self, request: &AgentLaunchRequest) -> Result<AgentLaunchPlan, String> {
-        Ok(AgentLaunchPlan { command: self.command(request), env: Vec::new(), stance: TRUSTED_IMPLICIT_STANCE.into() })
+        let mut env = request.environment.clone();
+        if matches!(&self.flavor, AdapterFlavor::ClaudeCode { contained: true, .. }) {
+            if !env.iter().any(|(name, _)| name == "CLAUDE_CODE_OAUTH_TOKEN") {
+                return Err("contained Claude Code requires credential environment `CLAUDE_CODE_OAUTH_TOKEN`".to_string());
+            }
+            env.retain(|(name, _)| name != "CLAUDE_CONFIG_DIR");
+            env.push(("CLAUDE_CONFIG_DIR".to_string(), request.cwd.as_path().join(".flotilla/claude").display().to_string()));
+        }
+        Ok(AgentLaunchPlan { command: self.command(request), env, stance: TRUSTED_IMPLICIT_STANCE.into() })
     }
 }
 
@@ -697,6 +724,7 @@ impl AgentAdapterRegistry {
                 flavor: AdapterFlavor::ClaudeCode {
                     state_config: state_path.map(|path| ClaudeStateConfig { path, lock: Arc::clone(&state_lock) }),
                     state_lock,
+                    contained: env.find_env_var("FLOTILLA_ENVIRONMENT_ID").is_some(),
                 },
             }));
         }
@@ -1188,8 +1216,15 @@ mod tests {
 
         let codex = registry.get("codex").expect("codex adapter");
         codex.prepare(&cwd, &brief).await.expect("prepare brief");
-        let plan =
-            codex.launch(&AgentLaunchRequest { role: "coder".into(), model: None, brief: brief.clone() }).expect("codex launch plan");
+        let plan = codex
+            .launch(&AgentLaunchRequest {
+                role: "coder".into(),
+                model: None,
+                brief: brief.clone(),
+                cwd: cwd.clone(),
+                environment: Vec::new(),
+            })
+            .expect("codex launch plan");
         assert_eq!(
             plan.command,
             "/tools/codex --dangerously-bypass-approvals-and-sandbox 'Read your crew brief at .flotilla/briefs/coder.md and follow it.'"
@@ -1199,7 +1234,13 @@ mod tests {
 
         let claude = registry.get("claude-code").expect("claude adapter");
         let plan = claude
-            .launch(&AgentLaunchRequest { role: "reviewer".into(), model: Some("opus".into()), brief: brief.clone() })
+            .launch(&AgentLaunchRequest {
+                role: "reviewer".into(),
+                model: Some("opus".into()),
+                brief: brief.clone(),
+                cwd: cwd.clone(),
+                environment: Vec::new(),
+            })
             .expect("claude launch plan");
         assert_eq!(
             plan.command,
@@ -1211,7 +1252,13 @@ mod tests {
         // the sink still shell-quotes so a hostile model can never splice
         // into the command line even if that boundary regressed.
         let plan = claude
-            .launch(&AgentLaunchRequest { role: "reviewer".into(), model: Some("opus; touch /tmp/pwned".into()), brief })
+            .launch(&AgentLaunchRequest {
+                role: "reviewer".into(),
+                model: Some("opus; touch /tmp/pwned".into()),
+                brief,
+                cwd,
+                environment: Vec::new(),
+            })
             .expect("claude launch plan");
         assert!(plan.command.contains("--model 'opus; touch /tmp/pwned'"));
     }
@@ -1226,7 +1273,13 @@ mod tests {
         let plan = registry
             .get("claude-code")
             .expect("claude adapter")
-            .launch(&AgentLaunchRequest { role: "coder".into(), model: None, brief })
+            .launch(&AgentLaunchRequest {
+                role: "coder".into(),
+                model: None,
+                brief,
+                cwd: ExecutionEnvironmentPath::new("/workspace"),
+                environment: Vec::new(),
+            })
             .expect("launch plan");
 
         assert!(plan.command.starts_with("/x/y/claude "));
@@ -1237,10 +1290,10 @@ mod tests {
     async fn claude_prepare_writes_a_settings_overlay_the_launch_command_loads() {
         let temp = tempfile::tempdir().expect("tempdir");
         let workspace = temp.path().join("workspace");
-        let claude_config = temp.path().join("claude-config");
         std::fs::create_dir_all(&workspace).expect("workspace");
-        std::fs::create_dir_all(&claude_config).expect("Claude config");
-        let env = EnvironmentBag::new().with(EnvironmentAssertion::binary("claude", "/tools/claude"));
+        let env = EnvironmentBag::new()
+            .with(EnvironmentAssertion::env_var("FLOTILLA_ENVIRONMENT_ID", "contained-claude"))
+            .with(EnvironmentAssertion::binary("claude", "/tools/claude"));
         let registry = AgentAdapterRegistry::discover(&env, Arc::new(ProcessCommandRunner));
         let claude = registry.get("claude-code").expect("claude adapter");
         let brief =
@@ -1248,16 +1301,34 @@ mod tests {
 
         claude
             .prepare_with_environment(&ExecutionEnvironmentPath::new(&workspace), &brief, &vec![(
-                "CLAUDE_CONFIG_DIR".to_string(),
-                claude_config.display().to_string(),
+                "CLAUDE_CODE_OAUTH_TOKEN".to_string(),
+                "redacted-test-token".to_string(),
             )])
             .await
             .expect("prepare claude workspace");
 
         // The launch command names this path relatively, so it must resolve
         // against the session's working directory.
-        let plan = claude.launch(&AgentLaunchRequest { role: "coder".into(), model: None, brief: brief.clone() }).expect("launch plan");
+        let plan = claude
+            .launch(&AgentLaunchRequest {
+                role: "coder".into(),
+                model: None,
+                brief: brief.clone(),
+                cwd: ExecutionEnvironmentPath::new(&workspace),
+                environment: vec![("CLAUDE_CODE_OAUTH_TOKEN".to_string(), "redacted-test-token".to_string())],
+            })
+            .expect("launch plan");
         assert!(plan.command.contains("--settings .flotilla/claude-settings.json"), "{}", plan.command);
+        assert!(
+            plan.env.iter().any(|(name, value)| name == "CLAUDE_CODE_OAUTH_TOKEN" && value == "redacted-test-token"),
+            "the adapter launch plan must carry the granted token"
+        );
+        assert!(
+            plan.env
+                .iter()
+                .any(|(name, value)| name == "CLAUDE_CONFIG_DIR" && value == &workspace.join(".flotilla/claude").display().to_string()),
+            "the adapter launch plan must carry its contained config path"
+        );
 
         let settings: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(workspace.join(".flotilla/claude-settings.json")).expect("read settings"))
@@ -1266,9 +1337,10 @@ mod tests {
         assert_eq!(settings["hooks"]["Notification"][0]["matcher"], "permission_prompt");
         assert_eq!(settings["skipDangerousModePermissionPrompt"], true);
 
-        let state: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(claude_config.join(".claude.json")).expect("read Claude state"))
-                .expect("parse Claude state");
+        let state: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(workspace.join(".flotilla/claude/.claude.json")).expect("read contained Claude state"),
+        )
+        .expect("parse Claude state");
         let canonical_workspace = workspace.canonicalize().expect("canonical workspace").display().to_string();
         assert_eq!(state["hasCompletedOnboarding"], true);
         assert_eq!(state["projects"][canonical_workspace]["hasTrustDialogAccepted"], true);

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use flotilla_protocol::arg::{flatten, Arg};
 use flotilla_resources::{TerminalAttentionState, TerminalBrief};
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 use toml_edit::{value, DocumentMut, Item, Table};
 
@@ -312,7 +313,6 @@ pub struct AgentLaunchRequest {
     pub role: String,
     pub model: Option<String>,
     pub brief: TerminalBrief,
-    pub cwd: ExecutionEnvironmentPath,
     pub environment: TerminalEnvVars,
 }
 
@@ -418,6 +418,8 @@ pub trait AgentAdapter: Send + Sync {
 /// relative to the session's working directory. It lives under `.flotilla/`
 /// alongside the brief so it inherits the same git exclusion and teardown.
 pub const CLAUDE_MANAGED_SETTINGS_PATH: &str = ".flotilla/claude-settings.json";
+const CONTAINED_CLAUDE_CONFIG_DIR: &str = "/run/flotilla/claude";
+const HOST_DIRECT_CLAUDE_OAUTH_CONFIG_ROOT: &str = "/run/flotilla/claude-oauth";
 
 struct CliAgentAdapter {
     binary: String,
@@ -490,6 +492,27 @@ impl CliAgentAdapter {
         args.push(Arg::Quoted(self.deliver_brief(&request.brief)));
         flatten(&args, 0)
     }
+
+    fn claude_invocation_config_dir(&self, environment: &TerminalEnvVars) -> Option<PathBuf> {
+        let AdapterFlavor::ClaudeCode { contained, .. } = &self.flavor else {
+            return None;
+        };
+        let oauth_token = environment.iter().find(|(name, _)| name == "CLAUDE_CODE_OAUTH_TOKEN").map(|(_, value)| value.as_str());
+        if *contained {
+            return oauth_token.map(|_| PathBuf::from(CONTAINED_CLAUDE_CONFIG_DIR));
+        }
+        if let Some((_, config_dir)) = environment.iter().find(|(name, _)| name == "CLAUDE_CONFIG_DIR") {
+            return Some(PathBuf::from(config_dir));
+        }
+        oauth_token.map(|token| {
+            // Host-direct OAuth identities still need separate supervisor and
+            // mutable-state homes. Key the ephemeral directory without putting
+            // credential material or a reversible account identifier in paths.
+            let digest = Sha256::digest(token.as_bytes());
+            let account_key = digest[..16].iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+            PathBuf::from(HOST_DIRECT_CLAUDE_OAUTH_CONFIG_ROOT).join(account_key)
+        })
+    }
 }
 
 #[async_trait]
@@ -510,19 +533,15 @@ impl AgentAdapter for CliAgentAdapter {
     ) -> Result<(), String> {
         match &self.flavor {
             AdapterFlavor::ClaudeCode { state_config, state_lock, contained } => {
-                let invocation_state = if *contained {
-                    if !environment.iter().any(|(name, _)| name == "CLAUDE_CODE_OAUTH_TOKEN") {
-                        return Err("contained Claude Code requires credential environment `CLAUDE_CODE_OAUTH_TOKEN`".to_string());
-                    }
-                    let config_dir = cwd.as_path().join(".flotilla/claude");
+                if *contained && !environment.iter().any(|(name, _)| name == "CLAUDE_CODE_OAUTH_TOKEN") {
+                    return Err("contained Claude Code requires credential environment `CLAUDE_CODE_OAUTH_TOKEN`".to_string());
+                }
+                let invocation_state = if let Some(config_dir) = self.claude_invocation_config_dir(environment) {
                     let config_dir_string = config_dir.display().to_string();
                     self.runner.run("mkdir", &["-p", &config_dir_string], Path::new("/"), &ChannelLabel::Noop).await?;
                     Some(ClaudeStateConfig { path: config_dir.join(".claude.json"), lock: Arc::clone(state_lock) })
                 } else {
-                    environment.iter().find(|(name, _)| name == "CLAUDE_CONFIG_DIR").map(|(_, config_dir)| ClaudeStateConfig {
-                        path: PathBuf::from(config_dir).join(".claude.json"),
-                        lock: Arc::clone(state_lock),
-                    })
+                    None
                 };
                 if let Some(state_config) = invocation_state.as_ref().or(state_config.as_ref()) {
                     seed_claude_headless_state(&*self.runner, cwd.as_path(), state_config).await?;
@@ -545,12 +564,6 @@ impl AgentAdapter for CliAgentAdapter {
     }
 
     async fn cleanup(&self, cwd: &ExecutionEnvironmentPath, brief: &TerminalBrief) -> Result<(), String> {
-        if matches!(&self.flavor, AdapterFlavor::ClaudeCode { contained: true, .. }) {
-            let config_dir = cwd.as_path().join(".flotilla/claude");
-            let config_dir =
-                config_dir.to_str().ok_or_else(|| format!("contained Claude config path is not valid UTF-8: {}", config_dir.display()))?;
-            self.runner.run("rm", &["-rf", config_dir], Path::new("/"), &ChannelLabel::Noop).await?;
-        }
         remove_agent_files(&*self.runner, cwd.as_path(), brief, self.flavor.managed_files()).await
     }
 
@@ -565,12 +578,14 @@ impl AgentAdapter for CliAgentAdapter {
 
     fn launch(&self, request: &AgentLaunchRequest) -> Result<AgentLaunchPlan, String> {
         let mut env = request.environment.clone();
-        if matches!(&self.flavor, AdapterFlavor::ClaudeCode { contained: true, .. }) {
-            if !env.iter().any(|(name, _)| name == "CLAUDE_CODE_OAUTH_TOKEN") {
-                return Err("contained Claude Code requires credential environment `CLAUDE_CODE_OAUTH_TOKEN`".to_string());
-            }
+        if matches!(&self.flavor, AdapterFlavor::ClaudeCode { contained: true, .. })
+            && !env.iter().any(|(name, _)| name == "CLAUDE_CODE_OAUTH_TOKEN")
+        {
+            return Err("contained Claude Code requires credential environment `CLAUDE_CODE_OAUTH_TOKEN`".to_string());
+        }
+        if let Some(config_dir) = self.claude_invocation_config_dir(&env) {
             env.retain(|(name, _)| name != "CLAUDE_CONFIG_DIR");
-            env.push(("CLAUDE_CONFIG_DIR".to_string(), request.cwd.as_path().join(".flotilla/claude").display().to_string()));
+            env.push(("CLAUDE_CONFIG_DIR".to_string(), config_dir.display().to_string()));
         }
         Ok(AgentLaunchPlan { command: self.command(request), env, stance: TRUSTED_IMPLICIT_STANCE.into() })
     }
@@ -772,8 +787,9 @@ mod tests {
 
     use crate::{
         agent_adapter::{
-            append_convoy_work_context, build_crew_brief, build_crew_brief_with_options, AgentAdapterRegistry, AgentLaunchRequest,
-            CapabilityTable, CrewAssignment, CrewBriefMember, CrewBriefRenderOptions, CrewBriefTemplateOverride, CrewBriefTemplateResolver,
+            append_convoy_work_context, build_crew_brief, build_crew_brief_with_options, AgentAdapterRegistry, AgentLaunchPlan,
+            AgentLaunchRequest, CapabilityTable, CrewAssignment, CrewBriefMember, CrewBriefRenderOptions, CrewBriefTemplateOverride,
+            CrewBriefTemplateResolver, CONTAINED_CLAUDE_CONFIG_DIR,
         },
         path_context::ExecutionEnvironmentPath,
         providers::{
@@ -1217,13 +1233,7 @@ mod tests {
         let codex = registry.get("codex").expect("codex adapter");
         codex.prepare(&cwd, &brief).await.expect("prepare brief");
         let plan = codex
-            .launch(&AgentLaunchRequest {
-                role: "coder".into(),
-                model: None,
-                brief: brief.clone(),
-                cwd: cwd.clone(),
-                environment: Vec::new(),
-            })
+            .launch(&AgentLaunchRequest { role: "coder".into(), model: None, brief: brief.clone(), environment: Vec::new() })
             .expect("codex launch plan");
         assert_eq!(
             plan.command,
@@ -1238,7 +1248,6 @@ mod tests {
                 role: "reviewer".into(),
                 model: Some("opus".into()),
                 brief: brief.clone(),
-                cwd: cwd.clone(),
                 environment: Vec::new(),
             })
             .expect("claude launch plan");
@@ -1256,7 +1265,6 @@ mod tests {
                 role: "reviewer".into(),
                 model: Some("opus; touch /tmp/pwned".into()),
                 brief,
-                cwd,
                 environment: Vec::new(),
             })
             .expect("claude launch plan");
@@ -1273,13 +1281,7 @@ mod tests {
         let plan = registry
             .get("claude-code")
             .expect("claude adapter")
-            .launch(&AgentLaunchRequest {
-                role: "coder".into(),
-                model: None,
-                brief,
-                cwd: ExecutionEnvironmentPath::new("/workspace"),
-                environment: Vec::new(),
-            })
+            .launch(&AgentLaunchRequest { role: "coder".into(), model: None, brief, environment: Vec::new() })
             .expect("launch plan");
 
         assert!(plan.command.starts_with("/x/y/claude "));
@@ -1290,44 +1292,32 @@ mod tests {
     async fn claude_prepare_writes_a_settings_overlay_the_launch_command_loads() {
         let temp = tempfile::tempdir().expect("tempdir");
         let workspace = temp.path().join("workspace");
+        let claude_config = temp.path().join("claude-config");
         std::fs::create_dir_all(&workspace).expect("workspace");
+        std::fs::create_dir_all(&claude_config).expect("Claude config");
         let env = EnvironmentBag::new()
-            .with(EnvironmentAssertion::env_var("FLOTILLA_ENVIRONMENT_ID", "contained-claude"))
+            .with(EnvironmentAssertion::env_var("CLAUDE_CONFIG_DIR", claude_config.display().to_string()))
             .with(EnvironmentAssertion::binary("claude", "/tools/claude"));
         let registry = AgentAdapterRegistry::discover(&env, Arc::new(ProcessCommandRunner));
         let claude = registry.get("claude-code").expect("claude adapter");
         let brief =
             flotilla_resources::TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "brief".into(), copies: Vec::new() };
 
+        let invocation_environment = vec![("CLAUDE_CONFIG_DIR".to_string(), claude_config.display().to_string())];
         claude
-            .prepare_with_environment(&ExecutionEnvironmentPath::new(&workspace), &brief, &vec![(
-                "CLAUDE_CODE_OAUTH_TOKEN".to_string(),
-                "redacted-test-token".to_string(),
-            )])
+            .prepare_with_environment(&ExecutionEnvironmentPath::new(&workspace), &brief, &invocation_environment)
             .await
             .expect("prepare claude workspace");
 
         // The launch command names this path relatively, so it must resolve
         // against the session's working directory.
         let plan = claude
-            .launch(&AgentLaunchRequest {
-                role: "coder".into(),
-                model: None,
-                brief: brief.clone(),
-                cwd: ExecutionEnvironmentPath::new(&workspace),
-                environment: vec![("CLAUDE_CODE_OAUTH_TOKEN".to_string(), "redacted-test-token".to_string())],
-            })
+            .launch(&AgentLaunchRequest { role: "coder".into(), model: None, brief: brief.clone(), environment: invocation_environment })
             .expect("launch plan");
         assert!(plan.command.contains("--settings .flotilla/claude-settings.json"), "{}", plan.command);
         assert!(
-            plan.env.iter().any(|(name, value)| name == "CLAUDE_CODE_OAUTH_TOKEN" && value == "redacted-test-token"),
-            "the adapter launch plan must carry the granted token"
-        );
-        assert!(
-            plan.env
-                .iter()
-                .any(|(name, value)| name == "CLAUDE_CONFIG_DIR" && value == &workspace.join(".flotilla/claude").display().to_string()),
-            "the adapter launch plan must carry its contained config path"
+            plan.env.iter().any(|(name, value)| name == "CLAUDE_CONFIG_DIR" && value == &claude_config.display().to_string()),
+            "the adapter launch plan must preserve explicit trusted config"
         );
 
         let settings: serde_json::Value =
@@ -1337,10 +1327,9 @@ mod tests {
         assert_eq!(settings["hooks"]["Notification"][0]["matcher"], "permission_prompt");
         assert_eq!(settings["skipDangerousModePermissionPrompt"], true);
 
-        let state: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(workspace.join(".flotilla/claude/.claude.json")).expect("read contained Claude state"),
-        )
-        .expect("parse Claude state");
+        let state: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(claude_config.join(".claude.json")).expect("read Claude state"))
+                .expect("parse Claude state");
         let canonical_workspace = workspace.canonicalize().expect("canonical workspace").display().to_string();
         assert_eq!(state["hasCompletedOnboarding"], true);
         assert_eq!(state["projects"][canonical_workspace]["hasTrustDialogAccepted"], true);
@@ -1348,6 +1337,29 @@ mod tests {
         claude.cleanup(&ExecutionEnvironmentPath::new(&workspace), &brief).await.expect("cleanup");
         assert!(!workspace.join(".flotilla/claude-settings.json").exists(), "settings overlay should be removed");
         assert!(!workspace.join(".flotilla").exists(), "settings overlay should not keep .flotilla alive");
+    }
+
+    #[tokio::test]
+    async fn contained_claude_owns_ephemeral_config_without_accepting_a_config_input() {
+        let workspace = ExecutionEnvironmentPath::new("/workspace");
+        let runner = Arc::new(MockRunner::new(vec![Ok(String::new()), Ok("/workspace\n".to_string()), Err("not a checkout".to_string())]));
+        let env = EnvironmentBag::new()
+            .with(EnvironmentAssertion::env_var("FLOTILLA_ENVIRONMENT_ID", "contained-claude"))
+            .with(EnvironmentAssertion::binary("claude", "/tools/claude"));
+        let registry = AgentAdapterRegistry::discover(&env, runner.clone());
+        let claude = registry.get("claude-code").expect("Claude adapter");
+        let brief =
+            flotilla_resources::TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "brief".into(), copies: Vec::new() };
+        let invocation_environment = vec![("CLAUDE_CODE_OAUTH_TOKEN".to_string(), "redacted-test-token".to_string())];
+
+        claude.prepare_with_environment(&workspace, &brief, &invocation_environment).await.expect("prepare contained Claude");
+        let plan = claude
+            .launch(&AgentLaunchRequest { role: "coder".into(), model: None, brief, environment: invocation_environment })
+            .expect("contained launch plan");
+
+        assert!(plan.env.iter().any(|(name, value)| name == "CLAUDE_CODE_OAUTH_TOKEN" && value == "redacted-test-token"));
+        assert!(plan.env.iter().any(|(name, value)| name == "CLAUDE_CONFIG_DIR" && value == CONTAINED_CLAUDE_CONFIG_DIR));
+        assert!(runner.calls().iter().any(|(command, args)| command == "mkdir" && args == &["-p", CONTAINED_CLAUDE_CONFIG_DIR]));
     }
 
     #[tokio::test]
@@ -1406,6 +1418,39 @@ mod tests {
             .expect("prepare host-direct Claude");
 
         assert_eq!(std::fs::read_to_string(global_state).expect("global Claude state"), r#"{"existing":true}"#);
+    }
+
+    #[test]
+    fn host_direct_claude_oauth_accounts_get_distinct_adapter_owned_config_dirs() {
+        let env = EnvironmentBag::new().with(EnvironmentAssertion::binary("claude", "/tools/claude"));
+        let registry = AgentAdapterRegistry::discover(&env, Arc::new(MockRunner::new(Vec::new())));
+        let claude = registry.get("claude-code").expect("Claude adapter");
+        let brief =
+            flotilla_resources::TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "brief".into(), copies: Vec::new() };
+        let launch = |token: &str| {
+            claude
+                .launch(&AgentLaunchRequest {
+                    role: "coder".into(),
+                    model: None,
+                    brief: brief.clone(),
+                    environment: vec![("CLAUDE_CODE_OAUTH_TOKEN".to_string(), token.to_string())],
+                })
+                .expect("host-direct OAuth launch")
+        };
+
+        let alice = launch("token-alice");
+        let bob = launch("token-bob");
+        let config_dir = |plan: &AgentLaunchPlan| {
+            plan.env
+                .iter()
+                .find(|(name, _)| name == "CLAUDE_CONFIG_DIR")
+                .map(|(_, value)| value.clone())
+                .expect("adapter-owned Claude config")
+        };
+
+        assert_ne!(config_dir(&alice), config_dir(&bob));
+        assert!(config_dir(&alice).starts_with("/run/flotilla/claude-oauth/"));
+        assert!(config_dir(&bob).starts_with("/run/flotilla/claude-oauth/"));
     }
 
     #[test]

--- a/crates/flotilla-daemon/src/credential.rs
+++ b/crates/flotilla-daemon/src/credential.rs
@@ -167,9 +167,6 @@ impl CredentialStore {
             let spec = self.spec(name).await?;
             match spec.consumer {
                 CredentialConsumer::Codex if !environment.contains_key("CODEX_HOME") => fragments.push(codex_home_fragment(name)),
-                CredentialConsumer::ClaudeOauth { .. } if !environment.contains_key("CLAUDE_CONFIG_DIR") => {
-                    fragments.push(claude_config_dir_fragment(name))
-                }
                 _ => {}
             }
         }
@@ -679,18 +676,11 @@ impl CredentialStore {
             // Subscription OAuth material (a `claude setup-token` long-lived
             // token) is delivered per-process through `CLAUDE_CODE_OAUTH_TOKEN`
             // — no login transformation exists or is needed, and one mint
-            // serves N crews (ADR 0022 amendment). A per-credential
-            // `CLAUDE_CONFIG_DIR` slot is delivered alongside it even though
-            // the crew adapter's `--settings` overlay already isolates hooks:
-            // the overlay does not isolate the per-config-dir singleton
-            // supervisor (which captures its environment from the first shell
-            // that uses it, so a shared dir would serve crew A's dispatches
-            // with crew B's credentials), the mutable `.claude.json` blob
-            // (lost writes observed in practice), or an ambient `apiKeyHelper`
-            // whose precedence outranks `CLAUDE_CODE_OAUTH_TOKEN` and would
-            // silently override the delivered identity. The slot is keyed by
-            // credential name, so two claude accounts coexist the same way two
-            // codex homes do. See
+            // serves N crews (ADR 0022 amendment). The credential-specific
+            // config directory below isolates the
+            // preflight from ambient authentication, but is not delivered to
+            // the crew. The Claude AgentAdapter owns the contained invocation's
+            // mutable config path and exports it in the launch plan. See
             // docs/research/2026-07-28-multi-crew-agent-config-seeding.md.
             CredentialConsumer::ClaudeOauth { .. } => {
                 if !runner.exists("claude", &["--version"]).await {
@@ -746,7 +736,6 @@ impl CredentialStore {
                         })?;
                 }
                 env.insert("CLAUDE_CODE_OAUTH_TOKEN".to_string(), material.to_string());
-                env.insert("CLAUDE_CONFIG_DIR".to_string(), config_dir);
             }
             CredentialConsumer::Codex => {
                 let codex_home_fragment = codex_home_fragment(name);
@@ -1146,7 +1135,7 @@ interactions:
     }
 
     #[tokio::test]
-    async fn claude_oauth_material_is_delivered_as_env_token_with_an_isolated_config_dir() {
+    async fn claude_oauth_material_is_delivered_as_an_env_token_without_owning_agent_config() {
         let backend = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(NodeId::new("root-a"));
         create_claude_oauth_spec(&backend, "claude-max", "ops@example.com", "TEST_CLAUDE_TOKEN").await;
         let secret = "sk-ant-oat01-test-token-never-in-argv";
@@ -1156,12 +1145,10 @@ interactions:
         let store = CredentialStore::new(backend, "flotilla", env, bag, runner.clone(), PathBuf::from("/tmp/flotilla-test-state"));
         let credential_refs = BTreeSet::from(["claude-max".to_string()]);
 
-        assert_eq!(store.vessel_config_fragments(&credential_refs, &BTreeMap::new()).await.expect("Claude fragment").len(), 1);
-        assert!(store
-            .vessel_config_fragments(&credential_refs, &BTreeMap::from([("CLAUDE_CONFIG_DIR".to_string(), "/image/claude".to_string())]))
-            .await
-            .expect("explicit Claude config dir")
-            .is_empty());
+        assert!(
+            store.vessel_config_fragments(&credential_refs, &BTreeMap::new()).await.expect("Claude fragments").is_empty(),
+            "Claude config belongs to the agent adapter, not credential delivery"
+        );
 
         assert!(
             store.prepare("env-without-grant", &BTreeSet::new(), runner.clone()).await.expect("prepare without a grant").is_empty(),
@@ -1169,15 +1156,12 @@ interactions:
         );
         let delivered = store.prepare("env-a", &credential_refs, runner.clone()).await.expect("prepare claude-oauth credential");
 
-        assert_eq!(delivered.len(), 2);
+        assert_eq!(delivered.len(), 1);
         assert!(
             delivered.iter().any(|(name, value)| name == "CLAUDE_CODE_OAUTH_TOKEN" && value == secret),
             "the OAuth token must be delivered under CLAUDE_CODE_OAUTH_TOKEN"
         );
-        assert!(
-            delivered.iter().any(|(name, value)| name == "CLAUDE_CONFIG_DIR" && value == "/run/flotilla/credentials/claude-max/claude"),
-            "the isolated Claude config directory must be delivered"
-        );
+        assert!(delivered.iter().all(|(name, _)| name != "CLAUDE_CONFIG_DIR"));
         let calls = runner.calls.lock().expect("calls lock");
         assert!(calls.iter().any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/run/flotilla/credentials/claude-max/claude"]));
         assert!(calls.iter().any(|(cmd, args, input)| {
@@ -1231,7 +1215,8 @@ interactions:
 
         assert_eq!(alice.get("CLAUDE_CODE_OAUTH_TOKEN"), Some(&"token-alice".to_string()));
         assert_eq!(bob.get("CLAUDE_CODE_OAUTH_TOKEN"), Some(&"token-bob".to_string()));
-        assert_ne!(alice.get("CLAUDE_CONFIG_DIR"), bob.get("CLAUDE_CONFIG_DIR"), "accounts must not share supervisor state");
+        assert!(!alice.contains_key("CLAUDE_CONFIG_DIR"));
+        assert!(!bob.contains_key("CLAUDE_CONFIG_DIR"));
 
         let error = store
             .prepare("env-c", &BTreeSet::from(["claude-alice".to_string(), "claude-bob".to_string()]), runner.clone())

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -2771,7 +2771,7 @@ impl TerminalRuntime for TerminalControllerRuntime {
             None => return Err("host-local credential store unavailable".to_string()),
         };
         let (command, mut env, crew, initial_message) = match &spec.source {
-            TerminalSessionSource::Tool { command } => (command.clone(), Vec::new(), None, None),
+            TerminalSessionSource::Tool { command } => (command.clone(), credential_env.clone(), None, None),
             TerminalSessionSource::Agent { selector, brief, context, message } => {
                 let requirement = CapabilityTable::seeded().resolve_selector(selector)?;
                 let adapter = registry
@@ -2789,6 +2789,8 @@ impl TerminalRuntime for TerminalControllerRuntime {
                     role: spec.role.clone(),
                     model: requirement.model.clone(),
                     brief: brief.clone(),
+                    cwd: cwd.clone(),
+                    environment: credential_env.clone(),
                 })?;
                 let crew_id = uuid::Uuid::new_v4().to_string();
                 let crew = flotilla_resources::CrewSessionStatus::builder()
@@ -2809,7 +2811,6 @@ impl TerminalRuntime for TerminalControllerRuntime {
                 (plan.command, env, Some(crew), message.clone())
             }
         };
-        env.extend(credential_env);
         env.push(("CARGO_INCREMENTAL".to_string(), "0".to_string()));
 
         if matches!(spec.source, TerminalSessionSource::Agent { .. })
@@ -7133,13 +7134,20 @@ mod tests {
             .await
             .expect("Claude credential declaration");
 
+        let workspace = temp.path().join("workspace");
+        fs::create_dir_all(&workspace).expect("workspace");
+        let contained_config_dir = workspace.join(".flotilla/claude");
+        let env_id = EnvironmentId::new("contained-claude");
         let runner: Arc<dyn CommandRunner> = Arc::new(CredentialInteriorRunner(
             DiscoveryMockRunner::builder()
                 .tool_exists("claude", true)
                 .on_run("mkdir", &["-p", "/run/flotilla/credentials/claude-max/claude"], Ok(String::new()))
+                .on_run("mkdir", &["-p", &contained_config_dir.display().to_string()], Ok(String::new()))
                 .build(),
         ));
-        let bag = EnvironmentBag::new().with(EnvironmentAssertion::binary("claude", "/usr/local/bin/claude"));
+        let bag = EnvironmentBag::new()
+            .with(EnvironmentAssertion::env_var("FLOTILLA_ENVIRONMENT_ID", env_id.to_string()))
+            .with(EnvironmentAssertion::binary("claude", "/usr/local/bin/claude"));
         assert!(bag.find_env_var("CLAUDE_CONFIG_DIR").is_none(), "the contained discovery environment must reproduce udder");
         let pool = Arc::new(FakeTerminalPool::new());
         let mut contained_registry = ProviderRegistry::new();
@@ -7150,7 +7158,6 @@ mod tests {
             pool.clone(),
         );
         let contained_registry = Arc::new(contained_registry);
-        let env_id = EnvironmentId::new("contained-claude");
         let handle: EnvironmentHandle = Arc::new(TestInteriorEnvironment {
             id: env_id.clone(),
             image: ImageId::new("contained-image"),
@@ -7182,8 +7189,6 @@ mod tests {
             )
             .with_credential_store(credential_store),
         );
-        let workspace = temp.path().join("workspace");
-        fs::create_dir_all(&workspace).expect("workspace");
         let spec = flotilla_resources::TerminalSessionSpec {
             env_ref: env_id.to_string(),
             role: "coder".to_string(),
@@ -7220,11 +7225,8 @@ mod tests {
             "the contained Claude process must receive its OAuth token"
         );
         assert!(
-            launch
-                .env_vars
-                .iter()
-                .any(|(name, value)| name == "CLAUDE_CONFIG_DIR" && value == "/run/flotilla/credentials/claude-max/claude"),
-            "the contained Claude process must receive its isolated config directory"
+            launch.env_vars.iter().any(|(name, value)| name == "CLAUDE_CONFIG_DIR" && value == &contained_config_dir.display().to_string()),
+            "the contained Claude process must receive the config directory owned by its adapter"
         );
     }
 

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -2789,7 +2789,6 @@ impl TerminalRuntime for TerminalControllerRuntime {
                     role: spec.role.clone(),
                     model: requirement.model.clone(),
                     brief: brief.clone(),
-                    cwd: cwd.clone(),
                     environment: credential_env.clone(),
                 })?;
                 let crew_id = uuid::Uuid::new_v4().to_string();
@@ -7136,13 +7135,12 @@ mod tests {
 
         let workspace = temp.path().join("workspace");
         fs::create_dir_all(&workspace).expect("workspace");
-        let contained_config_dir = workspace.join(".flotilla/claude");
         let env_id = EnvironmentId::new("contained-claude");
         let runner: Arc<dyn CommandRunner> = Arc::new(CredentialInteriorRunner(
             DiscoveryMockRunner::builder()
                 .tool_exists("claude", true)
                 .on_run("mkdir", &["-p", "/run/flotilla/credentials/claude-max/claude"], Ok(String::new()))
-                .on_run("mkdir", &["-p", &contained_config_dir.display().to_string()], Ok(String::new()))
+                .on_run("mkdir", &["-p", "/run/flotilla/claude"], Ok(String::new()))
                 .build(),
         ));
         let bag = EnvironmentBag::new()
@@ -7225,7 +7223,7 @@ mod tests {
             "the contained Claude process must receive its OAuth token"
         );
         assert!(
-            launch.env_vars.iter().any(|(name, value)| name == "CLAUDE_CONFIG_DIR" && value == &contained_config_dir.display().to_string()),
+            launch.env_vars.iter().any(|(name, value)| name == "CLAUDE_CONFIG_DIR" && value == "/run/flotilla/claude"),
             "the contained Claude process must receive the config directory owned by its adapter"
         );
     }


### PR DESCRIPTION
## Summary

- make the Claude AgentAdapter own contained config placement, seeding, launch export, and cleanup
- deliver Claude OAuth credentials as `CLAUDE_CODE_OAUTH_TOKEN` only, without treating `CLAUDE_CONFIG_DIR` as credential input
- route granted agent environments through the adapter launch plan and preserve generic delivery for tool sessions
- reproduce udder with no ambient or credential-supplied `CLAUDE_CONFIG_DIR`

## Root cause

The first two fixes still treated `CLAUDE_CONFIG_DIR` as an input. On udder, the contained environment exposed only `FLOTILLA_ENVIRONMENT_ID`, so the adapter neither seeded onboarding state nor exported a config path even though a matching OAuth grant existed.

Contained adapters now derive an isolated config directory beneath the vessel workspace, seed onboarding and workspace trust there, and force that path into the launch plan alongside the granted OAuth token. Trusted Claude sessions continue to respect ambient configuration.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- targeted adapter, OAuth delivery, contained provisioning, and named missing-grant tests

Closes #1487
