### PR TITLE
fix: make crew image runtime tools writable

### DIFF
--- a/.flotilla/Dockerfile.crew
+++ b/.flotilla/Dockerfile.crew
@@ -66,10 +66,17 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
         jq \
         less \
         openssh-client \
+        python3 \
         ripgrep \
         unzip \
         zsh \
     && rm -rf /var/lib/apt/lists/*
+
+# Cargo's registry/cache and rustup-installed proxies must be writable by the
+# host-mapped runtime user. Keep the baked toolchain on the read-only image
+# layer and route only Cargo's mutable home through Flotilla's writable base.
+ENV CARGO_HOME=/tmp/flotilla-config/cargo
+ENV PATH="/tmp/flotilla-config/cargo/bin:/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # 4. Agent adapters. Keep this fastest-moving layer last.
 ARG CLAUDE_CODE_VERSION=2.1.220
@@ -86,7 +93,8 @@ ENV SHELL=/bin/zsh
 # Build-time smoke check: declaring these adapters in a PlacementPolicy is a
 # promise that both entry points are executable in the image.
 RUN claude --version \
-    && codex --version
+    && codex --version \
+    && python3 --version
 
 WORKDIR /workspace
 CMD ["sleep", "infinity"]

--- a/.flotilla/placement-policy.crew-image.yaml
+++ b/.flotilla/placement-policy.crew-image.yaml
@@ -9,7 +9,7 @@ spec:
   pool: cleat
   docker_per_vessel:
     host_ref: d49f4c59-811f-44aa-a4ca-d4cac66cf2a3
-    image: forgejo.lab.flotilla.work/image-builder/flotilla-crew:2026-07-26.1
+    image: forgejo.lab.flotilla.work/image-builder/flotilla-crew:2026-08-15.1
     pull_policy: always
     agent_adapters:
       - claude-code

--- a/docs/crew-image.md
+++ b/docs/crew-image.md
@@ -133,6 +133,7 @@ populate that writable home and run a dependency-backed test:
 
 ```bash
 docker run --rm --user 12345:12345 "$IMAGE" sh -c '
+  set -eu
   test "$CARGO_HOME" = /tmp/flotilla-config/cargo
   mkdir -p /tmp/cargo-smoke/src
   printf "[package]\nname = \"cargo-smoke\"\nversion = \"0.1.0\"\nedition = \"2024\"\n[dependencies]\nanyhow = \"1\"\n" > /tmp/cargo-smoke/Cargo.toml

--- a/docs/crew-image.md
+++ b/docs/crew-image.md
@@ -3,7 +3,7 @@
 Contained vessels use the curated image at:
 
 ```text
-forgejo.lab.flotilla.work/image-builder/flotilla-crew:2026-07-26.1
+forgejo.lab.flotilla.work/image-builder/flotilla-crew:2026-08-15.1
 ```
 
 The explicit release tag is the deployment contract. Do not point placement
@@ -95,7 +95,7 @@ From the repository root, a builder with amd64 and arm64 workers can publish
 the release with:
 
 ```bash
-IMAGE=forgejo.lab.flotilla.work/image-builder/flotilla-crew:2026-07-26.1
+IMAGE=forgejo.lab.flotilla.work/image-builder/flotilla-crew:2026-08-15.1
 docker buildx build \
   --platform linux/amd64,linux/arm64 \
   --file .flotilla/Dockerfile.crew \
@@ -119,10 +119,27 @@ Pull the published image rather than relying on the local build cache, then
 run both adapter entry points:
 
 ```bash
-IMAGE=forgejo.lab.flotilla.work/image-builder/flotilla-crew:2026-07-26.1
+IMAGE=forgejo.lab.flotilla.work/image-builder/flotilla-crew:2026-08-15.1
 docker pull "$IMAGE"
 docker run --rm "$IMAGE" claude --version
 docker run --rm "$IMAGE" codex --version
+docker run --rm "$IMAGE" python3 --version
+```
+
+Cargo's installed toolchain remains on the read-only image layer, while its
+runtime registry, cache, and additional tool proxies live beneath
+`/tmp/flotilla-config/cargo`. Verify that an arbitrary non-root runtime user can
+populate that writable home and run a dependency-backed test:
+
+```bash
+docker run --rm --user 12345:12345 "$IMAGE" sh -c '
+  test "$CARGO_HOME" = /tmp/flotilla-config/cargo
+  mkdir -p /tmp/cargo-smoke/src
+  printf "[package]\nname = \"cargo-smoke\"\nversion = \"0.1.0\"\nedition = \"2024\"\n[dependencies]\nanyhow = \"1\"\n" > /tmp/cargo-smoke/Cargo.toml
+  printf "#[test]\nfn dependency_is_usable() { assert_eq!(anyhow::anyhow!(\"smoke\").to_string(), \"smoke\"); }\n" > /tmp/cargo-smoke/src/lib.rs
+  cargo test --manifest-path /tmp/cargo-smoke/Cargo.toml
+  test -d "$CARGO_HOME/registry/cache"
+'
 ```
 
 Until the image bakes cleat, run its version check against a provisioned


### PR DESCRIPTION
## Summary

- route runtime CARGO_HOME through /tmp/flotilla-config/cargo while retaining the baked Rust toolchain under /usr/local
- install python3 in the crew image utilities layer
- publish and pin forgejo.lab.flotilla.work/image-builder/flotilla-crew:2026-08-15.1
- document the arbitrary non-root Cargo registry smoke test

## Published image evidence

- OCI index: sha256:20240227ff1d9a1dce31a893c0251e4885ba52643f29692f5eb987f02ff86a0b
- platforms: linux/amd64 and linux/arm64
- pulled-image entry points: Claude Code 2.1.220, codex-cli 0.145.0, Python 3.12.3
- pulled image as UID/GID 12345:12345 fetched anyhow from crates.io, compiled it, passed cargo test, created CARGO_HOME/registry/cache, and reported cargo_home=/tmp/flotilla-config/cargo owner=12345:12345

## Verification

- cargo +nightly-2026-03-12 fmt --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --locked
- multi-architecture image build and push
- fresh pull plus Claude, Codex, Python, and arbitrary-UID Cargo smoke tests

Closes #1516
Closes #1515
