### PR TITLE
refactor: remove obsolete recovery paths

### DIFF
--- a/crates/flotilla-controllers/src/reconcilers/vessel.rs
+++ b/crates/flotilla-controllers/src/reconcilers/vessel.rs
@@ -7,7 +7,8 @@ use std::{
 
 use chrono::{DateTime, Utc};
 use flotilla_core::agent_adapter::{
-    append_convoy_work_context, build_crew_brief_with_options, CapabilityTable, CrewAssignment, CrewBriefMember, CrewBriefTemplateResolver,
+    append_convoy_work_context, build_crew_brief_with_options, required_agent_adapters, CrewAssignment, CrewBriefMember,
+    CrewBriefTemplateResolver,
 };
 use flotilla_protocol::PlacementDecision;
 use flotilla_resources::{
@@ -313,18 +314,10 @@ impl Reconciler for VesselReconciler {
             Some((vessel_index, requirement)) => (vessel_index, requirement),
             None => return Ok(VesselDeps::failed(format!("vessel {} missing from convoy snapshot", obj.spec.vessel_name))),
         };
-        let capabilities = CapabilityTable::seeded();
-        let mut required_agent_adapters = BTreeSet::new();
-        for process in &requirement.crew {
-            if let CrewSource::Agent { selector, .. } = &process.source {
-                match capabilities.resolve_selector(selector) {
-                    Ok(agent) => {
-                        required_agent_adapters.insert(agent.adapter);
-                    }
-                    Err(message) => return Ok(VesselDeps::failed(message)),
-                }
-            }
-        }
+        let required_adapters = match required_agent_adapters(&requirement.crew) {
+            Ok(adapters) => adapters,
+            Err(message) => return Ok(VesselDeps::failed(message)),
+        };
         let effective_stance = strategy.effective_stance();
         if effective_stance < requirement.stance {
             return Ok(VesselDeps::failed(format!(
@@ -444,7 +437,7 @@ impl Reconciler for VesselReconciler {
                                     host_ref: host_ref.clone(),
                                     image: image.clone(),
                                     declared_agent_adapters: declared_agent_adapters.clone(),
-                                    required_agent_adapters: required_agent_adapters.clone(),
+                                    required_agent_adapters: required_adapters.clone(),
                                     pull_policy: *pull_policy,
                                     mounts: Vec::new(),
                                     env: environment_with_credentials(
@@ -801,7 +794,7 @@ impl Reconciler for VesselReconciler {
                                     host_ref: host_ref.clone(),
                                     image: image.clone(),
                                     declared_agent_adapters: declared_agent_adapters.clone(),
-                                    required_agent_adapters: required_agent_adapters.clone(),
+                                    required_agent_adapters: required_adapters.clone(),
                                     pull_policy: *pull_policy,
                                     mounts,
                                     env: environment_with_credentials(

--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -369,6 +369,21 @@ impl CapabilityTable {
         let seeded = self.resolve(&selector.capability)?;
         Ok(AgentRequirement { adapter: seeded.adapter.clone(), model: selector.model.clone().or_else(|| seeded.model.clone()) })
     }
+}
+
+/// Resolve the distinct agent adapters required by crew process selectors.
+///
+/// Admission and vessel materialization share this primitive so selector
+/// overrides and capability errors cannot drift between the two paths.
+pub fn required_agent_adapters<'a>(crew: impl IntoIterator<Item = &'a flotilla_resources::CrewSpec>) -> Result<BTreeSet<String>, String> {
+    let capabilities = CapabilityTable::seeded();
+    let mut required = BTreeSet::new();
+    for process in crew {
+        if let flotilla_resources::CrewSource::Agent { selector, .. } = &process.source {
+            required.insert(capabilities.resolve_selector(selector)?.adapter);
+        }
+    }
+    Ok(required)
 }
 
 impl AgentRequirement {

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -65,7 +65,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::{
-    agent_adapter::CapabilityTable,
+    agent_adapter::{required_agent_adapters, CapabilityTable},
     aggregator_projection::AggregatorProjectionState,
     checkout_integration::{
         checkout_path_from_status_and_spec, convoy_change_request_id_for_checkout, inspect_checkout_integration,
@@ -3735,14 +3735,7 @@ fn apply_agent_overrides(workflow: &mut WorkflowTemplateSpec, overrides: &[floti
 }
 
 fn required_workflow_agent_adapters(workflow: &WorkflowTemplateSpec) -> Result<BTreeSet<String>, String> {
-    let capabilities = CapabilityTable::seeded();
-    let mut required_adapters = BTreeSet::new();
-    for crew in workflow.vessels.iter().flat_map(|vessel| &vessel.crew) {
-        if let CrewSource::Agent { selector, .. } = &crew.source {
-            required_adapters.insert(capabilities.resolve_selector(selector)?.adapter);
-        }
-    }
-    Ok(required_adapters)
+    required_agent_adapters(workflow.vessels.iter().flat_map(|vessel| &vessel.crew))
 }
 
 async fn placement_agent_adapters(

--- a/crates/flotilla-daemon/src/credential.rs
+++ b/crates/flotilla-daemon/src/credential.rs
@@ -739,9 +739,9 @@ impl CredentialStore {
                     preflight: Some(GitCredentialPreflight::Gh),
                 });
             }
-            CredentialConsumer::Forgejo { api_url, username } => {
+            CredentialConsumer::Forgejo { server_url, username } => {
                 let delivery_paths = delivery_paths.expect("Forgejo adapter resolves delivery paths");
-                let server_url = api_url.trim_end_matches('/');
+                let server_url = server_url.trim_end_matches('/');
                 let parsed_url = Url::parse(server_url).map_err(|error| format!("invalid Forgejo server URL: {error}"))?;
                 if parsed_url.scheme() != "https" {
                     return Err("Forgejo server URL must use HTTPS".to_string());
@@ -1908,7 +1908,10 @@ interactions:
             .clone()
             .definitions::<CredentialSpec>("flotilla")
             .create(&InputMeta::builder().name("lab-forgejo".to_string()).build(), &CredentialSpecSpec {
-                consumer: CredentialConsumer::Forgejo { api_url: "https://forgejo.lab".to_string(), username: "flotilla-crew".to_string() },
+                consumer: CredentialConsumer::Forgejo {
+                    server_url: "https://forgejo.lab".to_string(),
+                    username: "flotilla-crew".to_string(),
+                },
                 source: CredentialSource::Env { name: "TEST_FORGEJO_TOKEN".to_string() },
                 lifecycle: CredentialLifecycle::Static,
                 placement: CredentialPlacementRequirements::default(),
@@ -1963,12 +1966,12 @@ interactions:
         assert!(calls.iter().flat_map(|(_, args, _)| args).all(|arg| !arg.contains(secret)));
     }
 
-    async fn create_forgejo_spec(backend: &ResourceBackend, name: &str, api_url: &str, source_env: &str) {
+    async fn create_forgejo_spec(backend: &ResourceBackend, name: &str, server_url: &str, source_env: &str) {
         backend
             .clone()
             .definitions::<CredentialSpec>("flotilla")
             .create(&InputMeta::builder().name(name.to_string()).build(), &CredentialSpecSpec {
-                consumer: CredentialConsumer::Forgejo { api_url: api_url.to_string(), username: "flotilla-crew".to_string() },
+                consumer: CredentialConsumer::Forgejo { server_url: server_url.to_string(), username: "flotilla-crew".to_string() },
                 source: CredentialSource::Env { name: source_env.to_string() },
                 lifecycle: CredentialLifecycle::Static,
                 placement: CredentialPlacementRequirements::default(),

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -444,10 +444,6 @@ impl DaemonRuntime {
             .await
             .map_err(|error| format!("scan stored resources for decode quarantine: {error}"))?;
         register_startup_resources(&daemon, &options.namespace, &profile).await?;
-        flotilla_resources::PreparedSnapshotGarbageCollector::new(daemon.resource_backend(), &options.namespace)
-            .recover_pending_claims()
-            .await
-            .map_err(|error| format!("recover prepared convoy admissions: {error}"))?;
         let active_environments = daemon
             .resource_backend()
             .using::<Environment>(&options.namespace)

--- a/crates/flotilla-resources/src/convoy.rs
+++ b/crates/flotilla-resources/src/convoy.rs
@@ -23,7 +23,6 @@ define_resource!(Convoy, "convoys", ConvoySpec, ConvoyStatus, ConvoyStatusPatch,
 
 pub const WORKFLOW_SNAPSHOT_ANNOTATION: &str = "flotilla.work/workflow-snapshot";
 pub const PLACEMENT_SNAPSHOT_ANNOTATION: &str = "flotilla.work/placement-snapshot";
-pub const PREPARED_SNAPSHOT_PENDING_ANNOTATION: &str = "flotilla.work/prepared-snapshot-pending";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 pub struct ConvoySpec {
@@ -340,10 +339,6 @@ pub fn pinned_workflow_ref(convoy: &crate::ResourceObject<Convoy>) -> &str {
 
 pub fn pinned_placement_ref(convoy: &crate::ResourceObject<Convoy>) -> Option<&str> {
     convoy.metadata.annotations.get(PLACEMENT_SNAPSHOT_ANNOTATION).map(String::as_str).or(convoy.spec.placement_policy.as_deref())
-}
-
-pub fn prepared_snapshot_pending(convoy: &crate::ResourceObject<Convoy>) -> bool {
-    convoy.metadata.annotations.contains_key(PREPARED_SNAPSHOT_PENDING_ANNOTATION)
 }
 
 /// Durable source-qualified issue context captured when a convoy is admitted.

--- a/crates/flotilla-resources/src/convoy/reconcile.rs
+++ b/crates/flotilla-resources/src/convoy/reconcile.rs
@@ -21,7 +21,7 @@ use crate::{
         ReplicaLabelMappedWatch, SecondaryWatch,
     },
     labels::{LifecycleAuthority, CONVOY_LABEL, VESSEL_LABEL},
-    pinned_placement_ref, pinned_workflow_ref, prepared_snapshot_pending,
+    pinned_placement_ref, pinned_workflow_ref,
     presentation::{Presentation, PresentationSpec},
     resource::ResourceObject,
     status_patch::StatusPatch,
@@ -609,9 +609,6 @@ fn reconcile_internal(
     conditions: LifecycleConditions,
     now: DateTime<Utc>,
 ) -> InternalReconcileOutcome {
-    if prepared_snapshot_pending(convoy) {
-        return InternalReconcileOutcome { patch: None, actuations: Vec::new(), events: Vec::new() };
-    }
     let status = convoy.status.clone().unwrap_or_default();
 
     if status.phase.is_terminal() {

--- a/crates/flotilla-resources/src/credential.rs
+++ b/crates/flotilla-resources/src/credential.rs
@@ -29,7 +29,7 @@ pub struct CredentialSpecSpec {
 pub enum CredentialConsumer {
     Gh,
     GithubApp { installation_id: u64 },
-    Forgejo { api_url: String, username: String },
+    Forgejo { server_url: String, username: String },
     Claude,
     ClaudeOauth { account_email: String },
     Codex,

--- a/crates/flotilla-resources/src/environment.rs
+++ b/crates/flotilla-resources/src/environment.rs
@@ -81,6 +81,8 @@ pub struct EnvironmentStatus {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum EnvironmentWaitReason {
+    /// Capacity contention surfaced immediately by Vessel planning rather than
+    /// waiting for the generic provisioning-stuck threshold.
     MaterialPoolExhausted { pool_ref: String },
 }
 

--- a/crates/flotilla-resources/src/lib.rs
+++ b/crates/flotilla-resources/src/lib.rs
@@ -57,13 +57,12 @@ pub use clone::{Clone, ClonePhase, CloneSpec, CloneStatus, CloneStatusPatch};
 pub use convoy::{
     bound_change_request_record_name, controller_patches, convoy_sanctions_checkout_reclaim, evaluate_landing_settlement,
     expected_change_request_leaves, expected_checkout_refs, external_patches, instantiate_exit, instantiate_turn_delivery,
-    pinned_placement_ref, pinned_workflow_ref, prepared_snapshot_pending, provisioning_patches, reconcile, select_convoy_children,
-    BoundChangeRequest, Convoy, ConvoyAttention, ConvoyEvent, ConvoyIssue, ConvoyPhase, ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec,
-    ConvoyStatus, ConvoyStatusPatch, ConvoyTeardownRuntime, CrewWorkPhase, CrewWorkState, InputValue, InstantiatedExit,
-    InstantiatedExitEntry, InstantiatedTurnDelivery, IssueSnapshot, PlacementStatus, ReconcileOutcome, SettlementEvaluation,
-    SettlementMode, TargetMismatch, TurnDeliveryEpisode, TurnDeliveryOutcome, TurnDeliveryRung, TurnDeliveryStatus,
-    UnmetSettlementExpectation, WorkCompletionAuthority, WorkPhase, WorkState, WorkflowSnapshot, PLACEMENT_SNAPSHOT_ANNOTATION,
-    PREPARED_SNAPSHOT_PENDING_ANNOTATION, WORKFLOW_SNAPSHOT_ANNOTATION,
+    pinned_placement_ref, pinned_workflow_ref, provisioning_patches, reconcile, select_convoy_children, BoundChangeRequest, Convoy,
+    ConvoyAttention, ConvoyEvent, ConvoyIssue, ConvoyPhase, ConvoyReconciler, ConvoyRepositorySpec, ConvoySpec, ConvoyStatus,
+    ConvoyStatusPatch, ConvoyTeardownRuntime, CrewWorkPhase, CrewWorkState, InputValue, InstantiatedExit, InstantiatedExitEntry,
+    InstantiatedTurnDelivery, IssueSnapshot, PlacementStatus, ReconcileOutcome, SettlementEvaluation, SettlementMode, TargetMismatch,
+    TurnDeliveryEpisode, TurnDeliveryOutcome, TurnDeliveryRung, TurnDeliveryStatus, UnmetSettlementExpectation, WorkCompletionAuthority,
+    WorkPhase, WorkState, WorkflowSnapshot, PLACEMENT_SNAPSHOT_ANNOTATION, WORKFLOW_SNAPSHOT_ANNOTATION,
 };
 pub use convoy_ensure::{ConvoyEnsure, ConvoyEnsureSpec, ConvoyEnsureStatus, ConvoyEnsureStatusPatch};
 pub use credential::{
@@ -103,8 +102,8 @@ pub use placement_policy::{
     HostDirectPlacementPolicySpec, PlacementPolicy, PlacementPolicySpec,
 };
 pub use prepared_snapshot::{
-    content_hash, PreparedSnapshotGarbageCollector, PreparedSnapshotGcResult, PreparedSnapshotRecoveryResult, PLACEMENT_SNAPSHOT_KIND,
-    PREPARED_SNAPSHOT_LABEL, WORKFLOW_SNAPSHOT_KIND,
+    content_hash, PreparedSnapshotGarbageCollector, PreparedSnapshotGcResult, PLACEMENT_SNAPSHOT_KIND, PREPARED_SNAPSHOT_LABEL,
+    WORKFLOW_SNAPSHOT_KIND,
 };
 pub use presentation::{Presentation, PresentationPhase, PresentationSpec, PresentationStatus, PresentationStatusPatch};
 pub use principal_attention::{

--- a/crates/flotilla-resources/src/prepared_snapshot.rs
+++ b/crates/flotilla-resources/src/prepared_snapshot.rs
@@ -4,8 +4,7 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 use crate::{
-    Convoy, InputMeta, PlacementPolicy, ResourceBackend, ResourceError, WorkflowTemplate, PLACEMENT_SNAPSHOT_ANNOTATION,
-    PREPARED_SNAPSHOT_PENDING_ANNOTATION, WORKFLOW_SNAPSHOT_ANNOTATION,
+    Convoy, PlacementPolicy, ResourceBackend, ResourceError, WorkflowTemplate, PLACEMENT_SNAPSHOT_ANNOTATION, WORKFLOW_SNAPSHOT_ANNOTATION,
 };
 
 pub const PREPARED_SNAPSHOT_LABEL: &str = "flotilla.work/prepared-snapshot";
@@ -32,60 +31,9 @@ pub struct PreparedSnapshotGcResult {
     pub placements_deleted: usize,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub struct PreparedSnapshotRecoveryResult {
-    pub completed: usize,
-    pub discarded: usize,
-}
-
 impl PreparedSnapshotGarbageCollector {
     pub fn new(backend: ResourceBackend, namespace: impl Into<String>) -> Self {
         Self { backend, namespace: namespace.into() }
-    }
-
-    /// Recover claims left pending by a daemon crash during prepared admission.
-    ///
-    /// Complete claims whose snapshots were fully materialized; discard claims
-    /// that cannot be completed because their shipped specs died with the
-    /// interrupted command.
-    pub async fn recover_pending_claims(&self) -> Result<PreparedSnapshotRecoveryResult, ResourceError> {
-        let convoys = self.backend.clone().using::<Convoy>(&self.namespace);
-        let workflows = self.backend.clone().using::<WorkflowTemplate>(&self.namespace);
-        let placements = self.backend.clone().using::<PlacementPolicy>(&self.namespace);
-        let mut result = PreparedSnapshotRecoveryResult::default();
-        for convoy in convoys.list().await?.items {
-            if !convoy.metadata.annotations.contains_key(PREPARED_SNAPSHOT_PENDING_ANNOTATION) {
-                continue;
-            }
-            let workflow_ready = match convoy.metadata.annotations.get(WORKFLOW_SNAPSHOT_ANNOTATION) {
-                Some(name) => resource_exists(&workflows, name).await?,
-                None => false,
-            };
-            let placement_ready = match convoy.metadata.annotations.get(PLACEMENT_SNAPSHOT_ANNOTATION) {
-                Some(name) => resource_exists(&placements, name).await?,
-                None => convoy.spec.placement_policy.is_none(),
-            };
-            if workflow_ready && placement_ready {
-                loop {
-                    let current = convoys.get(&convoy.metadata.name).await?;
-                    let mut meta = InputMeta::from(&current.metadata);
-                    meta.annotations.remove(PREPARED_SNAPSHOT_PENDING_ANNOTATION);
-                    match convoys.update(&meta, &current.metadata.resource_version, &current.spec).await {
-                        Ok(_) => {
-                            result.completed += 1;
-                            break;
-                        }
-                        Err(ResourceError::Conflict { .. }) => continue,
-                        Err(error) => return Err(error),
-                    }
-                }
-            } else {
-                convoys.delete(&convoy.metadata.name).await?;
-                result.discarded += 1;
-            }
-        }
-        self.collect(None).await?;
-        Ok(result)
     }
 
     /// Delete prepared snapshots not referenced by any remaining convoy.
@@ -139,14 +87,6 @@ impl PreparedSnapshotGarbageCollector {
             }
         }
         Ok(result)
-    }
-}
-
-async fn resource_exists<T: crate::Resource>(resolver: &crate::TypedResolver<T>, name: &str) -> Result<bool, ResourceError> {
-    match resolver.get(name).await {
-        Ok(_) => Ok(true),
-        Err(ResourceError::NotFound { .. }) => Ok(false),
-        Err(error) => Err(error),
     }
 }
 

--- a/crates/flotilla-resources/tests/prepared_snapshot_gc.rs
+++ b/crates/flotilla-resources/tests/prepared_snapshot_gc.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 
 use flotilla_resources::{
-    reconcile, Convoy, ConvoySpec, InMemoryBackend, InputMeta, PlacementPolicy, PlacementPolicySpec, PreparedSnapshotGarbageCollector,
+    Convoy, ConvoySpec, InMemoryBackend, InputMeta, PlacementPolicy, PlacementPolicySpec, PreparedSnapshotGarbageCollector,
     ResourceBackend, ResourceError, WorkflowTemplate, WorkflowTemplateSpec, PLACEMENT_SNAPSHOT_ANNOTATION, PLACEMENT_SNAPSHOT_KIND,
-    PREPARED_SNAPSHOT_LABEL, PREPARED_SNAPSHOT_PENDING_ANNOTATION, WORKFLOW_SNAPSHOT_ANNOTATION, WORKFLOW_SNAPSHOT_KIND,
+    PREPARED_SNAPSHOT_LABEL, WORKFLOW_SNAPSHOT_ANNOTATION, WORKFLOW_SNAPSHOT_KIND,
 };
 
 fn prepared_meta(name: &str, kind: &str) -> InputMeta {
@@ -91,69 +91,4 @@ async fn sweep_removes_unreferenced_legacy_snapshots() {
     let result = PreparedSnapshotGarbageCollector::new(backend, "flotilla").collect(None).await.expect("sweep legacy snapshots");
     assert_eq!(result.workflows_deleted, 1);
     assert_eq!(result.placements_deleted, 1);
-}
-
-#[tokio::test]
-async fn pending_convoy_claim_protects_snapshots_without_bootstrapping_early() {
-    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
-    let workflow_name = "workflow-snapshot-012345abcdef";
-    let convoys = backend.clone().using::<Convoy>("flotilla");
-    convoys
-        .create(
-            &InputMeta::builder()
-                .name("preparing".to_string())
-                .annotations(BTreeMap::from([
-                    (WORKFLOW_SNAPSHOT_ANNOTATION.to_string(), workflow_name.to_string()),
-                    (PREPARED_SNAPSHOT_PENDING_ANNOTATION.to_string(), "true".to_string()),
-                ]))
-                .build(),
-            &ConvoySpec::builder().workflow_ref("logical-workflow".to_string()).build(),
-        )
-        .await
-        .expect("create pending convoy claim");
-    backend
-        .clone()
-        .using::<WorkflowTemplate>("flotilla")
-        .create(&prepared_meta(workflow_name, WORKFLOW_SNAPSHOT_KIND), &WorkflowTemplateSpec::builder().vessels(Vec::new()).build())
-        .await
-        .expect("create prepared workflow");
-
-    let collector = PreparedSnapshotGarbageCollector::new(backend, "flotilla");
-    let result = collector.collect(None).await.expect("collect during preparation");
-    assert_eq!(result.workflows_deleted, 0);
-    let convoy = convoys.get("preparing").await.expect("get pending convoy claim");
-    let outcome = reconcile(&convoy, None, chrono::Utc::now());
-    assert!(outcome.patch.is_none());
-    assert!(outcome.events.is_empty());
-
-    let recovered = collector.recover_pending_claims().await.expect("recover completed pending claim");
-    assert_eq!(recovered.completed, 1);
-    assert_eq!(recovered.discarded, 0);
-    let convoy = convoys.get("preparing").await.expect("get recovered convoy");
-    assert!(!convoy.metadata.annotations.contains_key(PREPARED_SNAPSHOT_PENDING_ANNOTATION));
-}
-
-#[tokio::test]
-async fn recovery_discards_pending_claim_whose_snapshot_was_not_materialized() {
-    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
-    let convoys = backend.clone().using::<Convoy>("flotilla");
-    convoys
-        .create(
-            &InputMeta::builder()
-                .name("interrupted".to_string())
-                .annotations(BTreeMap::from([
-                    (WORKFLOW_SNAPSHOT_ANNOTATION.to_string(), "workflow-snapshot-012345abcdef".to_string()),
-                    (PREPARED_SNAPSHOT_PENDING_ANNOTATION.to_string(), "true".to_string()),
-                ]))
-                .build(),
-            &ConvoySpec::builder().workflow_ref("logical-workflow".to_string()).build(),
-        )
-        .await
-        .expect("create interrupted claim");
-
-    let recovered =
-        PreparedSnapshotGarbageCollector::new(backend, "flotilla").recover_pending_claims().await.expect("recover interrupted claim");
-    assert_eq!(recovered.completed, 0);
-    assert_eq!(recovered.discarded, 1);
-    assert!(matches!(convoys.get("interrupted").await, Err(ResourceError::NotFound { .. })));
 }


### PR DESCRIPTION
## Summary

- remove the unreachable prepared convoy pending-claim annotation, startup recovery API, reconciliation guard, exports, and focused recovery tests while preserving content-addressed snapshot GC
- rename the Forgejo credential consumer's persisted web base from `api_url` to `server_url`
- keep typed material-pool wait reasons as the immediate Vessel-status visibility contract
- centralize required agent-adapter resolution across admission and Vessel environment materialization

## Compatibility and deployment

Flotilla is in its no-backwards-compatibility phase. The routed prepared-admission protocol was removed before this cleanup, so no supported store version can contain pending prepared-snapshot rows and no migration is provided.

Before deploying the Forgejo field rename to kiwi, update `flotilla-manifests/credential-lab-forgejo-crew-pr.json` from `api_url` to `server_url`, then delete and reapply that credential resource before restarting the daemon. The manifest lives in the separately deployed project-map configuration and is not part of this repository.

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #1439
Closes #1294
Closes #1244
Closes #1245
