### PR TITLE
feat: seed the governor capability as claude-code fable

### DIFF
--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -342,6 +342,9 @@ impl CapabilityTable {
                 ("code".into(), AgentRequirement { adapter: "codex".into(), model: None }),
                 ("review".into(), AgentRequirement { adapter: "claude-code".into(), model: Some("opus".into()) }),
                 ("code-review".into(), AgentRequirement { adapter: "claude-code".into(), model: Some("opus".into()) }),
+                // The most judgment-concentrated, lowest-volume role in the
+                // fleet gets the strongest planner available (ADR 0030).
+                ("governor".into(), AgentRequirement { adapter: CLAUDE_CODE_ADAPTER_ID.into(), model: Some("fable".into()) }),
             ]),
         }
     }

--- a/docs/adr/0030-the-first-standing-agent-is-a-governor-entry-point.md
+++ b/docs/adr/0030-the-first-standing-agent-is-a-governor-entry-point.md
@@ -99,6 +99,13 @@ never a desk machine whose lid couples governor liveness. Placement is free
 because dispatch works from any credentialed host (ADR 0031's
 rank-retirement).
 
+Engine and model selection is **declarative** — the capability table (and,
+as trajectory, issue labels driving a table lookup) decides; an inline
+governor override at dispatch time is an exception that must name its
+reason. Inline model-picking mid-context is suspect by default: it gets
+poisoned by whatever else the governor is holding (ruled 2026-08-14 on
+#1440; see #1501 for the label-driven direction).
+
 ## Consequences
 
 - The ensure mechanism's first real exerciser tests presence, restart


### PR DESCRIPTION
Enactment step one of #1440 now that the contained-claude smoke gate (#1410) has fallen: the capability table gains `governor` → `claude-code`:`fable` per ADR 0030's crewing section, and ADR 0030 gains the pledged amendment from the 2026-08-14 engine-selection ruling (declarative selection; inline overrides name their reason; #1501 tracks label-driven lookup).

Remaining #1440 enactment after this: andamento-side declarations (governor workflow template, ensure entry, charter pointer — on andamento's tracker), then project refresh and the first on-station report.

https://claude.ai/code/session_01P3eF4i73CQk8zWVKBVArKp