### PR TITLE
feat: surface credential expiry proactively as a condition

### DIFF
--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -379,6 +379,16 @@ impl AgentRequirement {
             _ => None,
         }
     }
+
+    /// Ambient-login scope this adapter falls back to when no credential is
+    /// delivered, named as it appears under the Host `credential_expiry`
+    /// capability. `None` for adapters with no ambient authentication path.
+    pub fn ambient_credential_scope(&self) -> Option<&'static str> {
+        match self.adapter.as_str() {
+            CLAUDE_CODE_ADAPTER_ID => Some(flotilla_resources::AMBIENT_CLAUDE_CREDENTIAL_SCOPE),
+            _ => None,
+        }
+    }
 }
 
 impl Default for CapabilityTable {

--- a/crates/flotilla-core/src/config.rs
+++ b/crates/flotilla-core/src/config.rs
@@ -358,6 +358,8 @@ pub struct DaemonConfig {
     #[serde(default)]
     pub admission: AdmissionConfig,
     #[serde(default)]
+    pub credentials: CredentialHealthConfig,
+    #[serde(default)]
     pub logging: DaemonLoggingConfig,
     #[serde(default)]
     pub environments: BTreeMap<String, StaticEnvironmentConfig>,
@@ -412,6 +414,25 @@ impl Default for AdmissionConfig {
     fn default() -> Self {
         Self { free_space_floor_gib: default_free_space_floor_gib() }
     }
+}
+
+/// Host-local credential health settings.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct CredentialHealthConfig {
+    /// Days before expiry at which held credential material surfaces as
+    /// near-expiry in `flotilla host list` and TUI attention.
+    #[serde(default = "default_credential_warning_window_days")]
+    pub warning_window_days: u32,
+}
+
+impl Default for CredentialHealthConfig {
+    fn default() -> Self {
+        Self { warning_window_days: default_credential_warning_window_days() }
+    }
+}
+
+const fn default_credential_warning_window_days() -> u32 {
+    7
 }
 
 const fn default_free_space_floor_gib() -> u64 {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -22,17 +22,18 @@ use flotilla_protocol::{
     commands::{AttachMode, RepositoryIdentityChange},
     qualified_path::{HostId, QualifiedPath},
     result_set::{CheckoutRow, ConvoyChangeRequest, ConvoyRow, ResultSet, Rows},
-    AttachBinding, Command, CommandAction, CommandValue, ConvoyDispatchRegard, ConvoyExplanation, CrewAttention, CrewCommandContext,
-    CrewListMember, CrewListResponse, DaemonEvent, DispatchQueueResponse, DispatchQueueRow, EnvironmentId, EvidenceFreshness,
-    ExplainedChangeRequest, ExplainedCheckout, ExplainedCondition, ExplainedCrewDelivery, ExplainedLeafFiring, ExplainedSettlement,
-    ExplainedSubscription, ExplainedUnmetExpectation, FleetHealthResponse, FleetHostRow, FleetHostStaleness, FleetListResponse,
-    FleetListRow, FleetObservationAgreement, FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListResponse, HostName,
-    HostProviderStatus, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId, NodeInfo, PeerConnectionState, PlacementDecision,
-    PlacementRefusal, PlacementTargetHost, PlacementViableCandidate, PrincipalRef, ProjectListEntry, ProjectListRepository,
-    ProjectListResponse, ProviderData, ProviderInfo, QueryCursor, RepoIdentity, RepoInfo, RepoProvidersResponse, RepoSummary,
-    ResolvedAttachAction, ResolvedAttachPlan, ResourceCursor, ResourceJsonResponse, ResourceReadEnvelope, ResourceReadRecord,
-    ResourceRecordProvenance, ResourceRecordType, ResourceRef, StatusResponse, StepStatus, StreamKey, SurfaceDeclaration, TopologyResponse,
-    TopologyRoute, ViewAddress, AGENT_ADAPTER_PROVIDER_CATEGORY, TERMINAL_POOL_PROVIDER_CATEGORY,
+    AttachBinding, Command, CommandAction, CommandValue, ConvoyDispatchRegard, ConvoyExplanation, CredentialAttention,
+    CredentialAttentionSeverity, CrewAttention, CrewCommandContext, CrewListMember, CrewListResponse, DaemonEvent, DispatchQueueResponse,
+    DispatchQueueRow, EnvironmentId, EvidenceFreshness, ExplainedChangeRequest, ExplainedCheckout, ExplainedCondition,
+    ExplainedCrewDelivery, ExplainedLeafFiring, ExplainedSettlement, ExplainedSubscription, ExplainedUnmetExpectation, FleetHealthResponse,
+    FleetHostRow, FleetHostStaleness, FleetListResponse, FleetListRow, FleetObservationAgreement, FleetReplicaSnapshot, FleetReplicaStatus,
+    FleetStaleness, HostListResponse, HostName, HostProviderStatus, HostProvidersResponse, HostStatusResponse, HostSummary, NodeId,
+    NodeInfo, PeerConnectionState, PlacementDecision, PlacementRefusal, PlacementTargetHost, PlacementViableCandidate, PrincipalRef,
+    ProjectListEntry, ProjectListRepository, ProjectListResponse, ProviderData, ProviderInfo, QueryCursor, RepoIdentity, RepoInfo,
+    RepoProvidersResponse, RepoSummary, ResolvedAttachAction, ResolvedAttachPlan, ResourceCursor, ResourceJsonResponse,
+    ResourceReadEnvelope, ResourceReadRecord, ResourceRecordProvenance, ResourceRecordType, ResourceRef, StatusResponse, StepStatus,
+    StreamKey, SurfaceDeclaration, TopologyResponse, TopologyRoute, ViewAddress, AGENT_ADAPTER_PROVIDER_CATEGORY,
+    TERMINAL_POOL_PROVIDER_CATEGORY,
 };
 use flotilla_resources::{
     api_version, apply_resource_document, apply_status_patch as apply_resource_status_patch,
@@ -867,11 +868,18 @@ fn accumulate_fleet_health_counts(counts: &mut HashMap<HostName, (usize, HashSet
     }
 }
 
-/// One attention line per expired or near-expiry credential scope on a host,
+/// One attention entry per expired or near-expiry credential scope on a host,
 /// derived from the `credential_expiry` capability its heartbeat publishes.
-fn host_credential_attention(status: &ResourceHostStatus, now: DateTime<Utc>, warning_window: chrono::Duration) -> Vec<String> {
+fn host_credential_attention(
+    status: &ResourceHostStatus,
+    now: DateTime<Utc>,
+    warning_window: chrono::Duration,
+) -> Vec<CredentialAttention> {
     let Ok(expiry) = status.credential_expiry() else {
-        return vec!["credential expiry capability is unreadable".to_string()];
+        return vec![CredentialAttention {
+            severity: CredentialAttentionSeverity::Unreadable,
+            message: "credential expiry capability is unreadable".to_string(),
+        }];
     };
     let mut attention = Vec::new();
     for (scope, entry) in expiry {
@@ -881,9 +889,15 @@ fn host_credential_attention(status: &ResourceHostStatus, now: DateTime<Utc>, wa
             format!("credential `{scope}`")
         };
         if let Some(expired_at) = entry.expired_at(now) {
-            attention.push(format!("{label} expired on {}", expired_at.format("%Y-%m-%d")));
+            attention.push(CredentialAttention {
+                severity: CredentialAttentionSeverity::Expired,
+                message: format!("{label} expired on {}", expired_at.format("%Y-%m-%d")),
+            });
         } else if let Some(expires_at) = entry.expires_within(now, warning_window) {
-            attention.push(format!("{label} expires on {}", expires_at.format("%Y-%m-%d")));
+            attention.push(CredentialAttention {
+                severity: CredentialAttentionSeverity::Expiring,
+                message: format!("{label} expires on {}", expires_at.format("%Y-%m-%d")),
+            });
         }
     }
     attention

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -44,17 +44,18 @@ use flotilla_resources::{
     watch_resource_kind_replica_sources, BoundChangeRequest, Checkout as ResourceCheckout, CheckoutIntegrationStatus,
     CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus, Clock,
     ConditionValue, Convoy as ResourceConvoy, ConvoyEnsure, ConvoyEnsureSpec, ConvoyEnsureStatusPatch, ConvoyIssue, ConvoyPhase,
-    ConvoyRepositorySpec, ConvoySpec, ConvoyStatusPatch, CredentialGrant, CredentialSpec, CrewCompletionPending, CrewSource, CrewWorkPhase,
-    Demand as ResourceDemand, Environment as ResourceEnvironment, HoldAct, Host as ResourceHost, HostDirectPlacementPolicyCheckout,
-    HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus, InMemoryBackend, InputMeta, InputValue, IntegrationCondition,
-    IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable, LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec,
-    PlacementPolicy, PlacementPolicySpec, Presentation as ResourcePresentation, Project, ProjectRepositoryRole, ProjectRepositorySpec,
-    ProjectSpec, ReadResourceObject, Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError, ResourceObject,
-    ResourceProvenance, SettlementMode, SystemClock, TerminalAttentionState, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
-    TerminalSession as ResourceTerminalSession, TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase,
-    TerminalSessionSource, TerminalSessionStatus, TerminalSessionStatusPatch, TurnDeliveryRung, UnmetSettlementExpectation, Vessel,
-    WatchEvent, WatchStart, WorkCompletionAuthority, WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec,
-    ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL, HEARTBEAT_READY_TTL_SECS, MANAGED_BY_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
+    ConvoyRepositorySpec, ConvoySpec, ConvoyStatusPatch, CredentialConsumer, CredentialGrant, CredentialSpec, CrewCompletionPending,
+    CrewSource, CrewWorkPhase, Demand as ResourceDemand, Environment as ResourceEnvironment, HoldAct, Host as ResourceHost,
+    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus, InMemoryBackend, InputMeta,
+    InputValue, IntegrationCondition, IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable, LifecycleAuthority,
+    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Presentation as ResourcePresentation,
+    Project, ProjectRepositoryRole, ProjectRepositorySpec, ProjectSpec, ReadResourceObject, Repository, RepositoryKey, RepositorySpec,
+    Resource, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance, SettlementMode, SystemClock, TerminalAttentionState,
+    TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession, TerminalSessionIdentity,
+    TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatus, TerminalSessionStatusPatch,
+    TurnDeliveryRung, UnmetSettlementExpectation, Vessel, WatchEvent, WatchStart, WorkCompletionAuthority, WorkPhase as ResourceWorkPhase,
+    WorkflowTemplate, WorkflowTemplateSpec, ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL, HEARTBEAT_READY_TTL_SECS, MANAGED_BY_LABEL,
+    ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
 use futures::{FutureExt, StreamExt};
 use sha2::{Digest, Sha256};
@@ -864,6 +865,28 @@ fn accumulate_fleet_health_counts(counts: &mut HashMap<HostName, (usize, HashSet
             convoys.insert(row.convoy.clone());
         }
     }
+}
+
+/// One attention line per expired or near-expiry credential scope on a host,
+/// derived from the `credential_expiry` capability its heartbeat publishes.
+fn host_credential_attention(status: &ResourceHostStatus, now: DateTime<Utc>, warning_window: chrono::Duration) -> Vec<String> {
+    let Ok(expiry) = status.credential_expiry() else {
+        return vec!["credential expiry capability is unreadable".to_string()];
+    };
+    let mut attention = Vec::new();
+    for (scope, entry) in expiry {
+        let label = if scope == flotilla_resources::AMBIENT_CLAUDE_CREDENTIAL_SCOPE {
+            "ambient claude login".to_string()
+        } else {
+            format!("credential `{scope}`")
+        };
+        if let Some(expired_at) = entry.expired_at(now) {
+            attention.push(format!("{label} expired on {}", expired_at.format("%Y-%m-%d")));
+        } else if let Some(expires_at) = entry.expires_within(now, warning_window) {
+            attention.push(format!("{label} expires on {}", expires_at.format("%Y-%m-%d")));
+        }
+    }
+    attention
 }
 
 fn fleet_observation_agreement(
@@ -3549,12 +3572,18 @@ async fn validate_workflow_credentials(
         .filter(|vessel| vessel.stance == flotilla_resources::Stance::Contained)
         .flat_map(|vessel| vessel.credential_refs.iter().cloned())
         .collect::<BTreeSet<_>>();
-    if required.is_empty() {
+    let ambient_dependent_vessels = ambient_credential_dependent_vessels(&capabilities, &specs, workflow)?;
+    if required.is_empty() && ambient_dependent_vessels.is_empty() {
         return Ok(());
     }
-    let placement = placement.ok_or_else(|| {
-        format!("workflow requires credential `{}`, but no placement is available", required.first().expect("required is non-empty"))
-    })?;
+    let Some(placement) = placement else {
+        if let Some(first) = required.first() {
+            return Err(format!("workflow requires credential `{first}`, but no placement is available"));
+        }
+        // Ambient-dependent vessels without a placement have no target host to
+        // check expiry against; admission proceeds as before.
+        return Ok(());
+    };
     let target_host = placement_target_host(backend, namespace, placement).await?;
     let host = backend
         .clone()
@@ -3563,22 +3592,82 @@ async fn validate_workflow_credentials(
         .await
         .map_err(|error| format!("placement `{}` target host is not ready: {error}", placement.metadata.name))?;
     let host_label = target_host.display_name;
-    let mut status =
-        host.status.ok_or_else(|| format!("placement `{}` host `{host_label}` has no observed status", placement.metadata.name))?;
+    let Some(mut status) = host.status else {
+        if required.is_empty() {
+            return Ok(());
+        }
+        return Err(format!("placement `{}` host `{host_label}` has no observed status", placement.metadata.name));
+    };
     status.apply_heartbeat_readiness(Utc::now());
-    if !status.ready {
-        return Err(format!("placement `{}` host `{host_label}` is not ready", placement.metadata.name));
+    if !required.is_empty() {
+        if !status.ready {
+            return Err(format!("placement `{}` host `{host_label}` is not ready", placement.metadata.name));
+        }
+        let held = status.held_credentials().map_err(|error| {
+            format!("placement `{}` host `{host_label}` has invalid held-credential capability: {error}", placement.metadata.name)
+        })?;
+        if let Some(missing) = required.iter().find(|credential| !held.contains(*credential)) {
+            return Err(format!(
+                "workflow requires credential `{missing}`, which placement `{}` host `{host_label}` does not hold",
+                placement.metadata.name
+            ));
+        }
     }
-    let held = status.held_credentials().map_err(|error| {
-        format!("placement `{}` host `{host_label}` has invalid held-credential capability: {error}", placement.metadata.name)
+    let expiry = status.credential_expiry().map_err(|error| {
+        format!("placement `{}` host `{host_label}` has invalid credential expiry capability: {error}", placement.metadata.name)
     })?;
-    if let Some(missing) = required.iter().find(|credential| !held.contains(*credential)) {
-        return Err(format!(
-            "workflow requires credential `{missing}`, which placement `{}` host `{host_label}` does not hold",
-            placement.metadata.name
-        ));
+    let now = Utc::now();
+    for credential in &required {
+        if let Some(expired_at) = expiry.get(credential).and_then(|entry| entry.expired_at(now)) {
+            return Err(format!(
+                "credential `{credential}` expired on host `{host_label}` on {} — refresh its material before dispatching",
+                expired_at.format("%Y-%m-%d")
+            ));
+        }
+    }
+    for (vessel, scope) in &ambient_dependent_vessels {
+        if let Some(expired_at) = expiry.get(*scope).and_then(|entry| entry.expired_at(now)) {
+            return Err(format!(
+                "vessel `{vessel}` depends on the ambient claude login on host `{host_label}`, which expired on {} — \
+                 log in again on that host or grant a delivered claude credential",
+                expired_at.format("%Y-%m-%d")
+            ));
+        }
     }
     Ok(())
+}
+
+/// Vessels whose agent crews will authenticate through a host's ambient login
+/// rather than delivered material: non-contained vessels with a crew on an
+/// ambient-capable adapter and no granted credential covering that adapter's
+/// delivery slot. Returns `(vessel name, ambient scope)` pairs, the scope
+/// being the entry name under the Host `credential_expiry` capability.
+fn ambient_credential_dependent_vessels<'workflow>(
+    capabilities: &CapabilityTable,
+    specs: &BTreeMap<String, CredentialConsumer>,
+    workflow: &'workflow WorkflowTemplateSpec,
+) -> Result<Vec<(&'workflow str, &'static str)>, String> {
+    let mut vessels = Vec::new();
+    for vessel in workflow.vessels.iter().filter(|vessel| vessel.stance != flotilla_resources::Stance::Contained) {
+        for crew in &vessel.crew {
+            let CrewSource::Agent { selector, .. } = &crew.source else {
+                continue;
+            };
+            let requirement = capabilities.resolve_selector(selector)?;
+            let Some(scope) = requirement.ambient_credential_scope() else {
+                continue;
+            };
+            let delivery_slot = requirement.contained_credential_delivery_slot();
+            let has_delivered_credential = delivery_slot.is_some_and(|slot| {
+                vessel.credential_refs.iter().any(|name| specs.get(name).is_some_and(|consumer| consumer.delivery_slot() == slot))
+            });
+            if !has_delivered_credential {
+                vessels.push((vessel.name.as_str(), scope));
+                break;
+            }
+        }
+    }
+    Ok(vessels)
 }
 
 /// Write dispatch-time agent choices into the workflow spec that is about to
@@ -5825,6 +5914,8 @@ impl InProcessDaemon {
             accumulate_fleet_health_counts(&mut counts, &entry.rows);
         }
 
+        let warning_window_days = self.config.load_daemon_config().unwrap_or_default().credentials.warning_window_days;
+        let credential_warning_window = chrono::Duration::days(i64::from(warning_window_days));
         let mut rows = Vec::with_capacity(host_rows.len());
         for (host, (is_local, configured, link)) in host_rows {
             let status = statuses.get(&host);
@@ -5861,6 +5952,8 @@ impl InProcessDaemon {
                 .filter(|condition| condition.value == ConditionValue::False)
                 .map(|condition| format!("{}: {}", condition.condition_type, condition.message))
                 .collect();
+            let credential_attention =
+                status.map(|status| host_credential_attention(status, now, credential_warning_window)).unwrap_or_default();
 
             rows.push(
                 FleetHostRow::builder()
@@ -5883,6 +5976,7 @@ impl InProcessDaemon {
                     .staleness(staleness)
                     .observation_agreement(observation_agreement)
                     .degraded_conditions(degraded_conditions)
+                    .credential_attention(credential_attention)
                     .build(),
             );
         }

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use flotilla_resources::{
-    CredentialConsumer, CredentialGrant, CredentialGrantSelector, CredentialGrantSpec, CredentialLifecycle,
+    CredentialConsumer, CredentialExpiry, CredentialGrant, CredentialGrantSelector, CredentialGrantSpec, CredentialLifecycle,
     CredentialPlacementRequirements, CredentialSource, CredentialSpec, CredentialSpecSpec, CrewSource, CrewSpec, CrewWorkPhase,
     Environment as ResourceEnvironment, EnvironmentSpec as ResourceEnvironmentSpec, HostDirectEnvironmentSpec,
     HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, PlacementPolicy, PlacementPolicySpec, Selector,
@@ -472,4 +472,116 @@ async fn contained_claude_requires_and_accepts_a_project_selected_oauth_grant() 
     validate_workflow_credentials(&backend, "flotilla", &with_grant, Some(&placement))
         .await
         .expect("matching held OAuth grant admits contained Claude");
+}
+
+async fn set_host_credential_expiry(backend: &ResourceBackend, host_ref: &str, expiry: BTreeMap<String, CredentialExpiry>) {
+    let hosts = backend.clone().using::<ResourceHost>("flotilla");
+    let host = hosts.get(host_ref).await.expect("host resource");
+    let mut status = host.status.expect("host status");
+    status.capabilities.insert(flotilla_resources::CREDENTIAL_EXPIRY_CAPABILITY.to_string(), serde_json::json!(expiry));
+    hosts.update_status(host_ref, &host.metadata.resource_version, &status).await.expect("update host status");
+}
+
+#[tokio::test]
+async fn dispatch_against_an_expired_credential_is_refused_with_the_credential_and_host_named() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(NodeId::new("root-a"));
+    backend
+        .clone()
+        .definitions::<CredentialSpec>("flotilla")
+        .create(&test_meta("claude-max"), &CredentialSpecSpec {
+            consumer: CredentialConsumer::ClaudeOauth { account_email: "ops@example.com".to_string() },
+            source: CredentialSource::Env { name: "CLAUDE_MAX_TOKEN".to_string() },
+            lifecycle: CredentialLifecycle::Static,
+            placement: CredentialPlacementRequirements::default(),
+        })
+        .await
+        .expect("create Claude credential declaration");
+    let mut workflow = WorkflowTemplateSpec::builder()
+        .vessels(vec![VesselRequirement::builder()
+            .name("work".to_string())
+            .stance(Stance::Contained)
+            .crew(vec![CrewSpec::builder()
+                .role("coder".to_string())
+                .source(CrewSource::Agent {
+                    selector: Selector { capability: "code".to_string(), adapter: Some("claude-code".to_string()), model: None },
+                    prompt: None,
+                    brief_template: None,
+                })
+                .build()])
+            .build()])
+        .build();
+    workflow.vessels[0].credential_refs = BTreeSet::from(["claude-max".to_string()]);
+    create_docker_placement(&backend, "docker-claude", "host-a", BTreeSet::from(["claude-max".to_string()])).await;
+    let placement = backend.using::<PlacementPolicy>("flotilla").get("docker-claude").await.expect("get placement");
+
+    let near_expiry = CredentialExpiry::builder().refresh_expires_at(Utc::now() + chrono::Duration::days(3)).build();
+    set_host_credential_expiry(&backend, "host-a", BTreeMap::from([("claude-max".to_string(), near_expiry)])).await;
+    validate_workflow_credentials(&backend, "flotilla", &workflow, Some(&placement))
+        .await
+        .expect("near-expiry material still admits dispatch");
+
+    let expired = CredentialExpiry::builder()
+        .expires_at("2020-01-01T00:00:00Z".parse().expect("timestamp"))
+        .refresh_expires_at("2020-02-01T00:00:00Z".parse().expect("timestamp"))
+        .build();
+    set_host_credential_expiry(&backend, "host-a", BTreeMap::from([("claude-max".to_string(), expired)])).await;
+    let error = validate_workflow_credentials(&backend, "flotilla", &workflow, Some(&placement))
+        .await
+        .expect_err("expired credential must refuse dispatch");
+    assert_eq!(error, "credential `claude-max` expired on host `host-a` on 2020-02-01 — refresh its material before dispatching");
+}
+
+#[tokio::test]
+async fn dispatch_of_an_ambient_claude_crew_is_refused_when_the_host_login_expired() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(NodeId::new("root-a"));
+    let workflow = WorkflowTemplateSpec::builder()
+        .vessels(vec![VesselRequirement::builder()
+            .name("work".to_string())
+            .stance(Stance::Trusted)
+            .crew(vec![CrewSpec::builder()
+                .role("shepherd".to_string())
+                .source(CrewSource::Agent {
+                    selector: Selector { capability: "review".to_string(), adapter: None, model: None },
+                    prompt: None,
+                    brief_template: None,
+                })
+                .build()])
+            .build()])
+        .build();
+    create_docker_placement(&backend, "host-direct-feta", "feta", BTreeSet::new()).await;
+    let placement = backend.using::<PlacementPolicy>("flotilla").get("host-direct-feta").await.expect("get placement");
+
+    validate_workflow_credentials(&backend, "flotilla", &workflow, Some(&placement))
+        .await
+        .expect("a host without expiry metadata admits ambient claude crews");
+
+    let refreshable = CredentialExpiry::builder()
+        .expires_at(Utc::now() - chrono::Duration::hours(1))
+        .refresh_expires_at(Utc::now() + chrono::Duration::days(30))
+        .build();
+    set_host_credential_expiry(
+        &backend,
+        "feta",
+        BTreeMap::from([(flotilla_resources::AMBIENT_CLAUDE_CREDENTIAL_SCOPE.to_string(), refreshable)]),
+    )
+    .await;
+    validate_workflow_credentials(&backend, "flotilla", &workflow, Some(&placement))
+        .await
+        .expect("a live refresh chain admits ambient claude crews");
+
+    let expired = CredentialExpiry::builder().refresh_expires_at("2026-07-30T00:00:00Z".parse().expect("timestamp")).build();
+    set_host_credential_expiry(
+        &backend,
+        "feta",
+        BTreeMap::from([(flotilla_resources::AMBIENT_CLAUDE_CREDENTIAL_SCOPE.to_string(), expired)]),
+    )
+    .await;
+    let error = validate_workflow_credentials(&backend, "flotilla", &workflow, Some(&placement))
+        .await
+        .expect_err("expired ambient login must refuse dispatch");
+    assert_eq!(
+        error,
+        "vessel `work` depends on the ambient claude login on host `feta`, which expired on 2026-07-30 — \
+         log in again on that host or grant a delivered claude credential"
+    );
 }

--- a/crates/flotilla-daemon/src/credential.rs
+++ b/crates/flotilla-daemon/src/credential.rs
@@ -5,13 +5,14 @@ use std::{
     sync::Arc,
 };
 
+use chrono::{DateTime, Utc};
 use flotilla_core::providers::{
     discovery::{EnvVars, EnvironmentBag},
     ChannelLabel, CommandRunner, HttpClient, ReqwestHttpClient,
 };
 use flotilla_resources::{
-    CredentialConsumer, CredentialLifecycle, CredentialSource, CredentialSpec, CredentialSpecSpec, Repository, RepositoryKey,
-    ResourceBackend, ResourceError,
+    CredentialConsumer, CredentialExpiry, CredentialLifecycle, CredentialSource, CredentialSpec, CredentialSpecSpec, Repository,
+    RepositoryKey, ResourceBackend, ResourceError, AMBIENT_CLAUDE_CREDENTIAL_SCOPE,
 };
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use serde::{Deserialize, Serialize};
@@ -37,6 +38,23 @@ struct GithubAppTokenRequest {
 #[derive(Deserialize)]
 struct GithubAppTokenResponse {
     token: String,
+}
+
+/// Metadata-only view of the ambient claude credentials file. Deliberately
+/// captures nothing but expiry timestamps — the token fields never
+/// deserialize into daemon memory.
+#[derive(Deserialize)]
+struct AmbientClaudeCredentialsMetadata {
+    #[serde(rename = "claudeAiOauth")]
+    claude_ai_oauth: Option<AmbientClaudeOauthMetadata>,
+}
+
+#[derive(Deserialize)]
+struct AmbientClaudeOauthMetadata {
+    #[serde(rename = "expiresAt")]
+    expires_at: Option<i64>,
+    #[serde(rename = "refreshTokenExpiresAt")]
+    refresh_token_expires_at: Option<i64>,
 }
 
 pub(crate) struct CredentialStore {
@@ -188,6 +206,41 @@ impl CredentialStore {
             }
         }
         Ok(held)
+    }
+
+    /// Expiry metadata for held material, keyed by scope name. Timestamps
+    /// only — material is never read into the result. Declared
+    /// `CredentialSpec`s contribute here once an adapter can express expiry
+    /// without touching material; today none of the declared sources carry
+    /// such metadata, so the map holds only the ambient claude login.
+    pub(crate) async fn credential_expiry(&self) -> BTreeMap<String, CredentialExpiry> {
+        let mut expiry = BTreeMap::new();
+        if let Some(ambient) = self.ambient_claude_expiry().await {
+            expiry.insert(AMBIENT_CLAUDE_CREDENTIAL_SCOPE.to_string(), ambient);
+        }
+        expiry
+    }
+
+    async fn ambient_claude_expiry(&self) -> Option<CredentialExpiry> {
+        let path = match self.env.get("CLAUDE_CONFIG_DIR").filter(|dir| !dir.trim().is_empty()) {
+            Some(dir) => PathBuf::from(dir).join(".credentials.json"),
+            None => self.expand_path("~/.claude/.credentials.json"),
+        };
+        let contents = tokio::fs::read(&path).await.ok()?;
+        let metadata: AmbientClaudeCredentialsMetadata = match serde_json::from_slice(&contents) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                tracing::debug!(path = %path.display(), line = error.line(), "ambient claude credentials file is not readable as JSON");
+                return None;
+            }
+        };
+        let oauth = metadata.claude_ai_oauth?;
+        let expires_at = oauth.expires_at.and_then(epoch_to_datetime);
+        let refresh_expires_at = oauth.refresh_token_expires_at.and_then(epoch_to_datetime);
+        if expires_at.is_none() && refresh_expires_at.is_none() {
+            return None;
+        }
+        Some(CredentialExpiry::builder().maybe_expires_at(expires_at).maybe_refresh_expires_at(refresh_expires_at).build())
     }
 
     #[cfg(test)]
@@ -825,6 +878,17 @@ async fn remove_registry_config(path: &Path) -> Result<(), std::io::Error> {
     }
 }
 
+/// The claude CLI writes millisecond epochs; treat implausibly-large
+/// second values as milliseconds so either unit decodes to the same instant.
+fn epoch_to_datetime(value: i64) -> Option<DateTime<Utc>> {
+    const MILLISECOND_THRESHOLD: i64 = 100_000_000_000;
+    if value.abs() >= MILLISECOND_THRESHOLD {
+        DateTime::from_timestamp_millis(value)
+    } else {
+        DateTime::from_timestamp(value, 0)
+    }
+}
+
 fn sanitize_curl_config(value: &str) -> String {
     value.replace(['\\', '"', '\r', '\n'], "")
 }
@@ -939,6 +1003,71 @@ mod tests {
     fn registry_matching_does_not_confuse_prefixes() {
         assert!(image_registry_matches("forgejo.lab/org/image:tag", "forgejo.lab"));
         assert!(!image_registry_matches("forgejo.lab.evil/org/image:tag", "forgejo.lab"));
+    }
+
+    fn store_with_env(env: BTreeMap<String, String>) -> CredentialStore {
+        CredentialStore::new(
+            ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(NodeId::new("root-a")),
+            "flotilla",
+            Arc::new(TestEnv(env)),
+            EnvironmentBag::new(),
+            Arc::new(RecordingRunner::default()),
+            PathBuf::from("/tmp/flotilla-test-state"),
+        )
+    }
+
+    #[tokio::test]
+    async fn ambient_claude_expiry_probe_reports_timestamps_and_never_material() {
+        let home = tempfile::tempdir().expect("home dir");
+        let claude_dir = home.path().join(".claude");
+        tokio::fs::create_dir_all(&claude_dir).await.expect("create claude dir");
+        let expires_at_ms: i64 = 1_756_000_000_000;
+        let refresh_expires_at_secs: i64 = 1_753_000_000;
+        let credentials = format!(
+            r#"{{"claudeAiOauth":{{"accessToken":"sk-ant-oat01-material","refreshToken":"sk-ant-ort01-material","expiresAt":{expires_at_ms},"refreshTokenExpiresAt":{refresh_expires_at_secs},"scopes":["user:inference"],"subscriptionType":"max"}}}}"#
+        );
+        tokio::fs::write(claude_dir.join(".credentials.json"), &credentials).await.expect("write credentials file");
+        let store = store_with_env(BTreeMap::from([("HOME".to_string(), home.path().to_string_lossy().into_owned())]));
+
+        let expiry = store.credential_expiry().await;
+
+        let ambient = expiry.get(AMBIENT_CLAUDE_CREDENTIAL_SCOPE).expect("ambient claude entry");
+        assert_eq!(ambient.expires_at, DateTime::from_timestamp_millis(expires_at_ms));
+        assert_eq!(ambient.refresh_expires_at, DateTime::from_timestamp(refresh_expires_at_secs, 0));
+        let encoded = serde_json::to_string(&expiry).expect("serialize expiry map");
+        assert!(!encoded.contains("material") && !encoded.contains("sk-ant"), "material leaked into expiry metadata: {encoded}");
+    }
+
+    #[tokio::test]
+    async fn ambient_claude_expiry_probe_prefers_the_configured_claude_dir() {
+        let config_dir = tempfile::tempdir().expect("config dir");
+        tokio::fs::write(config_dir.path().join(".credentials.json"), r#"{"claudeAiOauth":{"expiresAt":1756000000000}}"#)
+            .await
+            .expect("write credentials file");
+        let store = store_with_env(BTreeMap::from([("CLAUDE_CONFIG_DIR".to_string(), config_dir.path().to_string_lossy().into_owned())]));
+
+        let expiry = store.credential_expiry().await;
+
+        let ambient = expiry.get(AMBIENT_CLAUDE_CREDENTIAL_SCOPE).expect("ambient claude entry");
+        assert_eq!(ambient.expires_at, DateTime::from_timestamp_millis(1_756_000_000_000));
+        assert_eq!(ambient.refresh_expires_at, None);
+    }
+
+    #[tokio::test]
+    async fn ambient_claude_expiry_probe_is_silent_without_a_login_or_metadata() {
+        let home = tempfile::tempdir().expect("home dir");
+        let store = store_with_env(BTreeMap::from([("HOME".to_string(), home.path().to_string_lossy().into_owned())]));
+        assert_eq!(store.credential_expiry().await, BTreeMap::new());
+
+        let claude_dir = home.path().join(".claude");
+        tokio::fs::create_dir_all(&claude_dir).await.expect("create claude dir");
+        tokio::fs::write(claude_dir.join(".credentials.json"), r#"{"claudeAiOauth":{"accessToken":"sk-ant-oat01-material"}}"#)
+            .await
+            .expect("write credentials file");
+        assert_eq!(store.credential_expiry().await, BTreeMap::new());
+
+        tokio::fs::write(claude_dir.join(".credentials.json"), "not json").await.expect("write malformed file");
+        assert_eq!(store.credential_expiry().await, BTreeMap::new());
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -38,13 +38,13 @@ use flotilla_protocol::{EnvironmentId, HostSummary, ImageId, NodeId, Rows, Termi
 use flotilla_resources::{
     canonicalize_repo_url, clone_key, controller::ControllerLoop, descriptive_repo_slug, ChangeRequest, ChangeRequestStatus, Checkout,
     CheckoutBranchProvenance, CheckoutIntegrationStatus, Clone, CloneSpec, ConditionValue, Convoy, ConvoyReconciler, ConvoyTeardownRuntime,
-    CrewSource, CrewSpec, Demand, DemandKind, DemandSpec, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Environment,
-    EnvironmentSpec, EnvironmentWaitReason, ForgeIdentity, Host, HostCondition, HostDirectEnvironmentSpec,
+    CredentialExpiry, CrewSource, CrewSpec, Demand, DemandKind, DemandSpec, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec,
+    Environment, EnvironmentSpec, EnvironmentWaitReason, ForgeIdentity, Host, HostCondition, HostDirectEnvironmentSpec,
     HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputDefinition, InputMeta,
     PlacementPolicySpec, Presentation, Project, Regard, ReplicaReadResolver, ReplicationClass, Repository, Resource, ResourceBackend,
     ResourceError, ResourceObject, Stance, TerminalSession, TerminalSessionSource, Vessel, VesselRequirement, WorkflowTemplate,
-    WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY, CREDENTIAL_REFS_ENV, CREDENTIAL_REF_SESSION_TAG, CREDENTIAL_SCOPES_ENV,
-    CREDENTIAL_SCOPES_SESSION_TAG, HELD_CREDENTIALS_CAPABILITY, MANAGED_BY_LABEL, REGISTERED_RESOURCE_KINDS,
+    WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY, CREDENTIAL_EXPIRY_CAPABILITY, CREDENTIAL_REFS_ENV, CREDENTIAL_REF_SESSION_TAG,
+    CREDENTIAL_SCOPES_ENV, CREDENTIAL_SCOPES_SESSION_TAG, HELD_CREDENTIALS_CAPABILITY, MANAGED_BY_LABEL, REGISTERED_RESOURCE_KINDS,
     SLEEP_INHIBITION_CONDITION_TYPE,
 };
 use serde_json::json;
@@ -1233,9 +1233,9 @@ async fn apply_host_heartbeat_with_credentials(
             "resource event log tripwire triggered",
         );
     }
-    let held_credentials = match credential_store {
-        Some(store) => store.held_credentials().await?,
-        None => BTreeSet::new(),
+    let (held_credentials, credential_expiry) = match credential_store {
+        Some(store) => (store.held_credentials().await?, store.credential_expiry().await),
+        None => (BTreeSet::new(), BTreeMap::new()),
     };
     let disk_free_bytes = daemon.admission_free_space_bytes().await?;
     let admission_free_space_floor_bytes = daemon.admission_free_space_floor_bytes()?;
@@ -1258,7 +1258,7 @@ async fn apply_host_heartbeat_with_credentials(
         conditions.push(condition.clone());
     }
     let status = HostStatus {
-        capabilities: host_capabilities(&summary, profile, &held_credentials),
+        capabilities: host_capabilities(&summary, profile, &held_credentials, &credential_expiry),
         agent_adapter_baseline: Some(adapter_assessment.baseline),
         heartbeat_at: Some(Utc::now()),
         ready: conditions.is_empty(),
@@ -1422,10 +1422,12 @@ fn host_capabilities(
     _summary: &HostSummary,
     profile: &LocalProvisioningProfile,
     held_credentials: &BTreeSet<String>,
+    credential_expiry: &BTreeMap<String, CredentialExpiry>,
 ) -> BTreeMap<String, serde_json::Value> {
     BTreeMap::from([
         (AGENT_ADAPTERS_CAPABILITY.to_string(), json!(profile.available_agent_adapters)),
         (HELD_CREDENTIALS_CAPABILITY.to_string(), json!(held_credentials)),
+        (CREDENTIAL_EXPIRY_CAPABILITY.to_string(), json!(credential_expiry)),
         ("docker".to_string(), json!(profile.docker_available)),
         ("terminal_pools".to_string(), json!(profile.available_pools)),
     ])
@@ -5689,6 +5691,86 @@ mod tests {
             available_agent_adapters: BTreeSet::new(),
             docker_available,
         }
+    }
+
+    #[tokio::test]
+    async fn heartbeat_publishes_ambient_claude_expiry_metadata_without_material() {
+        let temp = TempDir::new().expect("tempdir");
+        let home = temp.path().join("home");
+        std::fs::create_dir_all(home.join(".claude")).expect("create claude dir");
+        std::fs::write(
+            home.join(".claude/.credentials.json"),
+            r#"{"claudeAiOauth":{"accessToken":"sk-ant-oat01-material","refreshToken":"sk-ant-ort01-material","expiresAt":1753000000000,"refreshTokenExpiresAt":1753900000000}}"#,
+        )
+        .expect("write ambient credentials");
+        let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+        let daemon = in_memory_daemon(Vec::new(), Arc::clone(&config)).await;
+        let host_id = daemon.local_host_id().expect("local host id").to_string();
+        let credential_store = CredentialStore::new(
+            daemon.resource_backend(),
+            NAMESPACE,
+            Arc::new(TestEnvVars::new([("HOME", home.display().to_string())])),
+            EnvironmentBag::new(),
+            Arc::new(ProcessCommandRunner),
+            config.state_dir().as_path().to_path_buf(),
+        );
+
+        apply_host_heartbeat_with_credentials(
+            &daemon,
+            NAMESPACE,
+            &manual_profile(&host_id, false),
+            Some(&credential_store),
+            &test_health_identity(),
+            &RuntimeHealth::default(),
+        )
+        .await
+        .expect("publish heartbeat");
+
+        let host = daemon.resource_backend().using::<Host>(NAMESPACE).get(&host_id).await.expect("host resource");
+        let status = host.status.expect("host status");
+        let expiry = status.credential_expiry().expect("decode credential expiry capability");
+        let ambient = expiry.get(flotilla_resources::AMBIENT_CLAUDE_CREDENTIAL_SCOPE).expect("ambient claude entry");
+        assert_eq!(ambient.expires_at, chrono::DateTime::from_timestamp_millis(1_753_000_000_000));
+        assert_eq!(ambient.refresh_expires_at, chrono::DateTime::from_timestamp_millis(1_753_900_000_000));
+        let encoded = serde_json::to_string(&status).expect("serialize host status");
+        assert!(!encoded.contains("sk-ant"), "credential material leaked into host status: {encoded}");
+    }
+
+    #[tokio::test]
+    async fn fleet_health_surfaces_an_expired_ambient_claude_login_without_any_crew_dispatched() {
+        let temp = TempDir::new().expect("tempdir");
+        let home = temp.path().join("home");
+        std::fs::create_dir_all(home.join(".claude")).expect("create claude dir");
+        std::fs::write(
+            home.join(".claude/.credentials.json"),
+            r#"{"claudeAiOauth":{"accessToken":"sk-ant-oat01-material","expiresAt":1577836800000,"refreshTokenExpiresAt":1580515200000}}"#,
+        )
+        .expect("write expired ambient credentials");
+        let config = Arc::new(ConfigStore::with_base(temp.path().join("config")));
+        let daemon = in_memory_daemon(Vec::new(), Arc::clone(&config)).await;
+        let host_id = daemon.local_host_id().expect("local host id").to_string();
+        let credential_store = CredentialStore::new(
+            daemon.resource_backend(),
+            NAMESPACE,
+            Arc::new(TestEnvVars::new([("HOME", home.display().to_string())])),
+            EnvironmentBag::new(),
+            Arc::new(ProcessCommandRunner),
+            config.state_dir().as_path().to_path_buf(),
+        );
+        apply_host_heartbeat_with_credentials(
+            &daemon,
+            NAMESPACE,
+            &manual_profile(&host_id, false),
+            Some(&credential_store),
+            &test_health_identity(),
+            &RuntimeHealth::default(),
+        )
+        .await
+        .expect("publish heartbeat");
+
+        let health = daemon.fleet_health_internal().await.expect("fleet health");
+        let local = health.hosts.iter().find(|host| host.is_local).expect("local fleet row");
+        assert_eq!(local.credential_attention, vec!["ambient claude login expired on 2020-02-01".to_string()]);
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -5770,7 +5770,10 @@ mod tests {
 
         let health = daemon.fleet_health_internal().await.expect("fleet health");
         let local = health.hosts.iter().find(|host| host.is_local).expect("local fleet row");
-        assert_eq!(local.credential_attention, vec!["ambient claude login expired on 2020-02-01".to_string()]);
+        assert_eq!(local.credential_attention, vec![flotilla_protocol::CredentialAttention {
+            severity: flotilla_protocol::CredentialAttentionSeverity::Expired,
+            message: "ambient claude login expired on 2020-02-01".to_string(),
+        }]);
     }
 
     #[tokio::test]

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -127,11 +127,12 @@ pub use provider_data::{
     WorkingTreeStatus, Workspace,
 };
 pub use query::{
-    CrewAttention, CrewCommandContext, CrewListMember, CrewListResponse, DiscoveryEntry, DispatchQueueResponse, DispatchQueueRow,
-    FleetHealthResponse, FleetHostRow, FleetHostStaleness, FleetListResponse, FleetListRow, FleetObservationAgreement,
-    FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListEntry, HostListResponse, HostProvidersResponse, HostStatusResponse,
-    PeerReconnectStatus, ProjectListEntry, ProjectListRepository, ProjectListResponse, ProviderHealthMap, ProviderInfo,
-    RepoProvidersResponse, RepoSummary, SleepInhibitionHealth, StatusResponse, TopologyResponse, TopologyRoute, UnmetRequirementInfo,
+    CredentialAttention, CredentialAttentionSeverity, CrewAttention, CrewCommandContext, CrewListMember, CrewListResponse, DiscoveryEntry,
+    DispatchQueueResponse, DispatchQueueRow, FleetHealthResponse, FleetHostRow, FleetHostStaleness, FleetListResponse, FleetListRow,
+    FleetObservationAgreement, FleetReplicaSnapshot, FleetReplicaStatus, FleetStaleness, HostListEntry, HostListResponse,
+    HostProvidersResponse, HostStatusResponse, PeerReconnectStatus, ProjectListEntry, ProjectListRepository, ProjectListResponse,
+    ProviderHealthMap, ProviderInfo, RepoProvidersResponse, RepoSummary, SleepInhibitionHealth, StatusResponse, TopologyResponse,
+    TopologyRoute, UnmetRequirementInfo,
 };
 pub use repository::{RepositoryRelation, RepositoryUpstream};
 pub use resource_ref::ResourceRef;

--- a/crates/flotilla-protocol/src/query.rs
+++ b/crates/flotilla-protocol/src/query.rs
@@ -268,6 +268,11 @@ pub struct FleetHostRow {
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub degraded_conditions: Vec<String>,
+    /// Expired or near-expiry credential material on this host, one line per
+    /// affected scope ("ambient claude login expired on 2026-07-30").
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub credential_attention: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/flotilla-protocol/src/query.rs
+++ b/crates/flotilla-protocol/src/query.rs
@@ -268,11 +268,28 @@ pub struct FleetHostRow {
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub degraded_conditions: Vec<String>,
-    /// Expired or near-expiry credential material on this host, one line per
+    /// Expired or near-expiry credential material on this host, one entry per
     /// affected scope ("ambient claude login expired on 2026-07-30").
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub credential_attention: Vec<String>,
+    pub credential_attention: Vec<CredentialAttention>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CredentialAttention {
+    pub severity: CredentialAttentionSeverity,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CredentialAttentionSeverity {
+    /// Material is past its effective expiry; dependent dispatch is refused.
+    Expired,
+    /// Material expires within the host's warning window.
+    Expiring,
+    /// The published expiry capability could not be decoded.
+    Unreadable,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/flotilla-resources/src/host.rs
+++ b/crates/flotilla-resources/src/host.rs
@@ -12,6 +12,11 @@ define_resource!(Host, "hosts", HostSpec, HostStatus, HostStatusPatch, replicati
 
 pub const AGENT_ADAPTERS_CAPABILITY: &str = "agent_adapters";
 pub const HELD_CREDENTIALS_CAPABILITY: &str = "held_credentials";
+pub const CREDENTIAL_EXPIRY_CAPABILITY: &str = "credential_expiry";
+/// Scope name under [`CREDENTIAL_EXPIRY_CAPABILITY`] for the host's ambient
+/// claude login (the credentials file a `claude login` leaves behind), which
+/// is held material without a `CredentialSpec` declaring it.
+pub const AMBIENT_CLAUDE_CREDENTIAL_SCOPE: &str = "ambient:claude";
 pub const TERMINAL_POOLS_CAPABILITY: &str = "terminal_pools";
 pub const HEARTBEAT_READY_TTL_SECS: i64 = 60;
 pub const SLEEP_INHIBITION_CONDITION_TYPE: &str = "SleepInhibition";
@@ -65,6 +70,14 @@ impl HostStatus {
         self.capabilities.get(HELD_CREDENTIALS_CAPABILITY).cloned().map(serde_json::from_value).transpose().map(Option::unwrap_or_default)
     }
 
+    /// Expiry metadata for held credential material, keyed by scope name —
+    /// [`AMBIENT_CLAUDE_CREDENTIAL_SCOPE`] for the ambient claude login, a
+    /// `CredentialSpec` name for declared credentials whose adapter can
+    /// express expiry. Timestamps only; never material.
+    pub fn credential_expiry(&self) -> Result<BTreeMap<String, CredentialExpiry>, serde_json::Error> {
+        self.capabilities.get(CREDENTIAL_EXPIRY_CAPABILITY).cloned().map(serde_json::from_value).transpose().map(Option::unwrap_or_default)
+    }
+
     pub fn apply_heartbeat_readiness(&mut self, now: DateTime<Utc>) {
         self.ready = self.ready
             && !self.is_degraded()
@@ -91,6 +104,43 @@ pub struct HostCondition {
     pub reason: String,
     pub message: String,
     pub observed_at: DateTime<Utc>,
+}
+
+/// Expiry metadata observed for one piece of held credential material.
+///
+/// Published under [`CREDENTIAL_EXPIRY_CAPABILITY`] in the same capability
+/// family as `held_credentials`. Carries timestamps and nothing else — the
+/// probe that produces it must never read tokens into these fields.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+pub struct CredentialExpiry {
+    /// When the primary material (e.g. an access token) expires.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<DateTime<Utc>>,
+    /// When the refresh chain dies, where the material is refreshable. While
+    /// this is in the future the primary material can be renewed, so it — not
+    /// `expires_at` — bounds the credential's usable life.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refresh_expires_at: Option<DateTime<Utc>>,
+}
+
+impl CredentialExpiry {
+    /// The latest point the material can still authenticate: the refresh
+    /// chain's expiry where one exists, otherwise the primary expiry. `None`
+    /// means no expiry metadata was observed.
+    pub fn effective_expires_at(&self) -> Option<DateTime<Utc>> {
+        self.refresh_expires_at.max(self.expires_at)
+    }
+
+    /// The expiry timestamp, if the material is expired at `now`.
+    pub fn expired_at(&self, now: DateTime<Utc>) -> Option<DateTime<Utc>> {
+        self.effective_expires_at().filter(|expires_at| *expires_at <= now)
+    }
+
+    /// The expiry timestamp, if the material is unexpired at `now` but
+    /// expires within `window`.
+    pub fn expires_within(&self, now: DateTime<Utc>, window: chrono::Duration) -> Option<DateTime<Utc>> {
+        self.effective_expires_at().filter(|expires_at| *expires_at > now && *expires_at <= now + window)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -183,5 +233,51 @@ mod tests {
         assert!(!status.ready);
         let encoded = serde_json::to_value(&status).expect("serialize host status");
         assert_eq!(encoded["conditions"][0]["type"], "Controller/checkout");
+    }
+
+    #[test]
+    fn credential_expiry_round_trips_through_the_capability_family() {
+        let expires_at = Utc::now();
+        let refresh_expires_at = expires_at + chrono::Duration::days(30);
+        let expiry = CredentialExpiry::builder().expires_at(expires_at).refresh_expires_at(refresh_expires_at).build();
+        let status = HostStatus {
+            capabilities: BTreeMap::from([(
+                CREDENTIAL_EXPIRY_CAPABILITY.to_string(),
+                serde_json::json!({ AMBIENT_CLAUDE_CREDENTIAL_SCOPE: expiry }),
+            )]),
+            ..HostStatus::default()
+        };
+
+        let decoded = status.credential_expiry().expect("decode credential expiry");
+        assert_eq!(decoded, BTreeMap::from([(AMBIENT_CLAUDE_CREDENTIAL_SCOPE.to_string(), expiry)]));
+        assert_eq!(HostStatus::default().credential_expiry().expect("absent capability decodes"), BTreeMap::new());
+    }
+
+    #[test]
+    fn credential_expiry_is_bounded_by_the_refresh_chain_where_one_exists() {
+        let now = Utc::now();
+        let window = chrono::Duration::days(7);
+        let refreshable = CredentialExpiry::builder()
+            .expires_at(now - chrono::Duration::hours(1))
+            .refresh_expires_at(now + chrono::Duration::days(3))
+            .build();
+        assert_eq!(refreshable.effective_expires_at(), refreshable.refresh_expires_at);
+        assert_eq!(refreshable.expired_at(now), None);
+        assert_eq!(refreshable.expires_within(now, window), refreshable.refresh_expires_at);
+
+        let dead = CredentialExpiry::builder()
+            .expires_at(now - chrono::Duration::days(20))
+            .refresh_expires_at(now - chrono::Duration::days(15))
+            .build();
+        assert_eq!(dead.expired_at(now), dead.refresh_expires_at);
+        assert_eq!(dead.expires_within(now, window), None);
+
+        let access_only = CredentialExpiry::builder().expires_at(now + chrono::Duration::days(30)).build();
+        assert_eq!(access_only.effective_expires_at(), access_only.expires_at);
+        assert_eq!(access_only.expired_at(now), None);
+        assert_eq!(access_only.expires_within(now, window), None);
+
+        assert_eq!(CredentialExpiry::default().effective_expires_at(), None);
+        assert_eq!(CredentialExpiry::default().expired_at(now), None);
     }
 }

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -81,8 +81,9 @@ pub use error::ResourceError;
 pub use field_ownership::{FieldOwnedResource, FieldOwnership, FieldOwnershipViolation, OwnershipEnforcement, WriterIdentity, WriterRole};
 pub use flotilla_protocol::{PrincipalRef, ResourceRef};
 pub use host::{
-    Host, HostCondition, HostSpec, HostStatus, HostStatusPatch, AGENT_ADAPTERS_CAPABILITY, HEARTBEAT_READY_TTL_SECS,
-    HELD_CREDENTIALS_CAPABILITY, SLEEP_INHIBITION_CONDITION_TYPE, TERMINAL_POOLS_CAPABILITY,
+    CredentialExpiry, Host, HostCondition, HostSpec, HostStatus, HostStatusPatch, AGENT_ADAPTERS_CAPABILITY,
+    AMBIENT_CLAUDE_CREDENTIAL_SCOPE, CREDENTIAL_EXPIRY_CAPABILITY, HEARTBEAT_READY_TTL_SECS, HELD_CREDENTIALS_CAPABILITY,
+    SLEEP_INHIBITION_CONDITION_TYPE, TERMINAL_POOLS_CAPABILITY,
 };
 pub use http::{ensure_crd, ensure_namespace, HttpBackend};
 pub use in_memory::InMemoryBackend;

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -196,7 +196,8 @@ pub(crate) fn format_fleet_health_human(response: &FleetHealthResponse) -> Strin
                 diagnoses.push(format!("⚠ DEGRADED: {}", host.degraded_conditions.join("; ")));
             }
             if !host.credential_attention.is_empty() {
-                diagnoses.push(format!("⚠ CREDENTIALS: {}", host.credential_attention.join("; ")));
+                let details = host.credential_attention.iter().map(|attention| attention.message.as_str()).collect::<Vec<_>>().join("; ");
+                diagnoses.push(format!("⚠ CREDENTIALS: {details}"));
             }
             if matches!(&host.sleep_inhibition, flotilla_protocol::SleepInhibitionHealth::Failed { .. }) {
                 diagnoses.push("⚠ SLEEP INHIBITION FAILED".to_string());

--- a/crates/flotilla-tui/src/cli.rs
+++ b/crates/flotilla-tui/src/cli.rs
@@ -195,6 +195,9 @@ pub(crate) fn format_fleet_health_human(response: &FleetHealthResponse) -> Strin
             if !host.degraded_conditions.is_empty() {
                 diagnoses.push(format!("⚠ DEGRADED: {}", host.degraded_conditions.join("; ")));
             }
+            if !host.credential_attention.is_empty() {
+                diagnoses.push(format!("⚠ CREDENTIALS: {}", host.credential_attention.join("; ")));
+            }
             if matches!(&host.sleep_inhibition, flotilla_protocol::SleepInhibitionHealth::Failed { .. }) {
                 diagnoses.push("⚠ SLEEP INHIBITION FAILED".to_string());
             }

--- a/crates/flotilla-tui/src/widgets/event_log.rs
+++ b/crates/flotilla-tui/src/widgets/event_log.rs
@@ -390,14 +390,15 @@ fn render_fleet_health(hosts: &[FleetHostRow], theme: &Theme, frame: &mut Frame,
         let degraded = !host.degraded_conditions.is_empty();
         let disagreement = host.observation_agreement == FleetObservationAgreement::Disagree;
         let inhibition_failed = matches!(host.sleep_inhibition, SleepInhibitionHealth::Failed { .. });
-        let icon = if degraded || disagreement || inhibition_failed {
+        let credential_expired = host.credential_attention.iter().any(|attention| attention.contains("expired"));
+        let icon = if degraded || disagreement || inhibition_failed || credential_expired {
             "⚠"
         } else if host.staleness == FleetHostStaleness::Current {
             "●"
         } else {
             "○"
         };
-        let style = if degraded || disagreement || inhibition_failed {
+        let style = if degraded || disagreement || inhibition_failed || credential_expired {
             Style::default().fg(theme.warning)
         } else if host.staleness == FleetHostStaleness::Current {
             Style::default().fg(theme.status_ok)
@@ -436,6 +437,13 @@ fn render_fleet_health(hosts: &[FleetHostRow], theme: &Theme, frame: &mut Frame,
             SleepInhibitionHealth::Acquiring { .. } => "acquiring",
             SleepInhibitionHealth::Failed { .. } => "FAILED",
         };
+        let credentials = if credential_expired {
+            "EXPIRED"
+        } else if host.credential_attention.is_empty() {
+            "-"
+        } else {
+            "expiring"
+        };
         Row::new(vec![
             Cell::from(Span::styled(icon, style)),
             Cell::from(name),
@@ -446,6 +454,7 @@ fn render_fleet_health(hosts: &[FleetHostRow], theme: &Theme, frame: &mut Frame,
             Cell::from(format!("{}/{}", host.crew_count, host.convoy_count)),
             Cell::from(disk),
             Cell::from(sleep),
+            Cell::from(credentials),
             Cell::from(stale),
         ])
     });
@@ -460,10 +469,22 @@ fn render_fleet_health(hosts: &[FleetHostRow], theme: &Theme, frame: &mut Frame,
         Constraint::Length(9),
         Constraint::Length(10),
         Constraint::Length(8),
+        Constraint::Length(8),
     ];
-    let header =
-        Row::new(["", "Host", "Daemon v/gen/up", "Link", "Heartbeat", "Replica sync/gen", "Crew/Conv", "Disk", "Sleep", "Staleness"])
-            .style(theme.header_style());
+    let header = Row::new([
+        "",
+        "Host",
+        "Daemon v/gen/up",
+        "Link",
+        "Heartbeat",
+        "Replica sync/gen",
+        "Crew/Conv",
+        "Disk",
+        "Sleep",
+        "Creds",
+        "Staleness",
+    ])
+    .style(theme.header_style());
     let table = Table::new(rows, widths).header(header).block(Block::bordered().style(theme.block_style()).title(" Fleet Health "));
     frame.render_widget(table, area);
 }

--- a/crates/flotilla-tui/src/widgets/event_log.rs
+++ b/crates/flotilla-tui/src/widgets/event_log.rs
@@ -2,7 +2,9 @@ use std::{any::Any, collections::HashMap};
 
 use chrono::{DateTime, Utc};
 use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
-use flotilla_protocol::{FleetHostRow, FleetHostStaleness, FleetObservationAgreement, PeerConnectionState, SleepInhibitionHealth};
+use flotilla_protocol::{
+    CredentialAttentionSeverity, FleetHostRow, FleetHostStaleness, FleetObservationAgreement, PeerConnectionState, SleepInhibitionHealth,
+};
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Style},
@@ -390,15 +392,18 @@ fn render_fleet_health(hosts: &[FleetHostRow], theme: &Theme, frame: &mut Frame,
         let degraded = !host.degraded_conditions.is_empty();
         let disagreement = host.observation_agreement == FleetObservationAgreement::Disagree;
         let inhibition_failed = matches!(host.sleep_inhibition, SleepInhibitionHealth::Failed { .. });
-        let credential_expired = host.credential_attention.iter().any(|attention| attention.contains("expired"));
-        let icon = if degraded || disagreement || inhibition_failed || credential_expired {
+        let credential_alert = host
+            .credential_attention
+            .iter()
+            .any(|attention| matches!(attention.severity, CredentialAttentionSeverity::Expired | CredentialAttentionSeverity::Unreadable));
+        let icon = if degraded || disagreement || inhibition_failed || credential_alert {
             "⚠"
         } else if host.staleness == FleetHostStaleness::Current {
             "●"
         } else {
             "○"
         };
-        let style = if degraded || disagreement || inhibition_failed || credential_expired {
+        let style = if degraded || disagreement || inhibition_failed || credential_alert {
             Style::default().fg(theme.warning)
         } else if host.staleness == FleetHostStaleness::Current {
             Style::default().fg(theme.status_ok)
@@ -437,8 +442,10 @@ fn render_fleet_health(hosts: &[FleetHostRow], theme: &Theme, frame: &mut Frame,
             SleepInhibitionHealth::Acquiring { .. } => "acquiring",
             SleepInhibitionHealth::Failed { .. } => "FAILED",
         };
-        let credentials = if credential_expired {
+        let credentials = if host.credential_attention.iter().any(|attention| attention.severity == CredentialAttentionSeverity::Expired) {
             "EXPIRED"
+        } else if host.credential_attention.iter().any(|attention| attention.severity == CredentialAttentionSeverity::Unreadable) {
+            "unreadable"
         } else if host.credential_attention.is_empty() {
             "-"
         } else {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,6 +119,21 @@ measurement from silently disabling admission.
 Set the floor to `0` only when an external system provides an equivalent
 capacity guard.
 
+## Credential health
+
+Each daemon's heartbeat probes expiry metadata for held credential material
+(the ambient claude login today; declared credentials as adapters learn to
+express expiry) and publishes it on the Host resource — timestamps and scope
+names only, never material. Expired material refuses dependent dispatch at
+admission; expired *and* near-expiry material surfaces in `flotilla host list`
+and the TUI fleet health pane. Override the near-expiry warning window
+(default 7 days) per host in that host's `~/.config/flotilla/daemon.toml`:
+
+```toml
+[credentials]
+warning_window_days = 14
+```
+
 ## Daemon logging
 
 Each daemon writes structured JSON-lines to


### PR DESCRIPTION
Closes #1500.

Credential health becomes an observed condition rather than a crew-discovered failure, per the #1140 ruling (2026-08-14).

## What changed

**Probe (heartbeat cadence, metadata only).** `CredentialStore::credential_expiry()` reads the ambient claude login's credentials file (`$CLAUDE_CONFIG_DIR/.credentials.json`, falling back to `~/.claude/.credentials.json`) through a metadata-only deserialization that captures `expiresAt` / `refreshTokenExpiresAt` and nothing else — token fields never enter daemon memory, logs, or resources. Parse failures log only the file path and line number, never content. Declared `CredentialSpec`s contribute to the same map once an adapter can express expiry without touching material; none of the current sources can, so today the map holds only the ambient login.

**Published condition.** The heartbeat publishes a new `credential_expiry` Host capability (same family as `held_credentials`): a map of scope name → `CredentialExpiry { expires_at, refresh_expires_at }`. The effective expiry is bounded by the refresh chain where one exists — an hourly-rotating access token with a live refresh token is *not* expired.

**Admission refusal by name.** `validate_workflow_credentials` now refuses dispatch against expired material, naming the credential and host:
- required contained credential expired → ``credential `claude-max` expired on host `feta` on 2026-07-30 — refresh its material before dispatching``
- a non-contained claude crew with no delivered claude-slot credential depends on the target host's ambient login; if that login is expired → ``vessel `work` depends on the ambient claude login on host `feta`, which expired on 2026-07-30 — log in again on that host or grant a delivered claude credential``

This prevents the feta incident shape (refresh token expired 2026-07-30, discovered by a Not-logged-in crew two weeks later). Near-expiry material does not refuse admission. Once #1499 delivers `claude-max` to trusted crews, those vessels carry a claude-slot credential and the ambient check naturally stops applying.

**Visibility.** `flotilla host list` gains a `⚠ CREDENTIALS:` diagnosis (``ambient claude login expired on 2026-07-30`` / ``credential `x` expires on …``) and the TUI fleet health pane gains a Creds column plus warning highlighting when material is expired. The near-expiry window is configurable via `daemon.toml` `[credentials] warning_window_days` (default 7).

## Acceptance criteria

- [x] An expired ambient claude login surfaces as a visible condition without any crew being dispatched (`fleet_health_surfaces_an_expired_ambient_claude_login_without_any_crew_dispatched`)
- [x] Dispatch against an expired credential is refused with the credential and host named (`dispatch_against_an_expired_credential_is_refused_with_the_credential_and_host_named`, `dispatch_of_an_ambient_claude_crew_is_refused_when_the_host_login_expired`)
- [x] No credential material appears in logs, resources, or replicas — metadata-only deserialization, and tests assert the published host status and expiry map contain no token material