### PR TITLE
fix: route container delivery through writable base

### DIFF
--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -535,8 +535,10 @@ impl AgentAdapter for CliAgentAdapter {
                 if *contained && !environment.iter().any(|(name, _)| name == "CLAUDE_CODE_OAUTH_TOKEN") {
                     return Err("contained Claude Code requires credential environment `CLAUDE_CODE_OAUTH_TOKEN`".to_string());
                 }
-                if *contained && !environment.iter().any(|(name, _)| name == "CLAUDE_CONFIG_DIR") {
-                    return Err("contained Claude Code requires seam-resolved environment `CLAUDE_CONFIG_DIR`".to_string());
+                if environment.iter().any(|(name, _)| name == "CLAUDE_CODE_OAUTH_TOKEN")
+                    && !environment.iter().any(|(name, _)| name == "CLAUDE_CONFIG_DIR")
+                {
+                    return Err("Claude Code OAuth requires seam-resolved environment `CLAUDE_CONFIG_DIR`".to_string());
                 }
                 let invocation_state = if let Some(config_dir) = self.claude_invocation_config_dir(environment) {
                     let config_dir_string = config_dir.display().to_string();
@@ -585,10 +587,11 @@ impl AgentAdapter for CliAgentAdapter {
         {
             return Err("contained Claude Code requires credential environment `CLAUDE_CODE_OAUTH_TOKEN`".to_string());
         }
-        if matches!(&self.flavor, AdapterFlavor::ClaudeCode { contained: true, .. })
+        if matches!(&self.flavor, AdapterFlavor::ClaudeCode { .. })
+            && env.iter().any(|(name, _)| name == "CLAUDE_CODE_OAUTH_TOKEN")
             && !env.iter().any(|(name, _)| name == "CLAUDE_CONFIG_DIR")
         {
-            return Err("contained Claude Code requires seam-resolved environment `CLAUDE_CONFIG_DIR`".to_string());
+            return Err("Claude Code OAuth requires seam-resolved environment `CLAUDE_CONFIG_DIR`".to_string());
         }
         if let Some(config_dir) = self.claude_invocation_config_dir(&env) {
             env.retain(|(name, _)| name != "CLAUDE_CONFIG_DIR");
@@ -1462,6 +1465,26 @@ mod tests {
 
         assert!(alice.env.contains(&("CLAUDE_CONFIG_DIR".to_string(), "/state/flotilla/credentials/alice/claude".to_string())));
         assert!(bob.env.contains(&("CLAUDE_CONFIG_DIR".to_string(), "/state/flotilla/credentials/bob/claude".to_string())));
+    }
+
+    #[test]
+    fn host_direct_claude_oauth_rejects_a_token_without_a_seam_resolved_config_dir() {
+        let env = EnvironmentBag::new().with(EnvironmentAssertion::binary("claude", "/tools/claude"));
+        let registry = AgentAdapterRegistry::discover(&env, Arc::new(MockRunner::new(Vec::new())));
+        let claude = registry.get("claude-code").expect("Claude adapter");
+        let brief =
+            flotilla_resources::TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "brief".into(), copies: Vec::new() };
+
+        let error = claude
+            .launch(&AgentLaunchRequest {
+                role: "coder".into(),
+                model: None,
+                brief,
+                environment: vec![("CLAUDE_CODE_OAUTH_TOKEN".to_string(), "token-alice".to_string())],
+            })
+            .expect_err("OAuth identities must never share ambient Claude state");
+
+        assert!(error.contains("CLAUDE_CONFIG_DIR"), "unexpected error: {error}");
     }
 
     #[test]

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -8,7 +8,6 @@ use async_trait::async_trait;
 use flotilla_protocol::arg::{flatten, Arg};
 use flotilla_resources::{TerminalAttentionState, TerminalBrief};
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 use toml_edit::{value, DocumentMut, Item, Table};
 
@@ -428,8 +427,6 @@ pub trait AgentAdapter: Send + Sync {
 /// relative to the session's working directory. It lives under `.flotilla/`
 /// alongside the brief so it inherits the same git exclusion and teardown.
 pub const CLAUDE_MANAGED_SETTINGS_PATH: &str = ".flotilla/claude-settings.json";
-const CONTAINED_CLAUDE_CONFIG_DIR: &str = "/run/flotilla/claude";
-const HOST_DIRECT_CLAUDE_OAUTH_CONFIG_ROOT: &str = "/run/flotilla/claude-oauth";
 
 struct CliAgentAdapter {
     binary: String,
@@ -504,24 +501,16 @@ impl CliAgentAdapter {
     }
 
     fn claude_invocation_config_dir(&self, environment: &TerminalEnvVars) -> Option<PathBuf> {
-        let AdapterFlavor::ClaudeCode { contained, .. } = &self.flavor else {
+        let AdapterFlavor::ClaudeCode { .. } = &self.flavor else {
             return None;
         };
         let oauth_token = environment.iter().find(|(name, _)| name == "CLAUDE_CODE_OAUTH_TOKEN").map(|(_, value)| value.as_str());
-        if *contained {
-            return oauth_token.map(|_| PathBuf::from(CONTAINED_CLAUDE_CONFIG_DIR));
+        if oauth_token.is_some() {
+            if let Some((_, config_dir)) = environment.iter().find(|(name, _)| name == "CLAUDE_CONFIG_DIR") {
+                return Some(PathBuf::from(config_dir));
+            }
         }
-        if let Some((_, config_dir)) = environment.iter().find(|(name, _)| name == "CLAUDE_CONFIG_DIR") {
-            return Some(PathBuf::from(config_dir));
-        }
-        oauth_token.map(|token| {
-            // Host-direct OAuth identities still need separate supervisor and
-            // mutable-state homes. Key the ephemeral directory without putting
-            // credential material or a reversible account identifier in paths.
-            let digest = Sha256::digest(token.as_bytes());
-            let account_key = digest[..16].iter().map(|byte| format!("{byte:02x}")).collect::<String>();
-            PathBuf::from(HOST_DIRECT_CLAUDE_OAUTH_CONFIG_ROOT).join(account_key)
-        })
+        None
     }
 }
 
@@ -545,6 +534,9 @@ impl AgentAdapter for CliAgentAdapter {
             AdapterFlavor::ClaudeCode { state_config, state_lock, contained } => {
                 if *contained && !environment.iter().any(|(name, _)| name == "CLAUDE_CODE_OAUTH_TOKEN") {
                     return Err("contained Claude Code requires credential environment `CLAUDE_CODE_OAUTH_TOKEN`".to_string());
+                }
+                if *contained && !environment.iter().any(|(name, _)| name == "CLAUDE_CONFIG_DIR") {
+                    return Err("contained Claude Code requires seam-resolved environment `CLAUDE_CONFIG_DIR`".to_string());
                 }
                 let invocation_state = if let Some(config_dir) = self.claude_invocation_config_dir(environment) {
                     let config_dir_string = config_dir.display().to_string();
@@ -592,6 +584,11 @@ impl AgentAdapter for CliAgentAdapter {
             && !env.iter().any(|(name, _)| name == "CLAUDE_CODE_OAUTH_TOKEN")
         {
             return Err("contained Claude Code requires credential environment `CLAUDE_CODE_OAUTH_TOKEN`".to_string());
+        }
+        if matches!(&self.flavor, AdapterFlavor::ClaudeCode { contained: true, .. })
+            && !env.iter().any(|(name, _)| name == "CLAUDE_CONFIG_DIR")
+        {
+            return Err("contained Claude Code requires seam-resolved environment `CLAUDE_CONFIG_DIR`".to_string());
         }
         if let Some(config_dir) = self.claude_invocation_config_dir(&env) {
             env.retain(|(name, _)| name != "CLAUDE_CONFIG_DIR");
@@ -797,9 +794,8 @@ mod tests {
 
     use crate::{
         agent_adapter::{
-            append_convoy_work_context, build_crew_brief, build_crew_brief_with_options, AgentAdapterRegistry, AgentLaunchPlan,
-            AgentLaunchRequest, CapabilityTable, CrewAssignment, CrewBriefMember, CrewBriefRenderOptions, CrewBriefTemplateOverride,
-            CrewBriefTemplateResolver, CONTAINED_CLAUDE_CONFIG_DIR,
+            append_convoy_work_context, build_crew_brief, build_crew_brief_with_options, AgentAdapterRegistry, AgentLaunchRequest,
+            CapabilityTable, CrewAssignment, CrewBriefMember, CrewBriefRenderOptions, CrewBriefTemplateOverride, CrewBriefTemplateResolver,
         },
         path_context::ExecutionEnvironmentPath,
         providers::{
@@ -1350,7 +1346,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn contained_claude_owns_ephemeral_config_without_accepting_a_config_input() {
+    async fn contained_claude_uses_the_seam_resolved_invocation_config() {
         let workspace = ExecutionEnvironmentPath::new("/workspace");
         let runner = Arc::new(MockRunner::new(vec![Ok(String::new()), Ok("/workspace\n".to_string()), Err("not a checkout".to_string())]));
         let env = EnvironmentBag::new()
@@ -1360,7 +1356,10 @@ mod tests {
         let claude = registry.get("claude-code").expect("Claude adapter");
         let brief =
             flotilla_resources::TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "brief".into(), copies: Vec::new() };
-        let invocation_environment = vec![("CLAUDE_CODE_OAUTH_TOKEN".to_string(), "redacted-test-token".to_string())];
+        let invocation_environment = vec![
+            ("CLAUDE_CODE_OAUTH_TOKEN".to_string(), "redacted-test-token".to_string()),
+            ("CLAUDE_CONFIG_DIR".to_string(), "/home/crew/flotilla/credentials/claude-max/claude".to_string()),
+        ];
 
         claude.prepare_with_environment(&workspace, &brief, &invocation_environment).await.expect("prepare contained Claude");
         let plan = claude
@@ -1368,8 +1367,15 @@ mod tests {
             .expect("contained launch plan");
 
         assert!(plan.env.iter().any(|(name, value)| name == "CLAUDE_CODE_OAUTH_TOKEN" && value == "redacted-test-token"));
-        assert!(plan.env.iter().any(|(name, value)| name == "CLAUDE_CONFIG_DIR" && value == CONTAINED_CLAUDE_CONFIG_DIR));
-        assert!(runner.calls().iter().any(|(command, args)| command == "mkdir" && args == &["-p", CONTAINED_CLAUDE_CONFIG_DIR]));
+        assert!(plan
+            .env
+            .iter()
+            .any(|(name, value)| name == "CLAUDE_CONFIG_DIR" && value == "/home/crew/flotilla/credentials/claude-max/claude"));
+        assert!(runner
+            .calls()
+            .iter()
+            .any(|(command, args)| { command == "mkdir" && args == &["-p", "/home/crew/flotilla/credentials/claude-max/claude"] }));
+        assert!(runner.calls().iter().flat_map(|(_, args)| args).all(|arg| !arg.starts_with("/run/flotilla")));
     }
 
     #[tokio::test]
@@ -1431,36 +1437,31 @@ mod tests {
     }
 
     #[test]
-    fn host_direct_claude_oauth_accounts_get_distinct_adapter_owned_config_dirs() {
+    fn host_direct_claude_oauth_accounts_keep_distinct_seam_resolved_config_dirs() {
         let env = EnvironmentBag::new().with(EnvironmentAssertion::binary("claude", "/tools/claude"));
         let registry = AgentAdapterRegistry::discover(&env, Arc::new(MockRunner::new(Vec::new())));
         let claude = registry.get("claude-code").expect("Claude adapter");
         let brief =
             flotilla_resources::TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "brief".into(), copies: Vec::new() };
-        let launch = |token: &str| {
+        let launch = |token: &str, config_dir: &str| {
             claude
                 .launch(&AgentLaunchRequest {
                     role: "coder".into(),
                     model: None,
                     brief: brief.clone(),
-                    environment: vec![("CLAUDE_CODE_OAUTH_TOKEN".to_string(), token.to_string())],
+                    environment: vec![
+                        ("CLAUDE_CODE_OAUTH_TOKEN".to_string(), token.to_string()),
+                        ("CLAUDE_CONFIG_DIR".to_string(), config_dir.to_string()),
+                    ],
                 })
                 .expect("host-direct OAuth launch")
         };
 
-        let alice = launch("token-alice");
-        let bob = launch("token-bob");
-        let config_dir = |plan: &AgentLaunchPlan| {
-            plan.env
-                .iter()
-                .find(|(name, _)| name == "CLAUDE_CONFIG_DIR")
-                .map(|(_, value)| value.clone())
-                .expect("adapter-owned Claude config")
-        };
+        let alice = launch("token-alice", "/state/flotilla/credentials/alice/claude");
+        let bob = launch("token-bob", "/state/flotilla/credentials/bob/claude");
 
-        assert_ne!(config_dir(&alice), config_dir(&bob));
-        assert!(config_dir(&alice).starts_with("/run/flotilla/claude-oauth/"));
-        assert!(config_dir(&bob).starts_with("/run/flotilla/claude-oauth/"));
+        assert!(alice.env.contains(&("CLAUDE_CONFIG_DIR".to_string(), "/state/flotilla/credentials/alice/claude".to_string())));
+        assert!(bob.env.contains(&("CLAUDE_CONFIG_DIR".to_string(), "/state/flotilla/credentials/bob/claude".to_string())));
     }
 
     #[test]

--- a/crates/flotilla-core/src/providers/environment/runner.rs
+++ b/crates/flotilla-core/src/providers/environment/runner.rs
@@ -11,6 +11,12 @@ use crate::providers::{
     FLOTILLA_HELPER_NAME, FLOTILLA_HELPER_SCRIPT,
 };
 
+/// Persistent writable base reserved inside provisioned containers. Unlike a
+/// user's home, this location is known before container creation, so writable
+/// material mounts and post-create runner writes can share one path contract.
+pub const CONTAINED_WRITABLE_CONFIG_BASE: &str = "/tmp/flotilla";
+pub const CONTAINED_CODEX_HOME: &str = "/tmp/flotilla/codex";
+
 /// A `CommandRunner` decorator that executes all commands inside a Docker container
 /// via `docker exec`. Absolute working directories are forwarded as `-w`; relative
 /// paths use the container's configured working directory. The host-side cwd is `/`.
@@ -40,6 +46,27 @@ impl DockerEnvironmentRunner {
     fn docker_exec_prefix(&self) -> Vec<&str> {
         vec!["exec", &self.container_name]
     }
+
+    async fn writable_base(&self, purpose: &str) -> Result<PathBuf, String> {
+        let base = self
+            .run(
+                "sh",
+                &[
+                    "-c",
+                    "if [ -n \"${HOME:-}\" ] && [ -d \"$HOME\" ] && [ -w \"$HOME\" ]; then printf '%s' \"$HOME\"; elif [ -d /tmp ] && [ -w /tmp ]; then printf /tmp; else exit 1; fi",
+                    purpose,
+                ],
+                Path::new("/"),
+                &ChannelLabel::Noop,
+            )
+            .await
+            .map_err(|error| format!("find writable directory in container: {error}"))?;
+        let base = base.trim();
+        if base.is_empty() {
+            return Err("find writable directory in container: probe returned an empty path".to_string());
+        }
+        Ok(PathBuf::from(base).join("flotilla"))
+    }
 }
 
 #[async_trait]
@@ -68,24 +95,14 @@ impl CommandRunner for DockerEnvironmentRunner {
     }
 
     async fn writable_scratch_base(&self, _preferred: Option<&Path>, _fallback: &Path) -> Result<PathBuf, String> {
-        let scratch = self
-            .run(
-                "sh",
-                &[
-                    "-c",
-                    "if [ -n \"${HOME:-}\" ] && [ -d \"$HOME\" ] && [ -w \"$HOME\" ]; then printf '%s' \"$HOME\"; elif [ -d /tmp ] && [ -w /tmp ]; then printf /tmp; else exit 1; fi",
-                    "flotilla-scratch-base",
-                ],
-                Path::new("/"),
-                &ChannelLabel::Noop,
-            )
+        self.writable_base("flotilla-scratch-base").await
+    }
+
+    async fn writable_config_base(&self, _preferred: Option<&Path>, _fallback: &Path) -> Result<PathBuf, String> {
+        self.run("sh", &["-c", "test -d /tmp && test -w /tmp", "flotilla-config-base"], Path::new("/"), &ChannelLabel::Noop)
             .await
-            .map_err(|error| format!("find writable scratch directory in container: {error}"))?;
-        let scratch = scratch.trim();
-        if scratch.is_empty() {
-            return Err("find writable scratch directory in container: probe returned an empty path".to_string());
-        }
-        Ok(PathBuf::from(scratch).join("flotilla"))
+            .map_err(|error| format!("find writable config directory in container: {error}"))?;
+        Ok(PathBuf::from(CONTAINED_WRITABLE_CONFIG_BASE))
     }
 
     async fn ensure_file(&self, path: &Path, content: &str) -> Result<String, String> {
@@ -113,9 +130,18 @@ mod tests {
     use std::{future, path::Path, sync::Arc, time::Duration};
 
     use async_trait::async_trait;
+    use uuid::Uuid;
 
     use super::DockerEnvironmentRunner;
-    use crate::providers::{testing::MockRunner, ChannelLabel, CommandOutput, CommandRunner};
+    use crate::providers::{testing::MockRunner, ChannelLabel, CommandOutput, CommandRunner, ProcessCommandRunner};
+
+    struct DockerContainer(String);
+
+    impl Drop for DockerContainer {
+        fn drop(&mut self) {
+            let _ = std::process::Command::new("docker").args(["rm", "-f", &self.0]).output();
+        }
+    }
 
     struct InvalidWorkdirHangingRunner;
 
@@ -177,6 +203,69 @@ mod tests {
         assert_eq!(calls[0].0, "docker");
         assert!(calls[0].1.starts_with(&["exec".to_string(), "-w".to_string(), "/".to_string(), "my-container".to_string()]));
         assert!(calls[0].1.iter().all(|arg| arg != "/run/user/1000" && arg != "/host/state"));
+    }
+
+    #[tokio::test]
+    async fn writable_config_base_is_resolved_inside_the_container() {
+        let inner = Arc::new(MockRunner::new(vec![Ok(String::new())]));
+        let runner = DockerEnvironmentRunner::new("my-container".into(), inner.clone());
+
+        let config =
+            runner.writable_config_base(Some(Path::new("/run/user/1000")), Path::new("/host/state")).await.expect("container config base");
+
+        assert_eq!(config, Path::new("/tmp/flotilla"));
+        let calls = inner.calls();
+        assert_eq!(calls.len(), 1);
+        assert!(calls[0].1.iter().any(|arg| arg == "flotilla-config-base"));
+        assert!(calls[0].1.iter().all(|arg| arg != "/run/user/1000" && arg != "/host/state"));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires Docker and the busybox:latest image"]
+    async fn persistent_delivery_paths_work_in_a_real_non_root_container() {
+        let container = DockerContainer(format!("flotilla-non-root-delivery-{}", Uuid::new_v4()));
+        ProcessCommandRunner
+            .run(
+                "docker",
+                &["run", "-d", "--name", &container.0, "--user", "65534:65534", "-e", "HOME=/tmp", "busybox:latest", "sleep", "infinity"],
+                Path::new("/"),
+                &ChannelLabel::Noop,
+            )
+            .await
+            .expect("start non-root test container");
+        let runner = DockerEnvironmentRunner::new(container.0.clone(), Arc::new(ProcessCommandRunner));
+        let base = runner
+            .writable_config_base(Some(Path::new("/run/user/65534")), Path::new("/host/state"))
+            .await
+            .expect("resolve container config base");
+        let git_config = base.join("credentials/gitconfig");
+        let agent_environment = base.join("agent-environment");
+
+        runner.write_file(&git_config, "[credential]\n\thelper = test\n").await.expect("write Git config as non-root user");
+        runner
+            .write_file(&agent_environment, &format!("export GIT_CONFIG_GLOBAL='{}'\n", git_config.display()))
+            .await
+            .expect("write agent environment as non-root user");
+
+        let agent_environment_arg = agent_environment.to_string_lossy();
+        let observed = runner
+            .run(
+                "sh",
+                &[
+                    "-c",
+                    ". \"$1\"; test -f \"$GIT_CONFIG_GLOBAL\"; printf '%s\\n%s' \"$GIT_CONFIG_GLOBAL\" \"$1\"",
+                    "flotilla-verify-delivery",
+                    &agent_environment_arg,
+                ],
+                Path::new("/"),
+                &ChannelLabel::Noop,
+            )
+            .await
+            .expect("resolve exported delivery paths");
+
+        assert_eq!(observed, format!("{}\n{}", git_config.display(), agent_environment.display()));
+        assert!(!git_config.starts_with("/run/flotilla"));
+        assert!(!agent_environment.starts_with("/run/flotilla"));
     }
 
     #[tokio::test]

--- a/crates/flotilla-core/src/providers/environment/runner.rs
+++ b/crates/flotilla-core/src/providers/environment/runner.rs
@@ -14,8 +14,8 @@ use crate::providers::{
 /// Persistent writable base reserved inside provisioned containers. Unlike a
 /// user's home, this location is known before container creation, so writable
 /// material mounts and post-create runner writes can share one path contract.
-pub const CONTAINED_WRITABLE_CONFIG_BASE: &str = "/tmp/flotilla";
-pub const CONTAINED_CODEX_HOME: &str = "/tmp/flotilla/codex";
+pub const CONTAINED_WRITABLE_CONFIG_BASE: &str = "/tmp/flotilla-config";
+pub const CONTAINED_CODEX_HOME: &str = "/tmp/flotilla-codex";
 
 /// A `CommandRunner` decorator that executes all commands inside a Docker container
 /// via `docker exec`. Absolute working directories are forwarded as `-w`; relative
@@ -127,12 +127,12 @@ impl CommandRunner for DockerEnvironmentRunner {
 
 #[cfg(test)]
 mod tests {
-    use std::{future, path::Path, sync::Arc, time::Duration};
+    use std::{future, os::unix::fs::PermissionsExt, path::Path, sync::Arc, time::Duration};
 
     use async_trait::async_trait;
     use uuid::Uuid;
 
-    use super::DockerEnvironmentRunner;
+    use super::{DockerEnvironmentRunner, CONTAINED_CODEX_HOME};
     use crate::providers::{testing::MockRunner, ChannelLabel, CommandOutput, CommandRunner, ProcessCommandRunner};
 
     struct DockerContainer(String);
@@ -213,7 +213,7 @@ mod tests {
         let config =
             runner.writable_config_base(Some(Path::new("/run/user/1000")), Path::new("/host/state")).await.expect("container config base");
 
-        assert_eq!(config, Path::new("/tmp/flotilla"));
+        assert_eq!(config, Path::new("/tmp/flotilla-config"));
         let calls = inner.calls();
         assert_eq!(calls.len(), 1);
         assert!(calls[0].1.iter().any(|arg| arg == "flotilla-config-base"));
@@ -224,10 +224,28 @@ mod tests {
     #[ignore = "requires Docker and the busybox:latest image"]
     async fn persistent_delivery_paths_work_in_a_real_non_root_container() {
         let container = DockerContainer(format!("flotilla-non-root-delivery-{}", Uuid::new_v4()));
+        let codex_home = tempfile::tempdir().expect("Codex home mount source");
+        std::fs::set_permissions(codex_home.path(), std::fs::Permissions::from_mode(0o777))
+            .expect("make Codex mount writable to test user");
+        let codex_mount = format!("{}:{CONTAINED_CODEX_HOME}:rw", codex_home.path().display());
         ProcessCommandRunner
             .run(
                 "docker",
-                &["run", "-d", "--name", &container.0, "--user", "65534:65534", "-e", "HOME=/tmp", "busybox:latest", "sleep", "infinity"],
+                &[
+                    "run",
+                    "-d",
+                    "--name",
+                    &container.0,
+                    "--user",
+                    "65534:65534",
+                    "-e",
+                    "HOME=/tmp",
+                    "-v",
+                    &codex_mount,
+                    "busybox:latest",
+                    "sleep",
+                    "infinity",
+                ],
                 Path::new("/"),
                 &ChannelLabel::Noop,
             )
@@ -264,6 +282,10 @@ mod tests {
             .expect("resolve exported delivery paths");
 
         assert_eq!(observed, format!("{}\n{}", git_config.display(), agent_environment.display()));
+        runner
+            .run("sh", &["-c", "test -w \"$1\"", "flotilla-verify-codex-home", CONTAINED_CODEX_HOME], Path::new("/"), &ChannelLabel::Noop)
+            .await
+            .expect("Codex home mount is writable as non-root user");
         assert!(!git_config.starts_with("/run/flotilla"));
         assert!(!agent_environment.starts_with("/run/flotilla"));
     }

--- a/crates/flotilla-core/src/providers/mod.rs
+++ b/crates/flotilla-core/src/providers/mod.rs
@@ -292,6 +292,17 @@ pub trait CommandRunner: Send + Sync {
         Ok(fallback.to_path_buf())
     }
 
+    /// Choose a Flotilla-owned writable base for files that must persist for
+    /// the lifetime of this runner's execution environment.
+    ///
+    /// This is deliberately distinct from [`Self::writable_scratch_base`]:
+    /// callers must not attach scratch-probe cleanup to paths returned here.
+    /// The default filesystem policy is shared, while namespace-crossing
+    /// runners may resolve the base in their own environment.
+    async fn writable_config_base(&self, preferred: Option<&Path>, fallback: &Path) -> Result<PathBuf, String> {
+        self.writable_scratch_base(preferred, fallback).await
+    }
+
     /// Ensure `path` exists with `content` if absent, returning the resulting
     /// file contents. Existing files are preserved.
     async fn ensure_file(&self, _path: &Path, content: &str) -> Result<String, String> {

--- a/crates/flotilla-daemon/src/agent_material.rs
+++ b/crates/flotilla-daemon/src/agent_material.rs
@@ -8,7 +8,7 @@ use std::{
 use async_trait::async_trait;
 use flotilla_core::providers::{
     discovery::EnvVars,
-    environment::{ProvisionedMount, ProvisionedMountMode},
+    environment::{runner::CONTAINED_CODEX_HOME, ProvisionedMount, ProvisionedMountMode},
 };
 use flotilla_protocol::ResourceRef;
 use flotilla_resources::{api_version, Environment, MaterialPoolSpec, MaterialPoolUnitSpec, Resource, ResourceBackend};
@@ -22,7 +22,7 @@ use crate::{
 
 const CODEX_ADAPTER_ID: &str = "codex";
 const CODEX_POOL_REF: &str = "codex-login";
-pub(crate) const CONTAINER_CODEX_HOME: &str = "/run/flotilla/codex";
+pub(crate) const CONTAINER_CODEX_HOME: &str = CONTAINED_CODEX_HOME;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AgentMaterialPreflight {

--- a/crates/flotilla-daemon/src/credential.rs
+++ b/crates/flotilla-daemon/src/credential.rs
@@ -21,8 +21,6 @@ use url::Url;
 
 use crate::vessel_config::{agent_environment_fragment, compose, Fragment, GitConfigKey, Merge, Provenance, TargetId, TargetKey};
 
-const GIT_CONFIG_PATH: &str = "/run/flotilla/credentials/gitconfig";
-
 #[derive(Serialize)]
 struct GithubAppJwtClaims {
     iat: i64,
@@ -82,6 +80,22 @@ struct GitCredentialContribution {
     preflight: Option<GitCredentialPreflight>,
 }
 
+struct CredentialDeliveryPaths {
+    base: PathBuf,
+    git_config: PathBuf,
+}
+
+impl CredentialDeliveryPaths {
+    fn new(base: PathBuf) -> Self {
+        let git_config = base.join("credentials/gitconfig");
+        Self { base, git_config }
+    }
+
+    fn credential_dir(&self, name: &str) -> PathBuf {
+        self.base.join("credentials").join(safe_component(name))
+    }
+}
+
 #[derive(bon::Builder)]
 struct PendingGitPreflight {
     credential_name: String,
@@ -97,7 +111,8 @@ enum GitCredentialPreflight {
 }
 
 impl GitCredentialPreflight {
-    async fn run(&self, runner: &dyn CommandRunner, material: &str) -> Result<(), String> {
+    async fn run(&self, runner: &dyn CommandRunner, material: &str, git_config_path: &Path) -> Result<(), String> {
+        let git_config_path = git_config_path.to_string_lossy();
         match self {
             Self::Gh => {
                 runner
@@ -107,7 +122,7 @@ impl GitCredentialPreflight {
                             "-c",
                             "IFS= read -r token; export GH_TOKEN=\"$token\" GIT_CONFIG_GLOBAL=\"$1\" GIT_TERMINAL_PROMPT=0; printf 'protocol=https\\nhost=github.com\\n\\n' | git credential fill >/dev/null",
                             "flotilla-gh-git-preflight",
-                            GIT_CONFIG_PATH,
+                            &git_config_path,
                         ],
                         Path::new("/"),
                         &ChannelLabel::Noop,
@@ -124,7 +139,7 @@ impl GitCredentialPreflight {
                         "-c",
                         "export GIT_CONFIG_GLOBAL=\"$1\" GIT_TERMINAL_PROMPT=0 FORGEJO_TOKEN_FILE=\"$2\" FORGEJO_USERNAME=\"$3\"; printf 'protocol=https\\nhost=%s\\n\\n' \"$4\" | git credential fill >/dev/null",
                         "flotilla-forgejo-git-preflight",
-                        GIT_CONFIG_PATH,
+                        &git_config_path,
                         token_file,
                         username,
                         host,
@@ -184,8 +199,27 @@ impl CredentialStore {
         for name in credential_refs {
             let spec = self.spec(name).await?;
             match spec.consumer {
-                CredentialConsumer::Codex if !environment.contains_key("CODEX_HOME") => fragments.push(codex_home_fragment(name)),
+                CredentialConsumer::Codex if !environment.contains_key("CODEX_HOME") => {
+                    fragments.push(codex_home_fragment(name, format!("credential-delivery-pending:{name}")))
+                }
                 _ => {}
+            }
+        }
+        Ok(fragments)
+    }
+
+    pub(crate) async fn vessel_config_fragments_for_runner(
+        &self,
+        credential_refs: &BTreeSet<String>,
+        environment: &BTreeMap<String, String>,
+        runner: &dyn CommandRunner,
+    ) -> Result<Vec<Fragment>, String> {
+        let paths = self.delivery_paths(runner).await?;
+        let mut fragments = Vec::new();
+        for name in credential_refs {
+            let spec = self.spec(name).await?;
+            if matches!(spec.consumer, CredentialConsumer::Codex) && !environment.contains_key("CODEX_HOME") {
+                fragments.push(codex_home_fragment(name, paths.credential_dir(name).join("codex").to_string_lossy()));
             }
         }
         Ok(fragments)
@@ -282,6 +316,23 @@ impl CredentialStore {
                 ));
             }
         }
+        if specs.is_empty() {
+            return Ok(Vec::new());
+        }
+        let delivery_paths = if specs.iter().any(|(_, spec)| {
+            matches!(
+                spec.consumer,
+                CredentialConsumer::Gh
+                    | CredentialConsumer::GithubApp { .. }
+                    | CredentialConsumer::Forgejo { .. }
+                    | CredentialConsumer::ClaudeOauth { .. }
+                    | CredentialConsumer::Codex
+            )
+        }) {
+            Some(self.delivery_paths(&*runner).await?)
+        } else {
+            None
+        };
         let mut env = BTreeMap::new();
         let mut new_git_config_fragments = BTreeMap::new();
         let mut git_config_owner = None;
@@ -311,13 +362,14 @@ impl CredentialStore {
                 self.materials.lock().await.remove(&cache_key);
                 return Err(error);
             }
-            let delivered = match self.prepare_adapter(name, spec, material, Arc::clone(&runner), already_prepared).await {
-                Ok(delivered) => delivered,
-                Err(message) => {
-                    self.materials.lock().await.remove(&cache_key);
-                    return Err(bounded_adapter_error(name, spec.consumer.adapter_name(), &message.replace(material, "[redacted]")));
-                }
-            };
+            let delivered =
+                match self.prepare_adapter(name, spec, material, Arc::clone(&runner), already_prepared, delivery_paths.as_ref()).await {
+                    Ok(delivered) => delivered,
+                    Err(message) => {
+                        self.materials.lock().await.remove(&cache_key);
+                        return Err(bounded_adapter_error(name, spec.consumer.adapter_name(), &message.replace(material, "[redacted]")));
+                    }
+                };
             env.extend(delivered.env);
             if let Some(git_credential) = delivered.git_credential {
                 git_config_owner.get_or_insert_with(|| (name.clone(), spec.consumer.adapter_name().to_string(), cache_key.clone()));
@@ -344,15 +396,16 @@ impl CredentialStore {
                 Ok(gitconfig) => gitconfig,
                 Err(error) => return Err(format!("compose shared Git config: {error}")),
             };
-            if let Err(error) = runner.write_file(Path::new(GIT_CONFIG_PATH), &gitconfig.contents).await {
+            let delivery_paths = delivery_paths.as_ref().expect("Git credential adapters resolve delivery paths");
+            if let Err(error) = runner.write_file(&delivery_paths.git_config, &gitconfig.contents).await {
                 let (name, adapter, cache_key) = git_config_owner.expect("Git config fragments have an owner");
                 self.materials.lock().await.remove(&cache_key);
                 return Err(bounded_adapter_error(&name, &adapter, &format!("write shared Git config: {error}")));
             }
-            env.insert("GIT_CONFIG_GLOBAL".to_string(), GIT_CONFIG_PATH.to_string());
+            env.insert("GIT_CONFIG_GLOBAL".to_string(), delivery_paths.git_config.to_string_lossy().into_owned());
             env.insert("GIT_TERMINAL_PROMPT".to_string(), "0".to_string());
             for pending in pending_git_preflights {
-                if let Err(message) = pending.preflight.run(&*runner, &pending.material).await {
+                if let Err(message) = pending.preflight.run(&*runner, &pending.material, &delivery_paths.git_config).await {
                     self.materials.lock().await.remove(&pending.cache_key);
                     return Err(bounded_adapter_error(
                         &pending.credential_name,
@@ -622,7 +675,14 @@ impl CredentialStore {
         let runtime_dir =
             self.env.get("XDG_RUNTIME_DIR").map(|value| PathBuf::from(value.trim())).filter(|value| !value.as_os_str().is_empty());
         let base = runner.writable_scratch_base(runtime_dir.as_deref(), &self.state_dir).await?;
-        Ok(base.join("credentials").join(safe_component(credential_name)).join("claude").to_string_lossy().into_owned())
+        Ok(base.join("credentials").join(safe_component(credential_name)).join("claude-preflight").to_string_lossy().into_owned())
+    }
+
+    async fn delivery_paths(&self, runner: &dyn CommandRunner) -> Result<CredentialDeliveryPaths, String> {
+        let runtime_dir =
+            self.env.get("XDG_RUNTIME_DIR").map(|value| PathBuf::from(value.trim())).filter(|value| !value.as_os_str().is_empty());
+        let base = runner.writable_config_base(runtime_dir.as_deref(), &self.state_dir).await?;
+        Ok(CredentialDeliveryPaths::new(base))
     }
 
     async fn prepare_adapter(
@@ -632,6 +692,7 @@ impl CredentialStore {
         material: &str,
         runner: Arc<dyn CommandRunner>,
         already_prepared: bool,
+        delivery_paths: Option<&CredentialDeliveryPaths>,
     ) -> Result<AdapterDelivery, String> {
         let mut env = BTreeMap::new();
         let mut git_credential = None;
@@ -673,6 +734,7 @@ impl CredentialStore {
                 });
             }
             CredentialConsumer::Forgejo { api_url, username } => {
+                let delivery_paths = delivery_paths.expect("Forgejo adapter resolves delivery paths");
                 let server_url = api_url.trim_end_matches('/');
                 let parsed_url = Url::parse(server_url).map_err(|error| format!("invalid Forgejo server URL: {error}"))?;
                 if parsed_url.scheme() != "https" {
@@ -683,8 +745,9 @@ impl CredentialStore {
                     Some(port) => format!("https://{host}:{port}"),
                     None => format!("https://{host}"),
                 };
-                let path = format!("/run/flotilla/credentials/{}/token", safe_component(name));
-                let helper_path = format!("/run/flotilla/credentials/{}/git-credential-forgejo", safe_component(name));
+                let credential_dir = delivery_paths.credential_dir(name);
+                let path = credential_dir.join("token").to_string_lossy().into_owned();
+                let helper_path = credential_dir.join("git-credential-forgejo").to_string_lossy().into_owned();
                 if !already_prepared {
                     runner.write_file(Path::new(&path), material).await.map_err(|error| format!("write token file: {error}"))?;
                     runner
@@ -753,6 +816,7 @@ impl CredentialStore {
             // mutable config path and exports it in the launch plan. See
             // docs/research/2026-07-28-multi-crew-agent-config-seeding.md.
             CredentialConsumer::ClaudeOauth { .. } => {
+                let delivery_paths = delivery_paths.expect("Claude OAuth adapter resolves delivery paths");
                 if !runner.exists("claude", &["--version"]).await {
                     return Err("consumer binary is unavailable".to_string());
                 }
@@ -813,10 +877,14 @@ impl CredentialStore {
                     probe?;
                 }
                 env.insert("CLAUDE_CODE_OAUTH_TOKEN".to_string(), material.to_string());
+                env.insert(
+                    "CLAUDE_CONFIG_DIR".to_string(),
+                    delivery_paths.credential_dir(name).join("claude").to_string_lossy().into_owned(),
+                );
             }
             CredentialConsumer::Codex => {
-                let codex_home_fragment = codex_home_fragment(name);
-                let codex_home = codex_home_fragment.value;
+                let delivery_paths = delivery_paths.expect("Codex adapter resolves delivery paths");
+                let codex_home = delivery_paths.credential_dir(name).join("codex").to_string_lossy().into_owned();
                 if !already_prepared {
                     runner
                         .run("mkdir", &["-p", &codex_home], Path::new("/"), &ChannelLabel::Noop)
@@ -865,12 +933,8 @@ fn git_credential_fragment(credential_name: &str, adapter: &str, credential_url:
         .build()
 }
 
-fn codex_home_fragment(credential_name: &str) -> Fragment {
-    agent_environment_fragment(
-        "CODEX_HOME",
-        format!("/run/flotilla/credentials/{}/codex", safe_component(credential_name)),
-        format!("credential/codex {credential_name}"),
-    )
+fn codex_home_fragment(credential_name: &str, path: impl Into<String>) -> Fragment {
+    agent_environment_fragment("CODEX_HOME", path, format!("credential/codex {credential_name}"))
 }
 
 async fn api_key_preflight(runner: &dyn CommandRunner, url: &str, headers: &[(&str, &str)]) -> Result<(), String> {
@@ -1269,12 +1333,14 @@ interactions:
 
         assert_eq!(delivered.len(), 1);
         assert_eq!(delivered[0].0, "CODEX_HOME");
+        assert_eq!(delivered[0].1, "/tmp/flotilla-test-state/credentials/model-api/codex");
         assert!(!delivered.iter().any(|(name, value)| name == "OPENAI_API_KEY" || value == secret));
         let calls = runner.calls.lock().expect("calls lock");
         assert!(calls.iter().any(|(cmd, args, input)| {
             cmd == "sh" && args.iter().any(|arg| arg == "CODEX_HOME=\"$1\" codex login --with-api-key") && input == secret.as_bytes()
         }));
         assert!(calls.iter().any(|(cmd, args, _)| cmd == "sh" && args.iter().any(|arg| arg.contains("codex login status"))));
+        assert!(calls.iter().flat_map(|(_, args, _)| args).all(|arg| !arg.starts_with("/run/flotilla")));
         assert!(calls.iter().flat_map(|(_, args, _)| args).all(|arg| !arg.contains(secret)));
     }
 
@@ -1314,26 +1380,30 @@ interactions:
         );
         let delivered = store.prepare("env-a", &credential_refs, runner.clone()).await.expect("prepare claude-oauth credential");
 
-        assert_eq!(delivered.len(), 1);
+        assert_eq!(delivered.len(), 2);
         assert!(
             delivered.iter().any(|(name, value)| name == "CLAUDE_CODE_OAUTH_TOKEN" && value == secret),
             "the OAuth token must be delivered under CLAUDE_CODE_OAUTH_TOKEN"
         );
-        assert!(delivered.iter().all(|(name, _)| name != "CLAUDE_CONFIG_DIR"));
+        assert!(delivered
+            .iter()
+            .any(|(name, value)| { name == "CLAUDE_CONFIG_DIR" && value == "/tmp/flotilla-test-state/credentials/claude-max/claude" }));
         let calls = runner.calls.lock().expect("calls lock");
         assert!(calls
             .iter()
-            .any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/tmp/flotilla-test-state/credentials/claude-max/claude"]));
+            .any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/tmp/flotilla-test-state/credentials/claude-max/claude-preflight"]));
         assert!(calls.iter().any(|(cmd, args, input)| {
             cmd == "sh"
                 && args.iter().any(|arg| arg.contains("unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN"))
                 && args.iter().any(|arg| arg.contains("CLAUDE_CODE_OAUTH_TOKEN=\"$token\"") && arg.contains("claude -p"))
                 && args.iter().any(|arg| arg.contains("claude -p ok 2>&1") && arg.contains("printf '%s\\n' \"$output\" >&2"))
-                && args.iter().any(|arg| arg == "/tmp/flotilla-test-state/credentials/claude-max/claude")
+                && args.iter().any(|arg| arg == "/tmp/flotilla-test-state/credentials/claude-max/claude-preflight")
                 && input == secret.as_bytes()
         }));
         assert!(
-            calls.iter().any(|(cmd, args, _)| cmd == "rm" && args == &["-rf", "/tmp/flotilla-test-state/credentials/claude-max/claude"]),
+            calls
+                .iter()
+                .any(|(cmd, args, _)| cmd == "rm" && args == &["-rf", "/tmp/flotilla-test-state/credentials/claude-max/claude-preflight"]),
             "the preflight scratch directory must not outlive the probe"
         );
         assert!(calls.iter().flat_map(|(_, args, _)| args).all(|arg| !arg.contains(secret)));
@@ -1356,9 +1426,9 @@ interactions:
         let calls = runner.calls.lock().expect("calls lock");
         assert!(calls
             .iter()
-            .any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/run/user/1000/flotilla/credentials/claude-max/claude"]));
+            .any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/run/user/1000/flotilla/credentials/claude-max/claude-preflight"]));
         assert!(calls.iter().any(|(cmd, args, _)| {
-            cmd == "sh" && args.iter().any(|arg| arg == "/run/user/1000/flotilla/credentials/claude-max/claude")
+            cmd == "sh" && args.iter().any(|arg| arg == "/run/user/1000/flotilla/credentials/claude-max/claude-preflight")
         }));
         assert!(
             calls.iter().flat_map(|(_, args, _)| args).all(|arg| !arg.starts_with("/run/flotilla")),
@@ -1383,7 +1453,7 @@ interactions:
         let calls = runner.calls.lock().expect("calls lock");
         assert!(calls
             .iter()
-            .any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/tmp/flotilla-test-state/credentials/claude-max/claude"]));
+            .any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/tmp/flotilla-test-state/credentials/claude-max/claude-preflight"]));
     }
 
     #[tokio::test]
@@ -1394,7 +1464,7 @@ interactions:
             ("TEST_CLAUDE_TOKEN".to_string(), "sk-ant-oat01-test-token".to_string()),
             ("XDG_RUNTIME_DIR".to_string(), "/run/user/1000-removed".to_string()),
         ])));
-        let runner = Arc::new(RecordingRunner::with_runtime_dir_checks([false]));
+        let runner = Arc::new(RecordingRunner::with_runtime_dir_checks([false, false]));
         let bag = EnvironmentBag::new().with(EnvironmentAssertion::binary("claude", "/usr/bin/claude"));
         let store = CredentialStore::new(backend, "flotilla", env, bag, runner.clone(), PathBuf::from("/tmp/flotilla-test-state"));
 
@@ -1403,10 +1473,10 @@ interactions:
         let calls = runner.calls.lock().expect("calls lock");
         assert!(calls
             .iter()
-            .any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/tmp/flotilla-test-state/credentials/claude-max/claude"]));
-        assert!(calls
-            .iter()
-            .all(|(cmd, args, _)| { cmd != "mkdir" || args != &["-p", "/run/user/1000-removed/flotilla/credentials/claude-max/claude"] }));
+            .any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/tmp/flotilla-test-state/credentials/claude-max/claude-preflight"]));
+        assert!(calls.iter().all(|(cmd, args, _)| {
+            cmd != "mkdir" || args != &["-p", "/run/user/1000-removed/flotilla/credentials/claude-max/claude-preflight"]
+        }));
     }
 
     #[tokio::test]
@@ -1417,7 +1487,7 @@ interactions:
             ("TEST_CLAUDE_TOKEN".to_string(), "sk-ant-oat01-test-token".to_string()),
             ("XDG_RUNTIME_DIR".to_string(), "/run/user/1000".to_string()),
         ])));
-        let runner = Arc::new(RecordingRunner::with_runtime_dir_checks([true, false]));
+        let runner = Arc::new(RecordingRunner::with_runtime_dir_checks([true, true, false, false]));
         let bag = EnvironmentBag::new().with(EnvironmentAssertion::binary("claude", "/usr/bin/claude"));
         let store = CredentialStore::new(backend, "flotilla", env, bag, runner.clone(), PathBuf::from("/tmp/flotilla-test-state"));
         let credential_refs = BTreeSet::from(["claude-max".to_string()]);
@@ -1428,10 +1498,10 @@ interactions:
         let calls = runner.calls.lock().expect("calls lock");
         assert!(calls
             .iter()
-            .any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/run/user/1000/flotilla/credentials/claude-max/claude"]));
+            .any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/run/user/1000/flotilla/credentials/claude-max/claude-preflight"]));
         assert!(calls
             .iter()
-            .any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/tmp/flotilla-test-state/credentials/claude-max/claude"]));
+            .any(|(cmd, args, _)| cmd == "mkdir" && args == &["-p", "/tmp/flotilla-test-state/credentials/claude-max/claude-preflight"]));
     }
 
     #[tokio::test]
@@ -1474,8 +1544,8 @@ interactions:
 
         assert_eq!(alice.get("CLAUDE_CODE_OAUTH_TOKEN"), Some(&"token-alice".to_string()));
         assert_eq!(bob.get("CLAUDE_CODE_OAUTH_TOKEN"), Some(&"token-bob".to_string()));
-        assert!(!alice.contains_key("CLAUDE_CONFIG_DIR"));
-        assert!(!bob.contains_key("CLAUDE_CONFIG_DIR"));
+        assert_eq!(alice.get("CLAUDE_CONFIG_DIR"), Some(&"/tmp/flotilla-test-state/credentials/claude-alice/claude".to_string()));
+        assert_eq!(bob.get("CLAUDE_CONFIG_DIR"), Some(&"/tmp/flotilla-test-state/credentials/claude-bob/claude".to_string()));
 
         let error = store
             .prepare("env-c", &BTreeSet::from(["claude-alice".to_string(), "claude-bob".to_string()]), runner.clone())
@@ -1700,12 +1770,12 @@ interactions:
 
         assert_eq!(delivered, vec![
             ("GH_TOKEN".to_string(), secret.to_string()),
-            ("GIT_CONFIG_GLOBAL".to_string(), "/run/flotilla/credentials/gitconfig".to_string()),
+            ("GIT_CONFIG_GLOBAL".to_string(), "/tmp/flotilla-test-state/credentials/gitconfig".to_string()),
             ("GIT_TERMINAL_PROMPT".to_string(), "0".to_string()),
         ]);
         let writes = runner.writes.lock().expect("writes lock");
         assert_eq!(writes.as_slice(), &[(
-            PathBuf::from("/run/flotilla/credentials/gitconfig"),
+            PathBuf::from("/tmp/flotilla-test-state/credentials/gitconfig"),
             "# fragment: credential/gh github\n[credential \"https://github.com\"]\n\thelper = !gh auth git-credential\n".to_string()
         )]);
         let calls = runner.calls.lock().expect("calls lock");
@@ -1715,6 +1785,7 @@ interactions:
         assert!(calls.iter().any(|(cmd, args, input)| {
             cmd == "sh" && args.iter().any(|arg| arg.contains("GIT_CONFIG_GLOBAL")) && input == secret.as_bytes()
         }));
+        assert!(calls.iter().flat_map(|(_, args, _)| args).all(|arg| !arg.starts_with("/run/flotilla")));
         assert!(calls.iter().flat_map(|(_, args, _)| args).all(|arg| !arg.contains(secret)));
     }
 
@@ -1750,7 +1821,7 @@ interactions:
             .into_iter()
             .collect();
 
-        assert_eq!(delivered.get("GIT_CONFIG_GLOBAL"), Some(&"/run/flotilla/credentials/gitconfig".to_string()));
+        assert_eq!(delivered.get("GIT_CONFIG_GLOBAL"), Some(&"/tmp/flotilla-test-state/credentials/gitconfig".to_string()));
         assert_eq!(delivered.get("GIT_TERMINAL_PROMPT"), Some(&"0".to_string()));
         assert!(!delivered
             .keys()
@@ -1759,12 +1830,13 @@ interactions:
         let gitconfig = writes
             .iter()
             .rev()
-            .find(|(path, _)| path == Path::new("/run/flotilla/credentials/gitconfig"))
+            .find(|(path, _)| path == Path::new("/tmp/flotilla-test-state/credentials/gitconfig"))
             .map(|(_, content)| content)
             .expect("staged shared Git config");
         assert!(gitconfig.contains("[credential \"https://github.com\"]\n\thelper = !gh auth git-credential"));
-        assert!(gitconfig
-            .contains("[credential \"https://forgejo.lab\"]\n\thelper = !/run/flotilla/credentials/lab-forgejo/git-credential-forgejo"));
+        assert!(gitconfig.contains(
+            "[credential \"https://forgejo.lab\"]\n\thelper = !/tmp/flotilla-test-state/credentials/lab-forgejo/git-credential-forgejo"
+        ));
         assert!(gitconfig.contains("# fragment: credential/gh github"));
         assert!(gitconfig.contains("# fragment: credential/forgejo lab-forgejo"));
         let calls = runner.calls.lock().expect("calls lock");
@@ -1813,12 +1885,13 @@ interactions:
         let gitconfig = writes
             .iter()
             .rev()
-            .find(|(path, _)| path == Path::new("/run/flotilla/credentials/gitconfig"))
+            .find(|(path, _)| path == Path::new("/tmp/flotilla-test-state/credentials/gitconfig"))
             .map(|(_, content)| content)
             .expect("staged shared Git config");
         assert!(gitconfig.contains("[credential \"https://github.com\"]\n\thelper = !gh auth git-credential"));
-        assert!(gitconfig
-            .contains("[credential \"https://forgejo.lab\"]\n\thelper = !/run/flotilla/credentials/lab-forgejo/git-credential-forgejo"));
+        assert!(gitconfig.contains(
+            "[credential \"https://forgejo.lab\"]\n\thelper = !/tmp/flotilla-test-state/credentials/lab-forgejo/git-credential-forgejo"
+        ));
     }
 
     #[tokio::test]
@@ -1847,14 +1920,14 @@ interactions:
         assert_eq!(delivered, vec![
             ("FORGEJO_API_URL".to_string(), "https://forgejo.lab/api/v1".to_string()),
             ("FORGEJO_SERVER_URL".to_string(), "https://forgejo.lab".to_string()),
-            ("FORGEJO_TOKEN_FILE".to_string(), "/run/flotilla/credentials/lab-forgejo/token".to_string()),
+            ("FORGEJO_TOKEN_FILE".to_string(), "/tmp/flotilla-test-state/credentials/lab-forgejo/token".to_string()),
             ("FORGEJO_USERNAME".to_string(), "flotilla-crew".to_string()),
-            ("GIT_CONFIG_GLOBAL".to_string(), "/run/flotilla/credentials/gitconfig".to_string()),
+            ("GIT_CONFIG_GLOBAL".to_string(), "/tmp/flotilla-test-state/credentials/gitconfig".to_string()),
             ("GIT_TERMINAL_PROMPT".to_string(), "0".to_string()),
         ]);
         let writes = runner.writes.lock().expect("writes lock");
-        assert_eq!(writes[0], (PathBuf::from("/run/flotilla/credentials/lab-forgejo/token"), secret.to_string()));
-        assert_eq!(writes[1].0, PathBuf::from("/run/flotilla/credentials/lab-forgejo/git-credential-forgejo"));
+        assert_eq!(writes[0], (PathBuf::from("/tmp/flotilla-test-state/credentials/lab-forgejo/token"), secret.to_string()));
+        assert_eq!(writes[1].0, PathBuf::from("/tmp/flotilla-test-state/credentials/lab-forgejo/git-credential-forgejo"));
         assert!(writes[1].1.contains("[ \"$protocol\" = https ]"));
         assert!(writes[1].1.contains("[ \"$host\" = forgejo.lab ]"));
         assert!(writes[1].1.contains("$FORGEJO_USERNAME"));
@@ -1862,21 +1935,24 @@ interactions:
         assert_eq!(
             writes[2],
             (
-                PathBuf::from("/run/flotilla/credentials/gitconfig"),
-                "# fragment: credential/forgejo lab-forgejo\n[credential \"https://forgejo.lab\"]\n\thelper = !/run/flotilla/credentials/lab-forgejo/git-credential-forgejo\n".to_string()
+                PathBuf::from("/tmp/flotilla-test-state/credentials/gitconfig"),
+                "# fragment: credential/forgejo lab-forgejo\n[credential \"https://forgejo.lab\"]\n\thelper = !/tmp/flotilla-test-state/credentials/lab-forgejo/git-credential-forgejo\n".to_string()
             )
         );
         let calls = runner.calls.lock().expect("calls lock");
-        assert!(calls.iter().any(|(cmd, args, _)| cmd == "chmod" && args == &["0600", "/run/flotilla/credentials/lab-forgejo/token"]));
         assert!(calls
             .iter()
-            .any(|(cmd, args, _)| { cmd == "chmod" && args == &["0700", "/run/flotilla/credentials/lab-forgejo/git-credential-forgejo"] }));
+            .any(|(cmd, args, _)| cmd == "chmod" && args == &["0600", "/tmp/flotilla-test-state/credentials/lab-forgejo/token"]));
+        assert!(calls.iter().any(|(cmd, args, _)| {
+            cmd == "chmod" && args == &["0700", "/tmp/flotilla-test-state/credentials/lab-forgejo/git-credential-forgejo"]
+        }));
         assert!(calls.iter().any(|(cmd, args, input)| {
             cmd == "curl"
                 && args == &["--config", "-"]
                 && String::from_utf8_lossy(input).contains("https://forgejo.lab/api/v1/user")
                 && String::from_utf8_lossy(input).contains(secret)
         }));
+        assert!(calls.iter().flat_map(|(_, args, _)| args).all(|arg| !arg.starts_with("/run/flotilla")));
         assert!(calls.iter().flat_map(|(_, args, _)| args).all(|arg| !arg.contains(secret)));
     }
 
@@ -1947,7 +2023,7 @@ interactions:
             .collect();
 
         assert_eq!(delivered.get("FORGEJO_SERVER_URL"), Some(&"https://forgejo.lab:3000".to_string()));
-        assert_eq!(delivered.get("GIT_CONFIG_GLOBAL"), Some(&"/run/flotilla/credentials/gitconfig".to_string()));
+        assert_eq!(delivered.get("GIT_CONFIG_GLOBAL"), Some(&"/tmp/flotilla-test-state/credentials/gitconfig".to_string()));
         let writes = runner.writes.lock().expect("writes lock");
         assert!(
             writes[1].1.contains("[ \"$host\" = forgejo.lab:3000 ]"),

--- a/crates/flotilla-daemon/src/credential.rs
+++ b/crates/flotilla-daemon/src/credential.rs
@@ -214,15 +214,21 @@ impl CredentialStore {
         environment: &BTreeMap<String, String>,
         runner: &dyn CommandRunner,
     ) -> Result<Vec<Fragment>, String> {
-        let paths = self.delivery_paths(runner).await?;
-        let mut fragments = Vec::new();
+        let mut codex_credentials = Vec::new();
         for name in credential_refs {
             let spec = self.spec(name).await?;
             if matches!(spec.consumer, CredentialConsumer::Codex) && !environment.contains_key("CODEX_HOME") {
-                fragments.push(codex_home_fragment(name, paths.credential_dir(name).join("codex").to_string_lossy()));
+                codex_credentials.push(name);
             }
         }
-        Ok(fragments)
+        if codex_credentials.is_empty() {
+            return Ok(Vec::new());
+        }
+        let paths = self.delivery_paths(runner).await?;
+        Ok(codex_credentials
+            .into_iter()
+            .map(|name| codex_home_fragment(name, paths.credential_dir(name).join("codex").to_string_lossy()))
+            .collect())
     }
 
     pub(crate) async fn held_credentials(&self) -> Result<BTreeSet<String>, String> {

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -60,7 +60,7 @@ use crate::{
     resource_manifest::ResourceManifestReconciler,
     sleep_inhibitor,
     supervisor::{supervise, ControllerSupervision, RestartBudgetExhausted},
-    vessel_config::{compose, ComposedFile, Fragment, TargetId, AGENT_ENVIRONMENT_PATH},
+    vessel_config::{compose, ComposedFile, Fragment, TargetId},
     Aggregator, AggregatorResolvers,
 };
 
@@ -81,6 +81,14 @@ fn compose_agent_environment(fragments: impl IntoIterator<Item = Fragment>) -> R
         return Ok(None);
     }
     compose(TargetId::AgentEnvironment, fragments).map(Some).map_err(|error| format!("compose shared agent environment: {error}"))
+}
+
+async fn stage_agent_environment(runner: &dyn CommandRunner, fallback: &Path, contents: &str) -> Result<PathBuf, String> {
+    let config_base =
+        runner.writable_config_base(None, fallback).await.map_err(|error| format!("resolve agent environment path: {error}"))?;
+    let path = config_base.join("agent-environment");
+    runner.write_file(&path, contents).await.map_err(|error| format!("stage composed agent environment: {error}"))?;
+    Ok(path)
 }
 
 struct DaemonConvoyTeardownRuntime {
@@ -1868,20 +1876,23 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
             .as_deref()
             .map(|registry| registry.fragments(&spec.required_agent_adapters, &spec.env))
             .unwrap_or_default();
-        let agent_environment = match compose_agent_environment(credential_config_fragments.into_iter().chain(agent_material_fragments)) {
-            Ok(composed) => composed,
-            Err(error) => {
-                return Err(discard_uncreated_environment(
-                    self.state.credential_store.as_deref(),
-                    self.state.agent_material.as_deref(),
-                    name,
-                    error,
-                )
-                .await
-                .into())
-            }
-        };
-        if let Some(composed) = &agent_environment {
+        let agent_environment_claims =
+            match compose_agent_environment(credential_config_fragments.iter().cloned().chain(agent_material_fragments.iter().cloned())) {
+                Ok(composed) => composed,
+                Err(error) => {
+                    return Err(discard_uncreated_environment(
+                        self.state.credential_store.as_deref(),
+                        self.state.agent_material.as_deref(),
+                        name,
+                        error,
+                    )
+                    .await
+                    .into())
+                }
+            };
+        let creation_agent_environment = compose_agent_environment(agent_material_fragments.iter().cloned())
+            .expect("agent material fragments already composed successfully with credential claims");
+        if let Some(composed) = &creation_agent_environment {
             for (name, value) in &composed.environment {
                 if !environment_variables.iter().any(|(existing, _)| existing == name) {
                     environment_variables.push((name.clone(), value.clone()));
@@ -1961,19 +1972,7 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
             }
         };
         let image_ref = handle.image().as_str().to_string();
-        if let Some(composed) = &agent_environment {
-            if let Err(error) = handle.runner().write_file(Path::new(AGENT_ENVIRONMENT_PATH), &composed.contents).await {
-                return Err(discard_failed_environment(
-                    &handle,
-                    self.state.credential_store.as_deref(),
-                    self.state.agent_material.as_deref(),
-                    name,
-                    format!("stage composed agent environment: {error}"),
-                )
-                .await
-                .into());
-            }
-        }
+        drop(agent_environment_claims);
         let image_digest = match handle.image_digest() {
             Some(digest) => digest.to_string(),
             None => {
@@ -2006,6 +2005,41 @@ impl DockerEnvironmentRuntime for DockerControllerRuntime {
             )
             .await
             .into());
+        }
+        let resolved_credential_fragments = match &self.state.credential_store {
+            Some(store) => match store.vessel_config_fragments_for_runner(&credential_refs, &spec.env, &*handle.runner()).await {
+                Ok(fragments) => fragments,
+                Err(error) => {
+                    return Err(discard_failed_environment(
+                        &handle,
+                        self.state.credential_store.as_deref(),
+                        self.state.agent_material.as_deref(),
+                        name,
+                        error,
+                    )
+                    .await
+                    .into())
+                }
+            },
+            None => Vec::new(),
+        };
+        let resolved_agent_environment =
+            compose_agent_environment(resolved_credential_fragments.into_iter().chain(agent_material_fragments.iter().cloned()))
+                .expect("resolved fragments preserve the successfully checked agent environment claims");
+        if let Some(composed) = &resolved_agent_environment {
+            if let Err(error) =
+                stage_agent_environment(&*handle.runner(), self.state.config.state_dir().as_path(), &composed.contents).await
+            {
+                return Err(discard_failed_environment(
+                    &handle,
+                    self.state.credential_store.as_deref(),
+                    self.state.agent_material.as_deref(),
+                    name,
+                    error,
+                )
+                .await
+                .into());
+            }
         }
         for delivery in &material_deliveries {
             let args = delivery.preflight.args.iter().map(String::as_str).collect::<Vec<_>>();
@@ -3484,6 +3518,51 @@ mod tests {
     }
 
     struct CredentialInteriorRunner(DiscoveryMockRunner);
+
+    #[derive(Default)]
+    struct PersistentPathRecordingRunner {
+        writes: StdMutex<Vec<(PathBuf, String)>>,
+    }
+
+    #[async_trait]
+    impl CommandRunner for PersistentPathRecordingRunner {
+        async fn run(&self, _cmd: &str, _args: &[&str], _cwd: &Path, _label: &ChannelLabel) -> Result<String, String> {
+            Ok(String::new())
+        }
+
+        async fn run_output(&self, _cmd: &str, _args: &[&str], _cwd: &Path, _label: &ChannelLabel) -> Result<CommandOutput, String> {
+            Ok(CommandOutput { stdout: String::new(), stderr: String::new(), success: true })
+        }
+
+        async fn exists(&self, _cmd: &str, _args: &[&str]) -> bool {
+            true
+        }
+
+        async fn writable_config_base(&self, _preferred: Option<&Path>, _fallback: &Path) -> Result<PathBuf, String> {
+            Ok(PathBuf::from("/home/crew/flotilla"))
+        }
+
+        async fn write_file(&self, path: &Path, content: &str) -> Result<(), String> {
+            self.writes.lock().expect("writes lock").push((path.to_path_buf(), content.to_string()));
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn agent_environment_is_staged_at_the_runner_writable_config_base() {
+        let runner = PersistentPathRecordingRunner::default();
+
+        let path = stage_agent_environment(&runner, Path::new("/host/state"), "export CODEX_HOME='/mounted/codex'\n")
+            .await
+            .expect("stage agent environment");
+
+        assert_eq!(path, Path::new("/home/crew/flotilla/agent-environment"));
+        assert_eq!(runner.writes.lock().expect("writes lock").as_slice(), &[(
+            PathBuf::from("/home/crew/flotilla/agent-environment"),
+            "export CODEX_HOME='/mounted/codex'\n".to_string()
+        )]);
+        assert!(!path.starts_with("/run/flotilla"));
+    }
 
     #[async_trait]
     impl CommandRunner for CredentialInteriorRunner {
@@ -7228,12 +7307,13 @@ mod tests {
         // Credential preflight runs through the contained runner, so its
         // scratch directory must be inside the container user's writable
         // world rather than derived from daemon-host paths (#1508).
-        let preflight_config_dir = PathBuf::from("/home/crew/flotilla/credentials/claude-max/claude");
+        let preflight_config_dir = PathBuf::from("/home/crew/flotilla/credentials/claude-max/claude-preflight");
+        let crew_config_dir = PathBuf::from("/home/crew/flotilla/credentials/claude-max/claude");
         let runner: Arc<dyn CommandRunner> = Arc::new(CredentialInteriorRunner(
             DiscoveryMockRunner::builder()
                 .tool_exists("claude", true)
                 .on_run("mkdir", &["-p", &preflight_config_dir.to_string_lossy()], Ok(String::new()))
-                .on_run("mkdir", &["-p", "/run/flotilla/claude"], Ok(String::new()))
+                .on_run("mkdir", &["-p", &crew_config_dir.to_string_lossy()], Ok(String::new()))
                 .build(),
         ));
         let bag = EnvironmentBag::new()
@@ -7316,7 +7396,10 @@ mod tests {
             "the contained Claude process must receive its OAuth token"
         );
         assert!(
-            launch.env_vars.iter().any(|(name, value)| name == "CLAUDE_CONFIG_DIR" && value == "/run/flotilla/claude"),
+            launch
+                .env_vars
+                .iter()
+                .any(|(name, value)| name == "CLAUDE_CONFIG_DIR" && value == crew_config_dir.to_str().expect("UTF-8 path")),
             "the contained Claude process must receive the config directory owned by its adapter"
         );
     }

--- a/crates/flotilla-daemon/src/vessel_config.rs
+++ b/crates/flotilla-daemon/src/vessel_config.rs
@@ -1,7 +1,5 @@
 use std::{collections::BTreeMap, fmt};
 
-pub const AGENT_ENVIRONMENT_PATH: &str = "/run/flotilla/agent-environment";
-
 pub mod order {
     pub const FIRST: u16 = 0;
     pub const EARLY: u16 = 500;


### PR DESCRIPTION
Closes #1513

## Summary

- add a persistent `writable_config_base` runner seam, distinct from cleaned preflight scratch, with a pre-create-known Docker config base at `/tmp/flotilla-config`
- route Git config, Forgejo token/helper files, credential Codex homes, composed agent environment, and Claude OAuth mutable config through persistent seam-derived paths
- move leased Codex material to the sibling `/tmp/flotilla-codex` Docker seam path so Docker mount creation cannot make the config base root-owned; every crew-visible `CODEX_HOME`, `GIT_CONFIG_GLOBAL`, `FORGEJO_TOKEN_FILE`, and `CLAUDE_CONFIG_DIR` names the actual selected path
- preserve Codex claim conflict detection before container creation while resolving credential path values after the container runner exists
- keep Claude preflight scratch separate as `claude-preflight` and cleaned immediately; lifetime config paths are never attached to that cleanup

The full `/run/flotilla` runner-write audit is posted on #1513: https://github.com/flotilla-org/flotilla/issues/1513#issuecomment-5294215668 (with final sibling-path correction in the follow-up comment).

## Real non-root container validation

Executed before opening this PR and again after review expanded the scenario:

```text
cargo test -p flotilla-core --locked \
  providers::environment::runner::tests::persistent_delivery_paths_work_in_a_real_non_root_container \
  -- --ignored --nocapture
```

The test launched `busybox:latest` as UID/GID `65534:65534` with `HOME=/tmp`, `/run` unwritable, and a Codex material bind mount already present at `/tmp/flotilla-codex`. The Docker environment runner selected `/tmp/flotilla-config`, verified the Codex mount was writable, successfully wrote its Git config and agent-environment file as the non-root user, sourced the agent-environment file, and verified its exported `GIT_CONFIG_GLOBAL` resolved to the written file. Result: **passed**.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- real non-root Docker test above
