### PR TITLE
fix: deliver claude oauth to trusted crews

### DIFF
--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -8,7 +8,6 @@ use async_trait::async_trait;
 use flotilla_protocol::arg::{flatten, Arg};
 use flotilla_resources::{TerminalAttentionState, TerminalBrief};
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 use toml_edit::{value, DocumentMut, Item, Table};
 
@@ -370,10 +369,10 @@ impl CapabilityTable {
 }
 
 impl AgentRequirement {
-    /// Credential delivery slot required for a contained invocation of this
-    /// adapter. Host-direct sessions may retain ambient authentication, but a
-    /// contained Claude session must never fall through to interactive login.
-    pub fn contained_credential_delivery_slot(&self) -> Option<&'static str> {
+    /// Credential delivery slot supported by this adapter. A session must
+    /// never fall through to ambient or interactive login when its adapter has
+    /// a deliverable material form.
+    pub fn credential_delivery_slot(&self) -> Option<&'static str> {
         match self.adapter.as_str() {
             CLAUDE_CODE_ADAPTER_ID => Some("claude"),
             _ => None,
@@ -429,7 +428,6 @@ pub trait AgentAdapter: Send + Sync {
 /// alongside the brief so it inherits the same git exclusion and teardown.
 pub const CLAUDE_MANAGED_SETTINGS_PATH: &str = ".flotilla/claude-settings.json";
 const CONTAINED_CLAUDE_CONFIG_DIR: &str = "/run/flotilla/claude";
-const HOST_DIRECT_CLAUDE_OAUTH_CONFIG_ROOT: &str = "/run/flotilla/claude-oauth";
 
 struct CliAgentAdapter {
     binary: String,
@@ -514,14 +512,7 @@ impl CliAgentAdapter {
         if let Some((_, config_dir)) = environment.iter().find(|(name, _)| name == "CLAUDE_CONFIG_DIR") {
             return Some(PathBuf::from(config_dir));
         }
-        oauth_token.map(|token| {
-            // Host-direct OAuth identities still need separate supervisor and
-            // mutable-state homes. Key the ephemeral directory without putting
-            // credential material or a reversible account identifier in paths.
-            let digest = Sha256::digest(token.as_bytes());
-            let account_key = digest[..16].iter().map(|byte| format!("{byte:02x}")).collect::<String>();
-            PathBuf::from(HOST_DIRECT_CLAUDE_OAUTH_CONFIG_ROOT).join(account_key)
-        })
+        None
     }
 }
 
@@ -797,9 +788,9 @@ mod tests {
 
     use crate::{
         agent_adapter::{
-            append_convoy_work_context, build_crew_brief, build_crew_brief_with_options, AgentAdapterRegistry, AgentLaunchPlan,
-            AgentLaunchRequest, CapabilityTable, CrewAssignment, CrewBriefMember, CrewBriefRenderOptions, CrewBriefTemplateOverride,
-            CrewBriefTemplateResolver, CONTAINED_CLAUDE_CONFIG_DIR,
+            append_convoy_work_context, build_crew_brief, build_crew_brief_with_options, AgentAdapterRegistry, AgentLaunchRequest,
+            CapabilityTable, CrewAssignment, CrewBriefMember, CrewBriefRenderOptions, CrewBriefTemplateOverride, CrewBriefTemplateResolver,
+            CONTAINED_CLAUDE_CONFIG_DIR,
         },
         path_context::ExecutionEnvironmentPath,
         providers::{
@@ -1313,7 +1304,10 @@ mod tests {
         let brief =
             flotilla_resources::TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "brief".into(), copies: Vec::new() };
 
-        let invocation_environment = vec![("CLAUDE_CONFIG_DIR".to_string(), claude_config.display().to_string())];
+        let invocation_environment = vec![
+            ("CLAUDE_CODE_OAUTH_TOKEN".to_string(), "delivered-token".to_string()),
+            ("CLAUDE_CONFIG_DIR".to_string(), claude_config.display().to_string()),
+        ];
         claude
             .prepare_with_environment(&ExecutionEnvironmentPath::new(&workspace), &brief, &invocation_environment)
             .await
@@ -1328,6 +1322,10 @@ mod tests {
         assert!(
             plan.env.iter().any(|(name, value)| name == "CLAUDE_CONFIG_DIR" && value == &claude_config.display().to_string()),
             "the adapter launch plan must preserve explicit trusted config"
+        );
+        assert!(
+            plan.env.iter().any(|(name, value)| name == "CLAUDE_CODE_OAUTH_TOKEN" && value == "delivered-token"),
+            "the adapter launch plan must deliver OAuth separately from trusted config"
         );
 
         let settings: serde_json::Value =
@@ -1431,36 +1429,23 @@ mod tests {
     }
 
     #[test]
-    fn host_direct_claude_oauth_accounts_get_distinct_adapter_owned_config_dirs() {
+    fn host_direct_claude_oauth_uses_delivered_auth_without_replacing_ambient_config() {
         let env = EnvironmentBag::new().with(EnvironmentAssertion::binary("claude", "/tools/claude"));
         let registry = AgentAdapterRegistry::discover(&env, Arc::new(MockRunner::new(Vec::new())));
         let claude = registry.get("claude-code").expect("Claude adapter");
         let brief =
             flotilla_resources::TerminalBrief { path: ".flotilla/briefs/coder.md".into(), content: "brief".into(), copies: Vec::new() };
-        let launch = |token: &str| {
-            claude
-                .launch(&AgentLaunchRequest {
-                    role: "coder".into(),
-                    model: None,
-                    brief: brief.clone(),
-                    environment: vec![("CLAUDE_CODE_OAUTH_TOKEN".to_string(), token.to_string())],
-                })
-                .expect("host-direct OAuth launch")
-        };
+        let plan = claude
+            .launch(&AgentLaunchRequest {
+                role: "coder".into(),
+                model: None,
+                brief,
+                environment: vec![("CLAUDE_CODE_OAUTH_TOKEN".to_string(), "token-alice".to_string())],
+            })
+            .expect("host-direct OAuth launch");
 
-        let alice = launch("token-alice");
-        let bob = launch("token-bob");
-        let config_dir = |plan: &AgentLaunchPlan| {
-            plan.env
-                .iter()
-                .find(|(name, _)| name == "CLAUDE_CONFIG_DIR")
-                .map(|(_, value)| value.clone())
-                .expect("adapter-owned Claude config")
-        };
-
-        assert_ne!(config_dir(&alice), config_dir(&bob));
-        assert!(config_dir(&alice).starts_with("/run/flotilla/claude-oauth/"));
-        assert!(config_dir(&bob).starts_with("/run/flotilla/claude-oauth/"));
+        assert!(plan.env.iter().any(|(name, value)| name == "CLAUDE_CODE_OAUTH_TOKEN" && value == "token-alice"));
+        assert!(plan.env.iter().all(|(name, _)| name != "CLAUDE_CONFIG_DIR"), "ambient Claude config must remain selected");
     }
 
     #[test]

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3500,11 +3500,6 @@ async fn resolve_workflow_credentials(
     let all_repositories = repositories.iter().map(|repository| repository.repo_ref.clone()).collect::<BTreeSet<_>>();
 
     for vessel in &mut workflow.vessels {
-        if vessel.stance != flotilla_resources::Stance::Contained {
-            // Uncontained crews retain their existing ambient behavior during
-            // the staged migration described by ADR 0022.
-            continue;
-        }
         let vessel_repositories = vessel
             .repository_refs
             .as_ref()
@@ -3549,13 +3544,13 @@ async fn validate_workflow_credentials(
         .map(|spec| (spec.metadata.name, spec.spec.consumer))
         .collect::<BTreeMap<_, _>>();
     let capabilities = CapabilityTable::seeded();
-    for vessel in workflow.vessels.iter().filter(|vessel| vessel.stance == flotilla_resources::Stance::Contained) {
+    for vessel in &workflow.vessels {
         for crew in &vessel.crew {
             let CrewSource::Agent { selector, .. } = &crew.source else {
                 continue;
             };
             let requirement = capabilities.resolve_selector(selector)?;
-            let Some(delivery_slot) = requirement.contained_credential_delivery_slot() else {
+            let Some(delivery_slot) = requirement.credential_delivery_slot() else {
                 continue;
             };
             let has_granted_credential =
@@ -3574,18 +3569,13 @@ async fn validate_workflow_credentials(
                 names => format!("one of credentials `{}`", names.join("`, `")),
             };
             return Err(format!(
-                "contained agent adapter `{}` requires {credential}, but no matching CredentialGrant selected it",
-                requirement.adapter
+                "{} agent adapter `{}` requires {credential}, but no matching CredentialGrant selected it",
+                vessel.stance, requirement.adapter
             ));
         }
     }
 
-    let required = workflow
-        .vessels
-        .iter()
-        .filter(|vessel| vessel.stance == flotilla_resources::Stance::Contained)
-        .flat_map(|vessel| vessel.credential_refs.iter().cloned())
-        .collect::<BTreeSet<_>>();
+    let required = workflow.vessels.iter().flat_map(|vessel| vessel.credential_refs.iter().cloned()).collect::<BTreeSet<_>>();
     let ambient_dependent_vessels = ambient_credential_dependent_vessels(&capabilities, &specs, workflow)?;
     if required.is_empty() && ambient_dependent_vessels.is_empty() {
         return Ok(());
@@ -3671,7 +3661,7 @@ fn ambient_credential_dependent_vessels<'workflow>(
             let Some(scope) = requirement.ambient_credential_scope() else {
                 continue;
             };
-            let delivery_slot = requirement.contained_credential_delivery_slot();
+            let delivery_slot = requirement.credential_delivery_slot();
             let has_delivered_credential = delivery_slot.is_some_and(|slot| {
                 vessel.credential_refs.iter().any(|name| specs.get(name).is_some_and(|consumer| consumer.delivery_slot() == slot))
             });

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -474,6 +474,78 @@ async fn contained_claude_requires_and_accepts_a_project_selected_oauth_grant() 
         .expect("matching held OAuth grant admits contained Claude");
 }
 
+#[tokio::test]
+async fn trusted_claude_requires_and_accepts_a_project_selected_oauth_grant() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(NodeId::new("root-a"));
+    backend
+        .clone()
+        .definitions::<CredentialSpec>("flotilla")
+        .create(&test_meta("claude-max"), &CredentialSpecSpec {
+            consumer: CredentialConsumer::ClaudeOauth { account_email: "ops@example.com".to_string() },
+            source: CredentialSource::Env { name: "CLAUDE_MAX_TOKEN".to_string() },
+            lifecycle: CredentialLifecycle::Static,
+            placement: CredentialPlacementRequirements::default(),
+        })
+        .await
+        .expect("create Claude credential declaration");
+    let workflow = WorkflowTemplateSpec::builder()
+        .vessels(vec![VesselRequirement::builder()
+            .name("work".to_string())
+            .stance(Stance::Trusted)
+            .crew(vec![CrewSpec::builder()
+                .role("coder".to_string())
+                .source(CrewSource::Agent {
+                    selector: Selector { capability: "code".to_string(), adapter: Some("claude-code".to_string()), model: None },
+                    prompt: None,
+                    brief_template: None,
+                })
+                .build()])
+            .build()])
+        .build();
+
+    let mut without_grant = workflow.clone();
+    resolve_workflow_credentials(&backend, "flotilla", Some("flotilla"), &[], &mut without_grant)
+        .await
+        .expect("resolve default-deny grants");
+    let error = validate_workflow_credentials(&backend, "flotilla", &without_grant, None)
+        .await
+        .expect_err("trusted Claude must not reach ambient login without delivered OAuth");
+    assert_eq!(error, "trusted agent adapter `claude-code` requires credential `claude-max`, but no matching CredentialGrant selected it");
+
+    backend
+        .clone()
+        .definitions::<CredentialGrant>("flotilla")
+        .create(
+            &test_meta("claude-max-trusted"),
+            &CredentialGrantSpec::builder()
+                .selector(
+                    CredentialGrantSelector::builder().stance(Stance::Trusted).projects(BTreeSet::from(["flotilla".to_string()])).build(),
+                )
+                .credentials(BTreeSet::from(["claude-max".to_string()]))
+                .build(),
+        )
+        .await
+        .expect("create project-selected trusted Claude grant");
+    let mut with_grant = workflow;
+    resolve_workflow_credentials(&backend, "flotilla", Some("flotilla"), &[], &mut with_grant)
+        .await
+        .expect("resolve matching trusted Claude grant");
+    assert_eq!(with_grant.vessels[0].credential_refs, BTreeSet::from(["claude-max".to_string()]));
+
+    create_docker_placement(&backend, "host-claude", "host-a", BTreeSet::from(["claude-max".to_string()])).await;
+    let placement = backend.using::<PlacementPolicy>("flotilla").get("host-claude").await.expect("get placement");
+    let expired_ambient = CredentialExpiry::builder().refresh_expires_at("2026-07-30T00:00:00Z".parse().expect("timestamp")).build();
+    set_host_credential_expiry(
+        &backend,
+        "host-a",
+        BTreeMap::from([(flotilla_resources::AMBIENT_CLAUDE_CREDENTIAL_SCOPE.to_string(), expired_ambient)]),
+    )
+    .await;
+    validate_workflow_credentials(&backend, "flotilla", &with_grant, Some(&placement))
+        .await
+        .expect("delivered OAuth admits trusted Claude despite an expired ambient login");
+}
+
 async fn set_host_credential_expiry(backend: &ResourceBackend, host_ref: &str, expiry: BTreeMap<String, CredentialExpiry>) {
     let hosts = backend.clone().using::<ResourceHost>("flotilla");
     let host = hosts.get(host_ref).await.expect("host resource");
@@ -529,59 +601,4 @@ async fn dispatch_against_an_expired_credential_is_refused_with_the_credential_a
         .await
         .expect_err("expired credential must refuse dispatch");
     assert_eq!(error, "credential `claude-max` expired on host `host-a` on 2020-02-01 — refresh its material before dispatching");
-}
-
-#[tokio::test]
-async fn dispatch_of_an_ambient_claude_crew_is_refused_when_the_host_login_expired() {
-    let backend = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(NodeId::new("root-a"));
-    let workflow = WorkflowTemplateSpec::builder()
-        .vessels(vec![VesselRequirement::builder()
-            .name("work".to_string())
-            .stance(Stance::Trusted)
-            .crew(vec![CrewSpec::builder()
-                .role("shepherd".to_string())
-                .source(CrewSource::Agent {
-                    selector: Selector { capability: "review".to_string(), adapter: None, model: None },
-                    prompt: None,
-                    brief_template: None,
-                })
-                .build()])
-            .build()])
-        .build();
-    create_docker_placement(&backend, "host-direct-feta", "feta", BTreeSet::new()).await;
-    let placement = backend.using::<PlacementPolicy>("flotilla").get("host-direct-feta").await.expect("get placement");
-
-    validate_workflow_credentials(&backend, "flotilla", &workflow, Some(&placement))
-        .await
-        .expect("a host without expiry metadata admits ambient claude crews");
-
-    let refreshable = CredentialExpiry::builder()
-        .expires_at(Utc::now() - chrono::Duration::hours(1))
-        .refresh_expires_at(Utc::now() + chrono::Duration::days(30))
-        .build();
-    set_host_credential_expiry(
-        &backend,
-        "feta",
-        BTreeMap::from([(flotilla_resources::AMBIENT_CLAUDE_CREDENTIAL_SCOPE.to_string(), refreshable)]),
-    )
-    .await;
-    validate_workflow_credentials(&backend, "flotilla", &workflow, Some(&placement))
-        .await
-        .expect("a live refresh chain admits ambient claude crews");
-
-    let expired = CredentialExpiry::builder().refresh_expires_at("2026-07-30T00:00:00Z".parse().expect("timestamp")).build();
-    set_host_credential_expiry(
-        &backend,
-        "feta",
-        BTreeMap::from([(flotilla_resources::AMBIENT_CLAUDE_CREDENTIAL_SCOPE.to_string(), expired)]),
-    )
-    .await;
-    let error = validate_workflow_credentials(&backend, "flotilla", &workflow, Some(&placement))
-        .await
-        .expect_err("expired ambient login must refuse dispatch");
-    assert_eq!(
-        error,
-        "vessel `work` depends on the ambient claude login on host `feta`, which expired on 2026-07-30 — \
-         log in again on that host or grant a delivered claude credential"
-    );
 }

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -7594,7 +7594,11 @@ mod tests {
                             CrewSpec::builder()
                                 .role("reviewer".to_string())
                                 .source(CrewSource::Agent {
-                                    selector: Selector::for_capability("review"),
+                                    selector: Selector {
+                                        capability: "review".to_string(),
+                                        adapter: Some("codex".to_string()),
+                                        model: None,
+                                    },
                                     prompt: Some("Review the coder's work.".to_string()),
                                     brief_template: None,
                                 })
@@ -7749,7 +7753,7 @@ mod tests {
             .find(|session| session.spec.role == "reviewer")
             .expect("reviewer session");
         let reviewer_id = reviewer.status.as_ref().and_then(|status| status.crew.as_ref()).expect("reviewer identity").id.clone();
-        assert_eq!(reviewer.status.as_ref().and_then(|status| status.crew.as_ref()).map(|crew| crew.adapter.as_str()), Some("claude-code"));
+        assert_eq!(reviewer.status.as_ref().and_then(|status| status.crew.as_ref()).map(|crew| crew.adapter.as_str()), Some("codex"));
         let delivered = pool.delivered.lock().await;
         assert!(delivered.iter().any(|(session, text, submit)| {
             session.ends_with("-reviewer") && text == "handoff from coder@implement\n\nReview commit abc123" && *submit

--- a/docs/adr/0022-credential-declarations-grants-and-local-material.md
+++ b/docs/adr/0022-credential-declarations-grants-and-local-material.md
@@ -161,3 +161,18 @@ bookkeeping is the operator's login inventory**.
 implementations of the same delivery interface; a future model-API proxy
 (per-crew attribution at the proxy, no material in vessels) must slot in
 without reshaping `CredentialSpec`.
+
+## Amendment (2026-08-14): trusted crews use deliverable material proactively
+
+The #1140 credential-health ruling narrows the migration rule that trusted
+stance inherits ambient identity. When a consumer has a long-lived material
+form that its adapter can deliver, trusted crews receive that material just as
+contained crews do. In particular, Claude Code receives the operator's
+subscription `claude setup-token` per process as `CLAUDE_CODE_OAUTH_TOKEN`;
+the token supplies authentication while the trusted adapter continues to use
+ambient Claude configuration for shared settings, skills, and MCP servers.
+
+Ambient identity inheritance remains only for consumers with no deliverable
+material form. A missing grant or unavailable material for a consumer with a
+deliverable form is therefore a named preflight refusal, not permission to
+start a crew and discover stale ambient authentication interactively.


### PR DESCRIPTION
## Summary

- resolve and validate credential grants for trusted crews as well as contained crews
- deliver Claude setup tokens through `CLAUDE_CODE_OAUTH_TOKEN` while retaining ambient Claude configuration
- fail preflight with a named credential error when trusted Claude lacks a grant or material
- amend ADR 0022 with the trusted-delivery ruling

## Testing

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #1499
