### PR TITLE
fix: derive claude-oauth preflight dir from writable base

### DIFF
--- a/crates/flotilla-daemon/src/credential.rs
+++ b/crates/flotilla-daemon/src/credential.rs
@@ -555,6 +555,23 @@ impl CredentialStore {
             .unwrap_or_else(|| PathBuf::from(path))
     }
 
+    // The preflight scratch dir must keep the `claude -p` probe blind to
+    // ambient authentication (`apiKeyHelper`, stored logins) — an empty
+    // per-credential dir. The daemon runs as an unprivileged user with no
+    // systemd `RuntimeDirectory=`, so absolute `/run` is unwritable; derive
+    // the dir from a daemon-owned writable base instead: the user runtime dir
+    // when present, the daemon state dir otherwise (#1498).
+    fn claude_preflight_config_dir(&self, credential_name: &str) -> String {
+        let base = self
+            .env
+            .get("XDG_RUNTIME_DIR")
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .map(|runtime_dir| PathBuf::from(runtime_dir).join("flotilla"))
+            .unwrap_or_else(|| self.state_dir.clone());
+        base.join("credentials").join(safe_component(credential_name)).join("claude").to_string_lossy().into_owned()
+    }
+
     async fn prepare_adapter(
         &self,
         name: &str,
@@ -686,8 +703,7 @@ impl CredentialStore {
                 if !runner.exists("claude", &["--version"]).await {
                     return Err("consumer binary is unavailable".to_string());
                 }
-                let config_dir_fragment = claude_config_dir_fragment(name);
-                let config_dir = config_dir_fragment.value;
+                let config_dir = self.claude_preflight_config_dir(name);
                 if !already_prepared {
                     runner
                         .run("mkdir", &["-p", &config_dir], Path::new("/"), &ChannelLabel::Noop)
@@ -793,14 +809,6 @@ fn codex_home_fragment(credential_name: &str) -> Fragment {
         "CODEX_HOME",
         format!("/run/flotilla/credentials/{}/codex", safe_component(credential_name)),
         format!("credential/codex {credential_name}"),
-    )
-}
-
-fn claude_config_dir_fragment(credential_name: &str) -> Fragment {
-    agent_environment_fragment(
-        "CLAUDE_CONFIG_DIR",
-        format!("/run/flotilla/credentials/{}/claude", safe_component(credential_name)),
-        format!("credential/claude-oauth {credential_name}"),
     )
 }
 
@@ -1163,16 +1171,45 @@ interactions:
         );
         assert!(delivered.iter().all(|(name, _)| name != "CLAUDE_CONFIG_DIR"));
         let calls = runner.calls.lock().expect("calls lock");
-        assert!(calls.iter().any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/run/flotilla/credentials/claude-max/claude"]));
+        assert!(calls
+            .iter()
+            .any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/tmp/flotilla-test-state/credentials/claude-max/claude"]));
         assert!(calls.iter().any(|(cmd, args, input)| {
             cmd == "sh"
                 && args.iter().any(|arg| arg.contains("unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN"))
                 && args.iter().any(|arg| arg.contains("CLAUDE_CODE_OAUTH_TOKEN=\"$token\"") && arg.contains("claude -p"))
                 && args.iter().any(|arg| arg.contains("claude -p ok 2>&1") && arg.contains("printf '%s\\n' \"$output\" >&2"))
-                && args.iter().any(|arg| arg == "/run/flotilla/credentials/claude-max/claude")
+                && args.iter().any(|arg| arg == "/tmp/flotilla-test-state/credentials/claude-max/claude")
                 && input == secret.as_bytes()
         }));
         assert!(calls.iter().flat_map(|(_, args, _)| args).all(|arg| !arg.contains(secret)));
+    }
+
+    #[tokio::test]
+    async fn claude_oauth_preflight_scratch_dir_prefers_the_user_runtime_dir_over_absolute_run() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(NodeId::new("root-a"));
+        create_claude_oauth_spec(&backend, "claude-max", "ops@example.com", "TEST_CLAUDE_TOKEN").await;
+        let env = Arc::new(TestEnv(BTreeMap::from([
+            ("TEST_CLAUDE_TOKEN".to_string(), "sk-ant-oat01-test-token".to_string()),
+            ("XDG_RUNTIME_DIR".to_string(), "/run/user/1000".to_string()),
+        ])));
+        let runner = Arc::new(RecordingRunner::default());
+        let bag = EnvironmentBag::new().with(EnvironmentAssertion::binary("claude", "/usr/bin/claude"));
+        let store = CredentialStore::new(backend, "flotilla", env, bag, runner.clone(), PathBuf::from("/tmp/flotilla-test-state"));
+
+        store.prepare("env-a", &BTreeSet::from(["claude-max".to_string()]), runner.clone()).await.expect("prepare claude-oauth credential");
+
+        let calls = runner.calls.lock().expect("calls lock");
+        assert!(calls
+            .iter()
+            .any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/run/user/1000/flotilla/credentials/claude-max/claude"]));
+        assert!(calls.iter().any(|(cmd, args, _)| {
+            cmd == "sh" && args.iter().any(|arg| arg == "/run/user/1000/flotilla/credentials/claude-max/claude")
+        }));
+        assert!(
+            calls.iter().flat_map(|(_, args, _)| args).all(|arg| !arg.starts_with("/run/flotilla")),
+            "the preflight must never touch root-owned /run/flotilla on the host"
+        );
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/credential.rs
+++ b/crates/flotilla-daemon/src/credential.rs
@@ -722,7 +722,7 @@ impl CredentialStore {
                     // `apiKeyHelper`, since each of those outranks
                     // `CLAUDE_CODE_OAUTH_TOKEN` and would mask a dead token
                     // (the stored ambient login ranks below it, so it cannot).
-                    runner
+                    let probe = runner
                         .run_with_input(
                             "sh",
                             &[
@@ -749,7 +749,15 @@ impl CredentialStore {
                             } else {
                                 Err(format!("subscription token preflight failed: {error}"))
                             }
-                        })?;
+                        });
+                    // The scratch dir is only needed while the probe runs; the
+                    // persistent-base fallback would otherwise accumulate
+                    // whatever `claude -p` writes for the daemon's lifetime,
+                    // and removal guarantees the next probe starts empty.
+                    if let Err(error) = runner.run("rm", &["-rf", &config_dir], Path::new("/"), &ChannelLabel::Noop).await {
+                        tracing::warn!(credential = %name, %error, "failed to remove Claude OAuth preflight scratch directory");
+                    }
+                    probe?;
                 }
                 env.insert("CLAUDE_CODE_OAUTH_TOKEN".to_string(), material.to_string());
             }
@@ -1182,6 +1190,10 @@ interactions:
                 && args.iter().any(|arg| arg == "/tmp/flotilla-test-state/credentials/claude-max/claude")
                 && input == secret.as_bytes()
         }));
+        assert!(
+            calls.iter().any(|(cmd, args, _)| cmd == "rm" && args == &["-rf", "/tmp/flotilla-test-state/credentials/claude-max/claude"]),
+            "the preflight scratch directory must not outlive the probe"
+        );
         assert!(calls.iter().flat_map(|(_, args, _)| args).all(|arg| !arg.contains(secret)));
     }
 
@@ -1210,6 +1222,26 @@ interactions:
             calls.iter().flat_map(|(_, args, _)| args).all(|arg| !arg.starts_with("/run/flotilla")),
             "the preflight must never touch root-owned /run/flotilla on the host"
         );
+    }
+
+    #[tokio::test]
+    async fn a_blank_user_runtime_dir_falls_back_to_the_daemon_state_dir() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(NodeId::new("root-a"));
+        create_claude_oauth_spec(&backend, "claude-max", "ops@example.com", "TEST_CLAUDE_TOKEN").await;
+        let env = Arc::new(TestEnv(BTreeMap::from([
+            ("TEST_CLAUDE_TOKEN".to_string(), "sk-ant-oat01-test-token".to_string()),
+            ("XDG_RUNTIME_DIR".to_string(), "   ".to_string()),
+        ])));
+        let runner = Arc::new(RecordingRunner::default());
+        let bag = EnvironmentBag::new().with(EnvironmentAssertion::binary("claude", "/usr/bin/claude"));
+        let store = CredentialStore::new(backend, "flotilla", env, bag, runner.clone(), PathBuf::from("/tmp/flotilla-test-state"));
+
+        store.prepare("env-a", &BTreeSet::from(["claude-max".to_string()]), runner.clone()).await.expect("prepare claude-oauth credential");
+
+        let calls = runner.calls.lock().expect("calls lock");
+        assert!(calls
+            .iter()
+            .any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/tmp/flotilla-test-state/credentials/claude-max/claude"]));
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -7136,10 +7136,13 @@ mod tests {
         let workspace = temp.path().join("workspace");
         fs::create_dir_all(&workspace).expect("workspace");
         let env_id = EnvironmentId::new("contained-claude");
+        // The preflight scratch dir must derive from a daemon-owned writable
+        // base (here the state dir), never absolute /run on the host (#1498).
+        let preflight_config_dir = config.state_dir().as_path().join("credentials/claude-max/claude");
         let runner: Arc<dyn CommandRunner> = Arc::new(CredentialInteriorRunner(
             DiscoveryMockRunner::builder()
                 .tool_exists("claude", true)
-                .on_run("mkdir", &["-p", "/run/flotilla/credentials/claude-max/claude"], Ok(String::new()))
+                .on_run("mkdir", &["-p", &preflight_config_dir.to_string_lossy()], Ok(String::new()))
                 .on_run("mkdir", &["-p", "/run/flotilla/claude"], Ok(String::new()))
                 .build(),
         ));


### PR DESCRIPTION
Closes #1498.

## What happened

The `CredentialConsumer::ClaudeOauth` preflight hardcoded its isolation config dir to `/run/flotilla/credentials/<name>/claude` and `mkdir -p`'d it on the host before any container exists. `/run` is root-owned tmpfs and every fleet daemon runs as an unprivileged user, so the first contained-claude dispatch on udder failed admission-side with `mkdir: cannot create directory '/run/flotilla': Permission denied`.

## What this does

- Replaces the hardcoded fragment with `CredentialStore::claude_preflight_config_dir`, which derives the scratch dir from a daemon-owned writable base: `$XDG_RUNTIME_DIR/flotilla/credentials/<name>/claude` when `XDG_RUNTIME_DIR` is present (read through the injected `EnvVars`, never `std::env`), falling back to `<state_dir>/credentials/<name>/claude` under the daemon state dir the daemon already owns.
- Preserves the isolation property the hardcoded dir was buying: the `claude -p` probe still runs under an empty per-credential config dir, so ambient authentication (`apiKeyHelper`, stored logins) cannot mask a dead token.
- Leaves container-internal `/run/flotilla/*` paths untouched: `CONTAINED_CLAUDE_CONFIG_DIR`, the codex home constants, and the agent-environment path are unchanged, and codex staging is unaffected.

## Tests

- Updated `claude_oauth_material_is_delivered_as_an_env_token_without_owning_agent_config` to assert the state-dir fallback path.
- New `claude_oauth_preflight_scratch_dir_prefers_the_user_runtime_dir_over_absolute_run` asserts the `XDG_RUNTIME_DIR` preference and that no call touches root-owned `/run/flotilla`.
- Updated the contained-claude launch test in `runtime.rs` to register the state-dir-derived mkdir; the contained launch still exports `/run/flotilla/claude` (adapter-owned, container-internal).
- No test pre-sets `CLAUDE_CONFIG_DIR` (per the #1494 banned test shape).

`cargo +nightly-2026-03-12 fmt --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace --locked` all pass.