### PR TITLE
fix: resolve remote credential paths natively

### DIFF
--- a/crates/flotilla-core/src/agent_adapter.rs
+++ b/crates/flotilla-core/src/agent_adapter.rs
@@ -326,9 +326,23 @@ pub struct AgentLaunchPlan {
 pub struct AgentRequirement {
     pub adapter: String,
     pub model: Option<String>,
+    credential_policy: AgentCredentialPolicy,
 }
 
 const CLAUDE_CODE_ADAPTER_ID: &str = "claude-code";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AgentCredentialPolicy {
+    None,
+    DeliveredWithAmbientFallback {
+        slot: &'static str,
+        scope: &'static str,
+    },
+    #[cfg(test)]
+    AmbientOnly {
+        scope: &'static str,
+    },
+}
 
 pub struct CapabilityTable {
     requirements: BTreeMap<String, AgentRequirement>,
@@ -338,19 +352,29 @@ impl CapabilityTable {
     pub fn seeded() -> Self {
         Self {
             requirements: BTreeMap::from([
-                ("coding".into(), AgentRequirement { adapter: "codex".into(), model: None }),
-                ("code".into(), AgentRequirement { adapter: "codex".into(), model: None }),
-                ("review".into(), AgentRequirement { adapter: "claude-code".into(), model: Some("opus".into()) }),
-                ("code-review".into(), AgentRequirement { adapter: "claude-code".into(), model: Some("opus".into()) }),
+                ("coding".into(), AgentRequirement::new("codex", None)),
+                ("code".into(), AgentRequirement::new("codex", None)),
+                ("review".into(), AgentRequirement::new("claude-code", Some("opus".into()))),
+                ("code-review".into(), AgentRequirement::new("claude-code", Some("opus".into()))),
                 // The most judgment-concentrated, lowest-volume role in the
                 // fleet gets the strongest planner available (ADR 0030).
-                ("governor".into(), AgentRequirement { adapter: CLAUDE_CODE_ADAPTER_ID.into(), model: Some("fable".into()) }),
+                ("governor".into(), AgentRequirement::new(CLAUDE_CODE_ADAPTER_ID, Some("fable".into()))),
             ]),
         }
     }
 
     pub fn resolve(&self, capability: &str) -> Result<&AgentRequirement, String> {
         self.requirements.get(capability).ok_or_else(|| format!("unknown agent capability `{capability}`"))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_ambient_only_test_requirement(mut self, capability: &str) -> Self {
+        self.requirements.insert(capability.to_string(), AgentRequirement {
+            adapter: "ambient-only-test".to_string(),
+            model: None,
+            credential_policy: AgentCredentialPolicy::AmbientOnly { scope: flotilla_resources::AMBIENT_CLAUDE_CREDENTIAL_SCOPE },
+        });
+        self
     }
 
     /// Resolve a workflow selector to its effective requirement.
@@ -364,21 +388,39 @@ impl CapabilityTable {
     /// check that matters (adapter availability) happens at placement.
     pub fn resolve_selector(&self, selector: &flotilla_resources::Selector) -> Result<AgentRequirement, String> {
         if let Some(adapter) = &selector.adapter {
-            return Ok(AgentRequirement { adapter: adapter.clone(), model: selector.model.clone() });
+            return Ok(AgentRequirement::new(adapter, selector.model.clone()));
         }
         let seeded = self.resolve(&selector.capability)?;
-        Ok(AgentRequirement { adapter: seeded.adapter.clone(), model: selector.model.clone().or_else(|| seeded.model.clone()) })
+        Ok(AgentRequirement {
+            adapter: seeded.adapter.clone(),
+            model: selector.model.clone().or_else(|| seeded.model.clone()),
+            credential_policy: seeded.credential_policy,
+        })
     }
 }
 
 impl AgentRequirement {
+    fn new(adapter: impl Into<String>, model: Option<String>) -> Self {
+        let adapter = adapter.into();
+        let credential_policy = match adapter.as_str() {
+            CLAUDE_CODE_ADAPTER_ID => AgentCredentialPolicy::DeliveredWithAmbientFallback {
+                slot: "claude",
+                scope: flotilla_resources::AMBIENT_CLAUDE_CREDENTIAL_SCOPE,
+            },
+            _ => AgentCredentialPolicy::None,
+        };
+        Self { adapter, model, credential_policy }
+    }
+
     /// Credential delivery slot supported by this adapter. A session must
     /// never fall through to ambient or interactive login when its adapter has
     /// a deliverable material form.
     pub fn credential_delivery_slot(&self) -> Option<&'static str> {
-        match self.adapter.as_str() {
-            CLAUDE_CODE_ADAPTER_ID => Some("claude"),
-            _ => None,
+        match self.credential_policy {
+            AgentCredentialPolicy::DeliveredWithAmbientFallback { slot, .. } => Some(slot),
+            AgentCredentialPolicy::None => None,
+            #[cfg(test)]
+            AgentCredentialPolicy::AmbientOnly { .. } => None,
         }
     }
 
@@ -386,9 +428,11 @@ impl AgentRequirement {
     /// delivered, named as it appears under the Host `credential_expiry`
     /// capability. `None` for adapters with no ambient authentication path.
     pub fn ambient_credential_scope(&self) -> Option<&'static str> {
-        match self.adapter.as_str() {
-            CLAUDE_CODE_ADAPTER_ID => Some(flotilla_resources::AMBIENT_CLAUDE_CREDENTIAL_SCOPE),
-            _ => None,
+        match self.credential_policy {
+            AgentCredentialPolicy::DeliveredWithAmbientFallback { scope, .. } => Some(scope),
+            AgentCredentialPolicy::None => None,
+            #[cfg(test)]
+            AgentCredentialPolicy::AmbientOnly { scope } => Some(scope),
         }
     }
 }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -3531,6 +3531,16 @@ async fn validate_workflow_credentials(
     workflow: &WorkflowTemplateSpec,
     placement: Option<&ResourceObject<PlacementPolicy>>,
 ) -> Result<(), String> {
+    validate_workflow_credentials_with_capabilities(backend, namespace, workflow, placement, &CapabilityTable::seeded()).await
+}
+
+async fn validate_workflow_credentials_with_capabilities(
+    backend: &ResourceBackend,
+    namespace: &str,
+    workflow: &WorkflowTemplateSpec,
+    placement: Option<&ResourceObject<PlacementPolicy>>,
+    capabilities: &CapabilityTable,
+) -> Result<(), String> {
     let specs = backend
         .clone()
         .definitions::<CredentialSpec>(namespace)
@@ -3540,7 +3550,6 @@ async fn validate_workflow_credentials(
         .into_iter()
         .map(|spec| (spec.metadata.name, spec.spec.consumer))
         .collect::<BTreeMap<_, _>>();
-    let capabilities = CapabilityTable::seeded();
     for vessel in &workflow.vessels {
         for crew in &vessel.crew {
             let CrewSource::Agent { selector, .. } = &crew.source else {
@@ -3573,7 +3582,7 @@ async fn validate_workflow_credentials(
     }
 
     let required = workflow.vessels.iter().flat_map(|vessel| vessel.credential_refs.iter().cloned()).collect::<BTreeSet<_>>();
-    let ambient_dependent_vessels = ambient_credential_dependent_vessels(&capabilities, &specs, workflow)?;
+    let ambient_dependent_vessels = ambient_credential_dependent_vessels(capabilities, &specs, workflow)?;
     if required.is_empty() && ambient_dependent_vessels.is_empty() {
         return Ok(());
     }
@@ -3643,6 +3652,8 @@ async fn validate_workflow_credentials(
 /// ambient-capable adapter and no granted credential covering that adapter's
 /// delivery slot. Returns `(vessel name, ambient scope)` pairs, the scope
 /// being the entry name under the Host `credential_expiry` capability.
+/// The seeded adapters currently pair ambient Claude scope with a delivery
+/// slot, so this is forward-provisioned for an ambient-only adapter.
 fn ambient_credential_dependent_vessels<'workflow>(
     capabilities: &CapabilityTable,
     specs: &BTreeMap<String, CredentialConsumer>,

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -547,6 +547,40 @@ async fn trusted_claude_requires_and_accepts_a_project_selected_oauth_grant() {
         .expect("delivered OAuth admits trusted Claude despite an expired ambient login");
 }
 
+#[tokio::test]
+async fn ambient_only_adapter_is_refused_when_the_host_login_expired() {
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(NodeId::new("root-a"));
+    let workflow = WorkflowTemplateSpec::builder()
+        .vessels(vec![VesselRequirement::builder()
+            .name("work".to_string())
+            .stance(Stance::Trusted)
+            .crew(vec![CrewSpec::builder()
+                .role("coder".to_string())
+                .source(CrewSource::Agent { selector: Selector::for_capability("ambient-only"), prompt: None, brief_template: None })
+                .build()])
+            .build()])
+        .build();
+    create_docker_placement(&backend, "ambient-host", "host-a", BTreeSet::new()).await;
+    let placement = backend.using::<PlacementPolicy>("flotilla").get("ambient-host").await.expect("get placement");
+    let expired = CredentialExpiry::builder().refresh_expires_at("2020-02-01T00:00:00Z".parse().expect("timestamp")).build();
+    set_host_credential_expiry(
+        &backend,
+        "host-a",
+        BTreeMap::from([(flotilla_resources::AMBIENT_CLAUDE_CREDENTIAL_SCOPE.to_string(), expired)]),
+    )
+    .await;
+    let capabilities = CapabilityTable::seeded().with_ambient_only_test_requirement("ambient-only");
+
+    let error = validate_workflow_credentials_with_capabilities(&backend, "flotilla", &workflow, Some(&placement), &capabilities)
+        .await
+        .expect_err("expired ambient-only authentication must refuse dispatch");
+
+    assert_eq!(
+        error,
+        "vessel `work` depends on the ambient claude login on host `host-a`, which expired on 2020-02-01 — log in again on that host or grant a delivered claude credential"
+    );
+}
+
 async fn set_host_credential_expiry(backend: &ResourceBackend, host_ref: &str, expiry: BTreeMap<String, CredentialExpiry>) {
     let hosts = backend.clone().using::<ResourceHost>("flotilla");
     let host = hosts.get(host_ref).await.expect("host resource");

--- a/crates/flotilla-core/src/providers/ssh_runner.rs
+++ b/crates/flotilla-core/src/providers/ssh_runner.rs
@@ -11,6 +11,26 @@ use crate::providers::{
     FLOTILLA_HELPER_NAME, FLOTILLA_HELPER_SCRIPT,
 };
 
+const REMOTE_WRITABLE_BASE_SCRIPT: &str = "if [ -n \"${XDG_RUNTIME_DIR:-}\" ] \
+                                               && [ -d \"$XDG_RUNTIME_DIR\" ] \
+                                               && [ -w \"$XDG_RUNTIME_DIR\" ] \
+                                               && mkdir -p \"$XDG_RUNTIME_DIR/flotilla\"; then \
+                                               base=$XDG_RUNTIME_DIR/flotilla; \
+                                           elif [ -n \"${XDG_STATE_HOME:-}\" ] \
+                                               && mkdir -p \"$XDG_STATE_HOME/flotilla\" 2>/dev/null \
+                                               && [ -d \"$XDG_STATE_HOME/flotilla\" ] \
+                                               && [ -w \"$XDG_STATE_HOME/flotilla\" ]; then \
+                                               base=$XDG_STATE_HOME/flotilla; \
+                                           elif [ -n \"${HOME:-}\" ] \
+                                               && mkdir -p \"$HOME/.local/state/flotilla\" 2>/dev/null \
+                                               && [ -d \"$HOME/.local/state/flotilla\" ] \
+                                               && [ -w \"$HOME/.local/state/flotilla\" ]; then \
+                                               base=$HOME/.local/state/flotilla; \
+                                           else \
+                                               exit 1; \
+                                           fi; \
+                                           printf '%s' \"$base\"";
+
 /// Command runner that executes commands on a remote host over SSH.
 ///
 /// This is intentionally narrow: it shells out to `ssh` for direct-environment
@@ -61,25 +81,7 @@ impl SshCommandRunner {
 
     async fn writable_base(&self, purpose: &str) -> Result<PathBuf, String> {
         let base = self
-            .run(
-                "sh",
-                &[
-                    "-c",
-                    "if [ -n \"${XDG_RUNTIME_DIR:-}\" ] && [ -d \"$XDG_RUNTIME_DIR\" ] && [ -w \"$XDG_RUNTIME_DIR\" ]; then \
-                         base=$XDG_RUNTIME_DIR; \
-                     elif [ -n \"${XDG_STATE_HOME:-}\" ]; then \
-                         base=$XDG_STATE_HOME; \
-                     elif [ -n \"${HOME:-}\" ]; then \
-                         base=$HOME/.local/state; \
-                     else \
-                         exit 1; \
-                     fi; \
-                     mkdir -p \"$base/flotilla\" && test -d \"$base/flotilla\" && test -w \"$base/flotilla\" && printf '%s' \"$base/flotilla\"",
-                    purpose,
-                ],
-                Path::new("/"),
-                &ChannelLabel::Noop,
-            )
+            .run("sh", &["-c", REMOTE_WRITABLE_BASE_SCRIPT, purpose], Path::new("/"), &ChannelLabel::Noop)
             .await
             .map_err(|error| format!("find writable directory on SSH host: {error}"))?;
         let base = base.trim();
@@ -150,7 +152,7 @@ mod tests {
 
     use async_trait::async_trait;
 
-    use super::SshCommandRunner;
+    use super::{SshCommandRunner, REMOTE_WRITABLE_BASE_SCRIPT};
     use crate::providers::{ChannelLabel, CommandOutput, CommandRunner, ProcessCommandRunner};
 
     struct RecordingRunner {
@@ -326,6 +328,33 @@ mod tests {
             let script = args.last().expect("remote execution script");
             script.contains("XDG_RUNTIME_DIR") && script.contains("XDG_STATE_HOME") && script.contains("HOME")
         }));
+    }
+
+    #[tokio::test]
+    async fn unusable_remote_state_home_falls_through_to_home() {
+        let home = tempfile::tempdir().expect("remote home");
+        let home_assignment = format!("HOME={}", home.path().display());
+
+        let base = ProcessCommandRunner
+            .run(
+                "env",
+                &[
+                    "-u",
+                    "XDG_RUNTIME_DIR",
+                    "XDG_STATE_HOME=/proc/flotilla-unwritable",
+                    &home_assignment,
+                    "sh",
+                    "-c",
+                    REMOTE_WRITABLE_BASE_SCRIPT,
+                    "flotilla-ssh-config-base",
+                ],
+                Path::new("/"),
+                &ChannelLabel::Noop,
+            )
+            .await
+            .expect("fall through unusable XDG state home");
+
+        assert_eq!(Path::new(base.trim()), home.path().join(".local/state/flotilla"));
     }
 
     #[tokio::test]

--- a/crates/flotilla-core/src/providers/ssh_runner.rs
+++ b/crates/flotilla-core/src/providers/ssh_runner.rs
@@ -1,4 +1,7 @@
-use std::{path::Path, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use uuid::Uuid;
@@ -55,6 +58,36 @@ impl SshCommandRunner {
         let ssh_args = self.ssh_shell_args(&script);
         self.runner.run("ssh", &ssh_args, Path::new("/"), label).await
     }
+
+    async fn writable_base(&self, purpose: &str) -> Result<PathBuf, String> {
+        let base = self
+            .run(
+                "sh",
+                &[
+                    "-c",
+                    "if [ -n \"${XDG_RUNTIME_DIR:-}\" ] && [ -d \"$XDG_RUNTIME_DIR\" ] && [ -w \"$XDG_RUNTIME_DIR\" ]; then \
+                         base=$XDG_RUNTIME_DIR; \
+                     elif [ -n \"${XDG_STATE_HOME:-}\" ]; then \
+                         base=$XDG_STATE_HOME; \
+                     elif [ -n \"${HOME:-}\" ]; then \
+                         base=$HOME/.local/state; \
+                     else \
+                         exit 1; \
+                     fi; \
+                     mkdir -p \"$base/flotilla\" && test -d \"$base/flotilla\" && test -w \"$base/flotilla\" && printf '%s' \"$base/flotilla\"",
+                    purpose,
+                ],
+                Path::new("/"),
+                &ChannelLabel::Noop,
+            )
+            .await
+            .map_err(|error| format!("find writable directory on SSH host: {error}"))?;
+        let base = base.trim();
+        if base.is_empty() {
+            return Err("find writable directory on SSH host: probe returned an empty path".to_string());
+        }
+        Ok(PathBuf::from(base))
+    }
 }
 
 #[async_trait]
@@ -77,6 +110,14 @@ impl CommandRunner for SshCommandRunner {
 
     async fn exists(&self, cmd: &str, args: &[&str]) -> bool {
         self.execute(cmd, args, Path::new("/"), &ChannelLabel::Noop).await.is_ok()
+    }
+
+    async fn writable_scratch_base(&self, _preferred: Option<&Path>, _fallback: &Path) -> Result<PathBuf, String> {
+        self.writable_base("flotilla-ssh-scratch-base").await
+    }
+
+    async fn writable_config_base(&self, _preferred: Option<&Path>, _fallback: &Path) -> Result<PathBuf, String> {
+        self.writable_base("flotilla-ssh-config-base").await
     }
 
     async fn ensure_file(&self, path: &Path, content: &str) -> Result<String, String> {
@@ -110,7 +151,7 @@ mod tests {
     use async_trait::async_trait;
 
     use super::SshCommandRunner;
-    use crate::providers::{ChannelLabel, CommandOutput, CommandRunner};
+    use crate::providers::{ChannelLabel, CommandOutput, CommandRunner, ProcessCommandRunner};
 
     struct RecordingRunner {
         calls: Mutex<Vec<(String, Vec<String>, PathBuf)>>,
@@ -261,6 +302,59 @@ mod tests {
         assert_eq!(args[4], "sh");
         assert_eq!(args[5], "-lc");
         assert_eq!(args[6], "cd '/' && exec 'cleat' '--version'");
+    }
+
+    #[tokio::test]
+    async fn writable_bases_are_derived_from_the_remote_environment() {
+        let inner = std::sync::Arc::new(RecordingRunner::with_run_results(vec![
+            Ok("/remote/runtime/flotilla".into()),
+            Ok("/remote/runtime/flotilla".into()),
+        ]));
+        let runner = SshCommandRunner::new("alice@feta.local", false, inner.clone());
+
+        let scratch =
+            runner.writable_scratch_base(Some(Path::new("/local/runtime")), Path::new("/local/state")).await.expect("remote scratch base");
+        let config =
+            runner.writable_config_base(Some(Path::new("/local/runtime")), Path::new("/local/state")).await.expect("remote config base");
+
+        assert_eq!(scratch, Path::new("/remote/runtime/flotilla"));
+        assert_eq!(config, Path::new("/remote/runtime/flotilla"));
+        let calls = inner.calls();
+        assert_eq!(calls.len(), 2);
+        assert!(calls.iter().flat_map(|(_, args, _)| args).all(|arg| !arg.contains("/local/runtime") && !arg.contains("/local/state")));
+        assert!(calls.iter().all(|(_, args, _)| {
+            let script = args.last().expect("remote execution script");
+            script.contains("XDG_RUNTIME_DIR") && script.contains("XDG_STATE_HOME") && script.contains("HOME")
+        }));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires batch-mode SSH access to localhost"]
+    async fn writable_bases_resolve_in_a_real_ssh_environment() {
+        let runner = SshCommandRunner::new("localhost", false, std::sync::Arc::new(ProcessCommandRunner));
+
+        let remote_base = runner
+            .writable_scratch_base(Some(Path::new("/daemon-only/runtime")), Path::new("/daemon-only/state"))
+            .await
+            .expect("resolve scratch base over real SSH");
+        let config_base = runner
+            .writable_config_base(Some(Path::new("/daemon-only/runtime")), Path::new("/daemon-only/state"))
+            .await
+            .expect("resolve config base over real SSH");
+
+        assert_eq!(config_base, remote_base);
+        assert!(remote_base.is_absolute());
+        assert!(!remote_base.starts_with("/daemon-only"));
+        eprintln!("real SSH writable base: {}", remote_base.display());
+        runner
+            .run(
+                "test",
+                &["-d", &remote_base.to_string_lossy(), "-a", "-w", &remote_base.to_string_lossy()],
+                Path::new("/"),
+                &ChannelLabel::Noop,
+            )
+            .await
+            .expect("selected remote base is writable");
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/credential.rs
+++ b/crates/flotilla-daemon/src/credential.rs
@@ -1034,6 +1034,14 @@ mod tests {
         }
     }
 
+    struct RotatingTokenEnv(StdMutex<VecDeque<String>>);
+
+    impl EnvVars for RotatingTokenEnv {
+        fn get(&self, key: &str) -> Option<String> {
+            (key == "TEST_CLAUDE_TOKEN").then(|| self.0.lock().expect("rotating token lock").pop_front()).flatten()
+        }
+    }
+
     type RecordedCall = (String, Vec<String>, Vec<u8>);
 
     #[derive(Default)]
@@ -1564,6 +1572,48 @@ interactions:
             .await
             .expect_err("ANTHROPIC_API_KEY outranks CLAUDE_CODE_OAUTH_TOKEN, so mixing them would silently drop the OAuth identity");
         assert!(error.contains("multiple granted credentials use this adapter"), "unexpected error: {error}");
+    }
+
+    #[tokio::test]
+    async fn rotating_named_claude_oauth_material_reuses_the_stable_config_directory() {
+        let backend = ResourceBackend::InMemory(InMemoryBackend::default()).with_local_root(NodeId::new("root-a"));
+        backend
+            .clone()
+            .definitions::<CredentialSpec>("flotilla")
+            .create(&InputMeta::builder().name("claude-max".to_string()).build(), &CredentialSpecSpec {
+                consumer: CredentialConsumer::ClaudeOauth { account_email: "ops@example.com".to_string() },
+                source: CredentialSource::Env { name: "TEST_CLAUDE_TOKEN".to_string() },
+                lifecycle: CredentialLifecycle::Refreshable,
+                placement: CredentialPlacementRequirements::default(),
+            })
+            .await
+            .expect("create refreshable Claude credential declaration");
+        let env = Arc::new(RotatingTokenEnv(StdMutex::new(VecDeque::from([
+            "token-before-rotation".to_string(),
+            "token-after-rotation".to_string(),
+        ]))));
+        let runner = Arc::new(RecordingRunner::default());
+        let bag = EnvironmentBag::new().with(EnvironmentAssertion::binary("claude", "/usr/bin/claude"));
+        let store = CredentialStore::new(backend, "flotilla", env, bag, runner.clone(), PathBuf::from("/tmp/flotilla-test-state"));
+        let credential_refs = BTreeSet::from(["claude-max".to_string()]);
+
+        let before: BTreeMap<_, _> =
+            store.prepare("env-a", &credential_refs, runner.clone()).await.expect("prepare before rotation").into_iter().collect();
+        let after: BTreeMap<_, _> =
+            store.prepare("env-a", &credential_refs, runner.clone()).await.expect("prepare after rotation").into_iter().collect();
+
+        assert_eq!(before.get("CLAUDE_CODE_OAUTH_TOKEN"), Some(&"token-before-rotation".to_string()));
+        assert_eq!(after.get("CLAUDE_CODE_OAUTH_TOKEN"), Some(&"token-after-rotation".to_string()));
+        assert_eq!(before.get("CLAUDE_CONFIG_DIR"), after.get("CLAUDE_CONFIG_DIR"));
+        assert_eq!(after.get("CLAUDE_CONFIG_DIR"), Some(&"/tmp/flotilla-test-state/credentials/claude-max/claude".to_string()));
+        let calls = runner.calls.lock().expect("calls lock");
+        assert!(calls.iter().all(|(command, args, _)| {
+            command != "rm" || args == &["-rf".to_string(), "/tmp/flotilla-test-state/credentials/claude-max/claude-preflight".to_string()]
+        }));
+        assert!(calls
+            .iter()
+            .flat_map(|(_, args, _)| args)
+            .all(|arg| !arg.contains("token-before-rotation") && !arg.contains("token-after-rotation")));
     }
 
     struct DeadTokenRunner {


### PR DESCRIPTION
## Summary

- make `SshCommandRunner` resolve scratch and persistent config bases from the remote shell's `XDG_RUNTIME_DIR`, `XDG_STATE_HOME`, or `HOME`, without accepting daemon-host path hints
- lock in the post-#1514 Claude OAuth rotation policy: stable credential-name config paths are reused across refreshable material rotations, avoiding both orphan creation and cleanup races with live sessions
- model credential behavior on resolved agent requirements and cover the forward-provisioned ambient-only expiry refusal path with a synthetic capability

## Real SSH environment validation

Executed against the machine's real batch-mode SSH environment:

```text
cargo test -p flotilla-core --locked \
  providers::ssh_runner::tests::writable_bases_resolve_in_a_real_ssh_environment \
  -- --ignored --nocapture
```

The runner crossed an actual `ssh localhost` boundary, ignored deliberately invalid daemon-host hints under `/daemon-only`, selected the remote environment's `/run/user/1000/flotilla`, and verified that directory exists and is writable from the remote execution world. Result: **passed**.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- real SSH environment test above

Closes #1510
Closes #1495
Closes #1522
