### PR TITLE
chore: allow flotilla-crew bot PRs to trigger claude review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,6 +32,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Crew convoys open PRs as the flotilla-crew GitHub App; the action's
+          # human-actor guard would otherwise refuse to review them.
+          allowed_bots: "flotilla-crew"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
PR #1517 — the first crew-bot-authored PR — had its claude-review check fail with the action's human-actor guard: `Workflow initiated by non-human actor: flotilla-crew (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.` Allow-lists `flotilla-crew` explicitly (not `*`, so arbitrary bots can't spend review tokens). Once merged, re-running the failed check on #1517 should produce the review.

https://claude.ai/code/session_01P3eF4i73CQk8zWVKBVArKp