### PR TITLE
fix: prefer authoritative host self-reports

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -1180,7 +1180,7 @@ fn canonical_placement_host_ref_from_sources(
     hosts: &[ReadResourceObject<ResourceHost>],
     host_ref: &str,
 ) -> Result<Option<PlacementTargetHost>, String> {
-    let exact = hosts.iter().find(|host| host.object.metadata.name == host_ref);
+    let exact = authoritative_host_source(hosts.iter().filter(|host| host.object.metadata.name == host_ref));
     let resolved = if let Some(host) = exact {
         host
     } else {
@@ -1199,6 +1199,46 @@ fn canonical_placement_host_ref_from_sources(
         resolved.object.spec.display_name.clone()
     };
     Ok(Some(PlacementTargetHost { reference: resolved.object.metadata.name.clone(), display_name }))
+}
+
+/// Select the target daemon's self-report over a locally materialized peer-summary row.
+///
+/// The transitional peer-summary path writes a ready local Host observation with
+/// adapter and pool capabilities, but it has no daemon identity fields. Resource
+/// replication separately brings in the full self-report. Among self-reports, a
+/// later daemon start supersedes an earlier generation and heartbeat breaks ties.
+fn authoritative_host_source<'a>(
+    sources: impl Iterator<Item = &'a ReadResourceObject<ResourceHost>>,
+) -> Option<&'a ReadResourceObject<ResourceHost>> {
+    sources.max_by_key(|source| {
+        let status = source.object.status.as_ref();
+        (
+            status.and_then(|status| status.daemon_generation.as_ref()).is_some(),
+            status.and_then(|status| status.daemon_started_at),
+            status.and_then(|status| status.heartbeat_at),
+            source.object.metadata.creation_timestamp,
+        )
+    })
+}
+
+async fn authoritative_placement_host(
+    backend: &ResourceBackend,
+    namespace: &str,
+    target_host: &PlacementTargetHost,
+    placement_name: &str,
+) -> Result<ResourceObject<ResourceHost>, String> {
+    let sources = backend
+        .including_replicas::<ResourceHost>(namespace)
+        .list()
+        .await
+        .map_err(|error| format!("placement `{placement_name}` target host is not ready: {error}"))?;
+    authoritative_host_source(sources.items.iter().filter(|source| source.object.metadata.name == target_host.reference))
+        .map(|source| source.object.clone())
+        .ok_or_else(|| format!("placement `{placement_name}` target host is not ready: resource not found: {}", target_host.reference))
+}
+
+fn host_generation(status: Option<&ResourceHostStatus>) -> &str {
+    status.and_then(|status| status.daemon_generation.as_deref()).unwrap_or("unknown")
 }
 
 fn check_placement_capacity(target_host: &PlacementTargetHost, capacity: Option<(u64, Option<u64>)>) -> Result<(), String> {
@@ -3586,30 +3626,32 @@ async fn validate_workflow_credentials(
         return Ok(());
     };
     let target_host = placement_target_host(backend, namespace, placement).await?;
-    let host = backend
-        .clone()
-        .using::<ResourceHost>(namespace)
-        .get(&target_host.reference)
-        .await
-        .map_err(|error| format!("placement `{}` target host is not ready: {error}", placement.metadata.name))?;
+    let host = authoritative_placement_host(backend, namespace, &target_host, &placement.metadata.name).await?;
     let host_label = target_host.display_name;
+    let generation = host_generation(host.status.as_ref()).to_string();
     let Some(mut status) = host.status else {
         if required.is_empty() {
             return Ok(());
         }
-        return Err(format!("placement `{}` host `{host_label}` has no observed status", placement.metadata.name));
+        return Err(format!(
+            "placement `{}` host `{host_label}` generation `{generation}` has no observed status",
+            placement.metadata.name
+        ));
     };
     status.apply_heartbeat_readiness(Utc::now());
     if !required.is_empty() {
         if !status.ready {
-            return Err(format!("placement `{}` host `{host_label}` is not ready", placement.metadata.name));
+            return Err(format!("placement `{}` host `{host_label}` generation `{generation}` is not ready", placement.metadata.name));
         }
         let held = status.held_credentials().map_err(|error| {
-            format!("placement `{}` host `{host_label}` has invalid held-credential capability: {error}", placement.metadata.name)
+            format!(
+                "placement `{}` host `{host_label}` generation `{generation}` has invalid held-credential capability: {error}",
+                placement.metadata.name
+            )
         })?;
         if let Some(missing) = required.iter().find(|credential| !held.contains(*credential)) {
             return Err(format!(
-                "workflow requires credential `{missing}`, which placement `{}` host `{host_label}` does not hold",
+                "workflow requires credential `{missing}`, which placement `{}` host `{host_label}` generation `{generation}` does not hold",
                 placement.metadata.name
             ));
         }
@@ -3754,21 +3796,21 @@ async fn placement_agent_adapters(
         Ok((docker.agent_adapters.clone(), format!("image `{}`", docker.image)))
     } else if placement.spec.host_direct.is_some() {
         let target_host = placement_target_host(backend, namespace, placement).await?;
-        let host = backend
-            .clone()
-            .using::<ResourceHost>(namespace)
-            .get(&target_host.reference)
-            .await
-            .map_err(|error| format!("placement `{}` target host is not ready: {error}", placement.metadata.name))?;
+        let host = authoritative_placement_host(backend, namespace, &target_host, &placement.metadata.name).await?;
         let host_label = target_host.display_name;
-        let mut status =
-            host.status.ok_or_else(|| format!("placement `{}` host `{host_label}` has no observed status", placement.metadata.name))?;
+        let generation = host_generation(host.status.as_ref()).to_string();
+        let mut status = host.status.ok_or_else(|| {
+            format!("placement `{}` host `{host_label}` generation `{generation}` has no observed status", placement.metadata.name)
+        })?;
         status.apply_heartbeat_readiness(Utc::now());
         if !status.ready {
-            return Err(format!("placement `{}` host `{host_label}` is not ready", placement.metadata.name));
+            return Err(format!("placement `{}` host `{host_label}` generation `{generation}` is not ready", placement.metadata.name));
         }
         let available_adapters = status.agent_adapters().map_err(|error| {
-            format!("placement `{}` host `{}` has invalid agent adapter capabilities: {error}", placement.metadata.name, host_label)
+            format!(
+                "placement `{}` host `{}` generation `{generation}` has invalid agent adapter capabilities: {error}",
+                placement.metadata.name, host_label
+            )
         })?;
         Ok((available_adapters, format!("host `{host_label}`")))
     } else {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -476,6 +476,91 @@ async fn contained_claude_requires_and_accepts_a_project_selected_oauth_grant() 
 }
 
 #[tokio::test]
+async fn remote_placement_uses_fresh_host_capabilities_over_a_stale_local_row() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(NodeId::new("kiwi-root"));
+    let now = Utc::now();
+    let hosts = backend.using::<ResourceHost>("flotilla");
+    let stale =
+        hosts.create(&test_meta("feta-host"), &HostSpec { display_name: "feta".to_string() }).await.expect("create stale local host row");
+    hosts
+        .update_status(&stale.metadata.name, &stale.metadata.resource_version, &HostStatus {
+            heartbeat_at: Some(now),
+            ready: true,
+            ..HostStatus::default()
+        })
+        .await
+        .expect("write stale null-capability host status");
+
+    let feta = ResourceBackend::InMemory(InMemoryBackend::default());
+    let feta_hosts = feta.using::<ResourceHost>("flotilla");
+    let fresh = feta_hosts
+        .create(&test_meta("feta-host"), &HostSpec { display_name: "feta".to_string() })
+        .await
+        .expect("create fresh feta self-report");
+    feta_hosts
+        .update_status(&fresh.metadata.name, &fresh.metadata.resource_version, &HostStatus {
+            capabilities: [(
+                flotilla_resources::HELD_CREDENTIALS_CAPABILITY.to_string(),
+                serde_json::json!(BTreeSet::from(["claude-max".to_string()])),
+            )]
+            .into_iter()
+            .collect(),
+            heartbeat_at: Some(now - chrono::Duration::seconds(1)),
+            ready: true,
+            daemon_generation: Some("fresh-feta-generation".to_string()),
+            daemon_started_at: Some(now - chrono::Duration::minutes(1)),
+            ..HostStatus::default()
+        })
+        .await
+        .expect("write fresh feta capabilities");
+    backend
+        .replica_writer::<ResourceHost>(NodeId::new("feta-root"), "flotilla")
+        .replace(&feta_hosts.list().await.expect("list feta self-report"), Utc::now())
+        .await
+        .expect("replicate fresh feta self-report to kiwi");
+
+    let sources = backend.including_replicas::<ResourceHost>("flotilla").list().await.expect("list host sources");
+    assert_eq!(sources.items.len(), 2, "reproduction requires the stale and fresh rows to coexist");
+
+    let placement = backend
+        .using::<PlacementPolicy>("flotilla")
+        .create(
+            &test_meta("feta-docker"),
+            &PlacementPolicySpec::builder()
+                .pool("passthrough".to_string())
+                .docker_per_vessel(flotilla_resources::DockerPerVesselPlacementPolicySpec {
+                    host_ref: "feta-host".to_string(),
+                    image: "crew:latest".to_string(),
+                    pull_policy: Default::default(),
+                    agent_adapters: BTreeSet::new(),
+                    default_cwd: None,
+                    env: BTreeMap::new(),
+                    checkout: flotilla_resources::DockerCheckoutStrategy::FreshCloneInContainer { clone_path: "/workspace".to_string() },
+                })
+                .build(),
+        )
+        .await
+        .expect("create feta placement");
+    let mut workflow = WorkflowTemplateSpec::builder()
+        .vessels(vec![VesselRequirement::builder().name("work".to_string()).stance(Stance::Contained).crew(Vec::new()).build()])
+        .build();
+    workflow.vessels[0].credential_refs = BTreeSet::from(["claude-max".to_string()]);
+
+    validate_workflow_credentials(&backend, "flotilla", &workflow, Some(&placement))
+        .await
+        .expect("kiwi-to-feta admission should use feta's fresh self-report");
+
+    workflow.vessels[0].credential_refs.insert("github-crew-pr".to_string());
+    let error = validate_workflow_credentials(&backend, "flotilla", &workflow, Some(&placement))
+        .await
+        .expect_err("a real missing credential should still refuse admission");
+    assert_eq!(
+        error,
+        "workflow requires credential `github-crew-pr`, which placement `feta-docker` host `feta` generation `fresh-feta-generation` does not hold"
+    );
+}
+
+#[tokio::test]
 async fn trusted_claude_requires_and_accepts_a_project_selected_oauth_grant() {
     let backend = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(NodeId::new("root-a"));
     backend

--- a/crates/flotilla-daemon/tests/request_session_pair.rs
+++ b/crates/flotilla-daemon/tests/request_session_pair.rs
@@ -26,9 +26,11 @@ use flotilla_protocol::{
     PeerConnectionState, PrincipalRef, RepoSelector, ResourceRef, SurfaceCharacter, SurfaceDeclaration,
 };
 use flotilla_resources::{
-    api_version, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoySpec, ConvoyStatus, DockerCheckoutStrategy,
-    DockerPerVesselPlacementPolicySpec, Host, HostSpec, HostStatus, InputMeta, PlacementPolicy, PlacementPolicySpec, Regard, Resource,
-    ResourceError, WorkPhase as ResourceWorkPhase, WorkState, WorkflowTemplate, WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY,
+    api_version, Convoy, ConvoyPhase as ResourceConvoyPhase, ConvoySpec, ConvoyStatus, CredentialConsumer, CredentialGrant,
+    CredentialGrantSelector, CredentialGrantSpec, CredentialLifecycle, CredentialPlacementRequirements, CredentialSource, CredentialSpec,
+    CredentialSpecSpec, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Host, HostSpec, HostStatus, InputMeta, PlacementPolicy,
+    PlacementPolicySpec, Regard, Resource, ResourceError, ResourceProvenance, WorkPhase as ResourceWorkPhase, WorkState, WorkflowTemplate,
+    WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY, HELD_CREDENTIALS_CAPABILITY,
 };
 
 fn test_config_store(config_dir: std::path::PathBuf) -> Arc<ConfigStore> {
@@ -654,6 +656,142 @@ async fn convoy_start_stays_on_admitting_store_when_placement_membership_is_stal
         ),
         "placement host must not become the convoy authority"
     );
+}
+
+#[tokio::test]
+async fn cross_host_convoy_start_uses_placement_hosts_credential_self_report() {
+    let leader = empty_daemon_named("kiwi").await;
+    let follower = empty_daemon_named("feta").await;
+    seed_host_capacity(&follower, 100 * 1024 * 1024 * 1024, 20 * 1024 * 1024 * 1024).await;
+    follower.set_local_placement_capabilities(&BTreeSet::from(["claude-code".to_string()]), &["cleat".to_string()]).await;
+    let remote_host_id = follower.local_host_id().expect("follower host identity").to_string();
+    let follower_hosts = follower.resource_backend().using::<Host>("flotilla");
+    let remote_host = follower_hosts.get(&remote_host_id).await.expect("feta self-report");
+    let mut remote_status = remote_host.status.expect("feta status");
+    remote_status.capabilities.extend([
+        (AGENT_ADAPTERS_CAPABILITY.to_string(), serde_json::json!(["claude-code"])),
+        (HELD_CREDENTIALS_CAPABILITY.to_string(), serde_json::json!(["claude-max"])),
+    ]);
+    remote_status.heartbeat_at = Some(Utc::now());
+    remote_status.daemon_generation = Some("feta-fresh-generation".to_string());
+    remote_status.daemon_started_at = Some(Utc::now() - chrono::Duration::minutes(1));
+    follower_hosts
+        .update_status(&remote_host_id, &remote_host.metadata.resource_version, &remote_status)
+        .await
+        .expect("publish feta credential self-report");
+
+    let topology = spawn_in_memory_request_topology_stateful(leader, follower).await.expect("spawn stateful topology");
+    let namespace = "flotilla";
+    let placement_policy = format!("host-direct-{remote_host_id}");
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let sources = topology
+                .leader
+                .resource_backend()
+                .including_replicas::<Host>(namespace)
+                .list()
+                .await
+                .expect("list kiwi host view")
+                .items
+                .into_iter()
+                .filter(|source| source.object.metadata.name == remote_host_id)
+                .collect::<Vec<_>>();
+            let stale_local =
+                sources.iter().any(|source| {
+                    matches!(source.provenance, ResourceProvenance::Local)
+                        && source.object.status.as_ref().is_some_and(|status| {
+                            status.held_credentials().expect("decode local held credentials").is_empty() && status.ready
+                        })
+                });
+            let fresh_replica = sources.iter().any(|source| {
+                matches!(source.provenance, ResourceProvenance::Replica { .. })
+                    && source.object.status.as_ref().is_some_and(|status| {
+                        status.daemon_generation.as_deref() == Some("feta-fresh-generation")
+                            && status.held_credentials().expect("decode replica held credentials").contains("claude-max")
+                    })
+            });
+            if stale_local
+                && fresh_replica
+                && topology.leader.resource_backend().using::<PlacementPolicy>(namespace).get(&placement_policy).await.is_ok()
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("kiwi should reproduce the stale local and fresh feta Host rows");
+
+    seed_trusted_remote_convoy_project(&topology.leader, namespace).await;
+    let workflows = topology.leader.resource_backend().using::<WorkflowTemplate>(namespace);
+    let workflow = workflows.get("remote-workflow").await.expect("remote workflow");
+    let mut workflow_spec = workflow.spec;
+    let flotilla_resources::CrewSource::Agent { selector, .. } = &mut workflow_spec.vessels[0].crew[0].source else {
+        panic!("remote workflow crew should be an agent");
+    };
+    selector.adapter = Some("claude-code".to_string());
+    workflows
+        .update(&InputMeta::from(&workflow.metadata), &workflow.metadata.resource_version, &workflow_spec)
+        .await
+        .expect("select claude-code for the remote workflow");
+    topology
+        .leader
+        .resource_backend()
+        .definitions::<CredentialSpec>(namespace)
+        .create(&InputMeta::builder().name("claude-max".to_string()).build(), &CredentialSpecSpec {
+            consumer: CredentialConsumer::ClaudeOauth { account_email: "crew@example.com".to_string() },
+            source: CredentialSource::Env { name: "TEST_CLAUDE_TOKEN".to_string() },
+            lifecycle: CredentialLifecycle::Static,
+            placement: CredentialPlacementRequirements::default(),
+        })
+        .await
+        .expect("create Claude credential declaration");
+    topology
+        .leader
+        .resource_backend()
+        .definitions::<CredentialGrant>(namespace)
+        .create(
+            &InputMeta::builder().name("claude-max-trusted".to_string()).build(),
+            &CredentialGrantSpec::builder()
+                .selector(
+                    CredentialGrantSelector::builder()
+                        .stance(flotilla_resources::Stance::Trusted)
+                        .projects(BTreeSet::from(["flotilla".to_string()]))
+                        .build(),
+                )
+                .credentials(BTreeSet::from(["claude-max".to_string()]))
+                .build(),
+        )
+        .await
+        .expect("grant Claude credential to trusted workflow");
+
+    let mut events = topology.leader.subscribe();
+    let command_id = topology
+        .client
+        .execute(Command {
+            node_id: None,
+            provisioning_target: None,
+            context_repo: None,
+            action: CommandAction::ConvoyStart {
+                intent: Box::new(
+                    ConvoyStartIntent::builder()
+                        .project_ref("flotilla".to_string())
+                        .name("kiwi-to-feta".to_string())
+                        .branch("fix/kiwi-to-feta".to_string())
+                        .placement_policy(placement_policy)
+                        .auto_attach(flotilla_protocol::ConvoyAutoAttach::Never)
+                        .build(),
+                ),
+            },
+        })
+        .await
+        .expect("dispatch kiwi-to-feta convoy start");
+
+    assert_eq!(await_command_result(&mut events, command_id).await, CommandValue::ConvoyStarted {
+        name: "kiwi-to-feta".to_string(),
+        attach_plan: None,
+        binding: None
+    });
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #1524.

## What changed

- Select the authoritative Host self-report for placement admission across local and replicated same-name rows.
- Prefer generation-bearing reports, then the newest daemon start and heartbeat.
- Include the selected daemon generation in Host readiness and credential refusal messages.
- Cover both the focused stale-null/fresh-capability regression and a kiwi-to-feta `ConvoyStart` over the client protocol.

## Root cause

The transitional peer-summary path materializes a local Host row with adapter and terminal-pool capabilities, while resource replication separately delivers the target daemon's full Host self-report. The two rows share a Host identity. Credential admission used a local-only lookup, so it could read the summary row's null `held_credentials` instead of the placement host's generation-bearing self-report.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`