### PR TITLE
fix: resolve OAuth scratch paths in runner environment

### DIFF
--- a/crates/flotilla-core/src/providers/environment/runner.rs
+++ b/crates/flotilla-core/src/providers/environment/runner.rs
@@ -1,4 +1,7 @@
-use std::{path::Path, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use uuid::Uuid;
@@ -62,6 +65,27 @@ impl CommandRunner for DockerEnvironmentRunner {
     async fn exists(&self, cmd: &str, _args: &[&str]) -> bool {
         let docker_args = ["exec", &self.container_name, "which", cmd];
         self.inner.run("docker", &docker_args, Path::new("/"), &ChannelLabel::Noop).await.is_ok()
+    }
+
+    async fn writable_scratch_base(&self, _preferred: Option<&Path>, _fallback: &Path) -> Result<PathBuf, String> {
+        let scratch = self
+            .run(
+                "sh",
+                &[
+                    "-c",
+                    "if [ -n \"${HOME:-}\" ] && [ -d \"$HOME\" ] && [ -w \"$HOME\" ]; then printf '%s' \"$HOME\"; elif [ -d /tmp ] && [ -w /tmp ]; then printf /tmp; else exit 1; fi",
+                    "flotilla-scratch-base",
+                ],
+                Path::new("/"),
+                &ChannelLabel::Noop,
+            )
+            .await
+            .map_err(|error| format!("find writable scratch directory in container: {error}"))?;
+        let scratch = scratch.trim();
+        if scratch.is_empty() {
+            return Err("find writable scratch directory in container: probe returned an empty path".to_string());
+        }
+        Ok(PathBuf::from(scratch).join("flotilla"))
     }
 
     async fn ensure_file(&self, path: &Path, content: &str) -> Result<String, String> {
@@ -135,6 +159,24 @@ mod tests {
         let args = runner.docker_exec_args("sh", &["-lc", "pwd"], Path::new("/workspace"), true);
 
         assert_eq!(args, ["exec", "-i", "-w", "/workspace", "my-container", "sh", "-lc", "pwd"]);
+    }
+
+    #[tokio::test]
+    async fn writable_scratch_base_is_resolved_inside_the_container() {
+        let inner = Arc::new(MockRunner::new(vec![Ok("/home/crew".into())]));
+        let runner = DockerEnvironmentRunner::new("my-container".into(), inner.clone());
+
+        let scratch = runner
+            .writable_scratch_base(Some(Path::new("/run/user/1000")), Path::new("/host/state"))
+            .await
+            .expect("container scratch base");
+
+        assert_eq!(scratch, Path::new("/home/crew/flotilla"));
+        let calls = inner.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "docker");
+        assert!(calls[0].1.starts_with(&["exec".to_string(), "-w".to_string(), "/".to_string(), "my-container".to_string()]));
+        assert!(calls[0].1.iter().all(|arg| arg != "/run/user/1000" && arg != "/host/state"));
     }
 
     #[tokio::test]

--- a/crates/flotilla-core/src/providers/mod.rs
+++ b/crates/flotilla-core/src/providers/mod.rs
@@ -13,7 +13,7 @@ pub mod terminal;
 pub mod types;
 pub mod vcs;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 use sha2::{Digest, Sha256};
@@ -264,6 +264,32 @@ pub trait CommandRunner: Send + Sync {
     async fn path_exists(&self, path: &Path) -> Result<bool, String> {
         let path = path.to_string_lossy();
         self.run_output("test", &["-e", &path], Path::new("/"), &ChannelLabel::Noop).await.map(|output| output.success)
+    }
+
+    /// Choose a Flotilla-owned writable scratch base in this runner's
+    /// filesystem world.
+    ///
+    /// Direct runners use the host's preferred runtime directory when it is
+    /// still usable, then fall back to the daemon-owned state directory.
+    /// Runners that cross into another filesystem namespace must override
+    /// this method and choose a path owned by that environment instead.
+    async fn writable_scratch_base(&self, preferred: Option<&Path>, fallback: &Path) -> Result<PathBuf, String> {
+        if let Some(preferred) = preferred {
+            let preferred_arg = preferred.to_string_lossy();
+            let output = self
+                .run_output(
+                    "sh",
+                    &["-c", "test -d \"$1\" && test -w \"$1\"", "flotilla-xdg-runtime-dir", &preferred_arg],
+                    Path::new("/"),
+                    &ChannelLabel::Noop,
+                )
+                .await;
+            if output.is_ok_and(|output| output.success) {
+                return Ok(preferred.join("flotilla"));
+            }
+            tracing::debug!(rejected_path = %preferred.display(), "preferred scratch directory is missing or unwritable; using fallback");
+        }
+        Ok(fallback.to_path_buf())
     }
 
     /// Ensure `path` exists with `content` if absent, returning the resulting

--- a/crates/flotilla-daemon/src/credential.rs
+++ b/crates/flotilla-daemon/src/credential.rs
@@ -613,16 +613,16 @@ impl CredentialStore {
     // per-credential dir. The daemon runs as an unprivileged user with no
     // systemd `RuntimeDirectory=`, so absolute `/run` is unwritable; derive
     // the dir from a daemon-owned writable base instead: the user runtime dir
-    // when present, the daemon state dir otherwise (#1498).
-    fn claude_preflight_config_dir(&self, credential_name: &str) -> String {
-        let base = self
-            .env
-            .get("XDG_RUNTIME_DIR")
-            .map(|value| value.trim().to_string())
-            .filter(|value| !value.is_empty())
-            .map(|runtime_dir| PathBuf::from(runtime_dir).join("flotilla"))
-            .unwrap_or_else(|| self.state_dir.clone());
-        base.join("credentials").join(safe_component(credential_name)).join("claude").to_string_lossy().into_owned()
+    // when present and writable, the daemon state dir otherwise (#1498,
+    // #1508). The runner owns the choice because it may target a different
+    // filesystem world, such as a provisioned container. Resolve on every
+    // preflight because logind can remove an inherited runtime dir after
+    // daemon startup.
+    async fn claude_preflight_config_dir(&self, credential_name: &str, runner: &dyn CommandRunner) -> Result<String, String> {
+        let runtime_dir =
+            self.env.get("XDG_RUNTIME_DIR").map(|value| PathBuf::from(value.trim())).filter(|value| !value.as_os_str().is_empty());
+        let base = runner.writable_scratch_base(runtime_dir.as_deref(), &self.state_dir).await?;
+        Ok(base.join("credentials").join(safe_component(credential_name)).join("claude").to_string_lossy().into_owned())
     }
 
     async fn prepare_adapter(
@@ -756,8 +756,8 @@ impl CredentialStore {
                 if !runner.exists("claude", &["--version"]).await {
                     return Err("consumer binary is unavailable".to_string());
                 }
-                let config_dir = self.claude_preflight_config_dir(name);
                 if !already_prepared {
+                    let config_dir = self.claude_preflight_config_dir(name, &*runner).await?;
                     runner
                         .run("mkdir", &["-p", &config_dir], Path::new("/"), &ChannelLabel::Noop)
                         .await
@@ -941,7 +941,7 @@ fn validate_scalar_material(name: &str, adapter: &str, material: &str) -> Result
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex as StdMutex;
+    use std::{collections::VecDeque, sync::Mutex as StdMutex};
 
     use async_trait::async_trait;
     use flotilla_core::providers::{
@@ -969,6 +969,13 @@ mod tests {
     struct RecordingRunner {
         calls: StdMutex<Vec<RecordedCall>>,
         writes: StdMutex<Vec<(PathBuf, String)>>,
+        runtime_dir_checks: StdMutex<VecDeque<bool>>,
+    }
+
+    impl RecordingRunner {
+        fn with_runtime_dir_checks(checks: impl IntoIterator<Item = bool>) -> Self {
+            Self { runtime_dir_checks: StdMutex::new(checks.into_iter().collect()), ..Self::default() }
+        }
     }
 
     #[async_trait]
@@ -979,7 +986,13 @@ mod tests {
         }
 
         async fn run_output(&self, cmd: &str, args: &[&str], cwd: &Path, label: &ChannelLabel) -> Result<CommandOutput, String> {
-            self.run(cmd, args, cwd, label).await.map(|stdout| CommandOutput { stdout, stderr: String::new(), success: true })
+            let stdout = self.run(cmd, args, cwd, label).await?;
+            let success = if cmd == "sh" && args.contains(&"flotilla-xdg-runtime-dir") {
+                self.runtime_dir_checks.lock().expect("runtime dir checks lock").pop_front().unwrap_or(true)
+            } else {
+                true
+            };
+            Ok(CommandOutput { stdout, stderr: String::new(), success })
         }
 
         async fn run_with_input(
@@ -1368,6 +1381,54 @@ interactions:
         store.prepare("env-a", &BTreeSet::from(["claude-max".to_string()]), runner.clone()).await.expect("prepare claude-oauth credential");
 
         let calls = runner.calls.lock().expect("calls lock");
+        assert!(calls
+            .iter()
+            .any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/tmp/flotilla-test-state/credentials/claude-max/claude"]));
+    }
+
+    #[tokio::test]
+    async fn a_dangling_user_runtime_dir_falls_back_to_the_daemon_state_dir() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(NodeId::new("root-a"));
+        create_claude_oauth_spec(&backend, "claude-max", "ops@example.com", "TEST_CLAUDE_TOKEN").await;
+        let env = Arc::new(TestEnv(BTreeMap::from([
+            ("TEST_CLAUDE_TOKEN".to_string(), "sk-ant-oat01-test-token".to_string()),
+            ("XDG_RUNTIME_DIR".to_string(), "/run/user/1000-removed".to_string()),
+        ])));
+        let runner = Arc::new(RecordingRunner::with_runtime_dir_checks([false]));
+        let bag = EnvironmentBag::new().with(EnvironmentAssertion::binary("claude", "/usr/bin/claude"));
+        let store = CredentialStore::new(backend, "flotilla", env, bag, runner.clone(), PathBuf::from("/tmp/flotilla-test-state"));
+
+        store.prepare("env-a", &BTreeSet::from(["claude-max".to_string()]), runner.clone()).await.expect("prepare claude-oauth credential");
+
+        let calls = runner.calls.lock().expect("calls lock");
+        assert!(calls
+            .iter()
+            .any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/tmp/flotilla-test-state/credentials/claude-max/claude"]));
+        assert!(calls
+            .iter()
+            .all(|(cmd, args, _)| { cmd != "mkdir" || args != &["-p", "/run/user/1000-removed/flotilla/credentials/claude-max/claude"] }));
+    }
+
+    #[tokio::test]
+    async fn user_runtime_dir_is_rechecked_for_each_claude_oauth_preflight() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(NodeId::new("root-a"));
+        create_claude_oauth_spec(&backend, "claude-max", "ops@example.com", "TEST_CLAUDE_TOKEN").await;
+        let env = Arc::new(TestEnv(BTreeMap::from([
+            ("TEST_CLAUDE_TOKEN".to_string(), "sk-ant-oat01-test-token".to_string()),
+            ("XDG_RUNTIME_DIR".to_string(), "/run/user/1000".to_string()),
+        ])));
+        let runner = Arc::new(RecordingRunner::with_runtime_dir_checks([true, false]));
+        let bag = EnvironmentBag::new().with(EnvironmentAssertion::binary("claude", "/usr/bin/claude"));
+        let store = CredentialStore::new(backend, "flotilla", env, bag, runner.clone(), PathBuf::from("/tmp/flotilla-test-state"));
+        let credential_refs = BTreeSet::from(["claude-max".to_string()]);
+
+        store.prepare("env-a", &credential_refs, runner.clone()).await.expect("first preflight");
+        store.prepare("env-b", &credential_refs, runner.clone()).await.expect("second preflight");
+
+        let calls = runner.calls.lock().expect("calls lock");
+        assert!(calls
+            .iter()
+            .any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/run/user/1000/flotilla/credentials/claude-max/claude"]));
         assert!(calls
             .iter()
             .any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/tmp/flotilla-test-state/credentials/claude-max/claude"]));

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -3514,6 +3514,10 @@ mod tests {
             self.0.path_exists(path).await
         }
 
+        async fn writable_scratch_base(&self, _preferred: Option<&Path>, _fallback: &Path) -> Result<PathBuf, String> {
+            Ok(PathBuf::from("/home/crew/flotilla"))
+        }
+
         async fn ensure_file(&self, path: &Path, content: &str) -> Result<String, String> {
             self.0.ensure_file(path, content).await
         }
@@ -7221,9 +7225,10 @@ mod tests {
         let workspace = temp.path().join("workspace");
         fs::create_dir_all(&workspace).expect("workspace");
         let env_id = EnvironmentId::new("contained-claude");
-        // The preflight scratch dir must derive from a daemon-owned writable
-        // base (here the state dir), never absolute /run on the host (#1498).
-        let preflight_config_dir = config.state_dir().as_path().join("credentials/claude-max/claude");
+        // Credential preflight runs through the contained runner, so its
+        // scratch directory must be inside the container user's writable
+        // world rather than derived from daemon-host paths (#1508).
+        let preflight_config_dir = PathBuf::from("/home/crew/flotilla/credentials/claude-max/claude");
         let runner: Arc<dyn CommandRunner> = Arc::new(CredentialInteriorRunner(
             DiscoveryMockRunner::builder()
                 .tool_exists("claude", true)


### PR DESCRIPTION
## Summary

- extend the command-runner seam so each execution environment selects a writable Flotilla scratch base in its own filesystem world
- resolve Docker scratch space from the container user's writable `HOME`, falling back to `/tmp`, without passing daemon-host paths into the container
- validate host-direct `XDG_RUNTIME_DIR` at each Claude OAuth preflight and fall back to the daemon state directory when it is missing or unwritable
- cover contained preflight path selection, dangling runtime directories, and per-preflight re-evaluation

## Testing

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1508
