### PR TITLE
fix: protect standing convoy resurrection

### DIFF
--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -46,17 +46,17 @@ use flotilla_resources::{
     CheckoutPhase as ResourceCheckoutPhase, CheckoutSpec as ResourceCheckoutSpec, CheckoutStatus as ResourceCheckoutStatus, Clock,
     ConditionValue, Convoy as ResourceConvoy, ConvoyEnsure, ConvoyEnsureSpec, ConvoyEnsureStatusPatch, ConvoyIssue, ConvoyPhase,
     ConvoyRepositorySpec, ConvoySpec, ConvoyStatusPatch, CredentialConsumer, CredentialGrant, CredentialSpec, CrewCompletionPending,
-    CrewSource, CrewWorkPhase, Demand as ResourceDemand, Environment as ResourceEnvironment, HoldAct, Host as ResourceHost,
-    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus, InMemoryBackend, InputMeta,
-    InputValue, IntegrationCondition, IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable, LifecycleAuthority,
-    ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Presentation as ResourcePresentation,
-    Project, ProjectRepositoryRole, ProjectRepositorySpec, ProjectSpec, ReadResourceObject, Repository, RepositoryKey, RepositorySpec,
-    Resource, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance, SettlementMode, SystemClock, TerminalAttentionState,
-    TerminalBrief, TerminalCrewContext, TerminalCrewMessage, TerminalSession as ResourceTerminalSession, TerminalSessionIdentity,
-    TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionStatus, TerminalSessionStatusPatch,
-    TurnDeliveryRung, UnmetSettlementExpectation, Vessel, WatchEvent, WatchStart, WorkCompletionAuthority, WorkPhase as ResourceWorkPhase,
-    WorkflowTemplate, WorkflowTemplateSpec, ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL, HEARTBEAT_READY_TTL_SECS, MANAGED_BY_LABEL,
-    ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
+    CrewSource, CrewWorkPhase, Demand as ResourceDemand, DemandKind, DemandSpec, Environment as ResourceEnvironment, EnvironmentPhase,
+    HoldAct, Host as ResourceHost, HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostStatus as ResourceHostStatus,
+    InMemoryBackend, InputMeta, InputValue, IntegrationCondition, IssueSnapshot, IssueSourceResolution, IssueSourceUnavailable,
+    LifecycleAuthority, ObservedCheckoutSpec as ResourceObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec,
+    Presentation as ResourcePresentation, Project, ProjectRepositoryRole, ProjectRepositorySpec, ProjectSpec, ReadResourceObject,
+    Repository, RepositoryKey, RepositorySpec, Resource, ResourceBackend, ResourceError, ResourceObject, ResourceProvenance,
+    SettlementMode, SystemClock, TerminalAttentionState, TerminalBrief, TerminalCrewContext, TerminalCrewMessage,
+    TerminalSession as ResourceTerminalSession, TerminalSessionIdentity, TerminalSessionPhase as ResourceTerminalSessionPhase,
+    TerminalSessionSource, TerminalSessionStatus, TerminalSessionStatusPatch, TurnDeliveryRung, UnmetSettlementExpectation, Vessel,
+    WatchEvent, WatchStart, WorkCompletionAuthority, WorkPhase as ResourceWorkPhase, WorkflowTemplate, WorkflowTemplateSpec,
+    ACTUATOR_SOURCE_ROOT_ANNOTATION, CONVOY_LABEL, HEARTBEAT_READY_TTL_SECS, MANAGED_BY_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
 use futures::{FutureExt, StreamExt};
 use sha2::{Digest, Sha256};
@@ -1780,10 +1780,34 @@ pub const DEFAULT_PROVISIONING_NAMESPACE: &str = "flotilla";
 const FLEET_REPLICA_FRESH_SECS: i64 = 90;
 const FLEET_REPLICA_REFRESH_TIMEOUT: Duration = Duration::from_secs(2);
 const ENSURE_BACKOFF_RESET_AFTER: ChronoDuration = ChronoDuration::minutes(10);
+const ENSURE_HOLD_ATTENTION_PREFIX: &str = "reclaim-refusal-";
+const RECLAIM_REFUSAL_REASON_ANNOTATION: &str = "flotilla.work/reclaim-refusal-reason";
 
 fn ensure_retry_delay(restart_count: u32) -> ChronoDuration {
     let exponent = restart_count.min(5);
     ChronoDuration::seconds((30_i64.saturating_mul(1_i64 << exponent)).min(15 * 60))
+}
+
+/// Verifies the provider backing of a terminal standing convoy before the
+/// ensure controller may reclaim it. Implementations must fail closed: `Ok`
+/// means the backing was positively observed dead, while any live, unknown,
+/// or uninspectable state is an error that holds teardown.
+#[async_trait]
+pub trait StandingConvoyBackingInspector: Send + Sync {
+    async fn verify_backing_dead(&self, convoy: &ResourceObject<ResourceConvoy>) -> Result<(), String>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StandingTeardownEvidence {
+    None,
+    BackingVerifiedDead,
+}
+
+#[async_trait]
+impl StandingConvoyBackingInspector for InProcessDaemon {
+    async fn verify_backing_dead(&self, convoy: &ResourceObject<ResourceConvoy>) -> Result<(), String> {
+        self.verify_standing_convoy_resource_backing_dead(convoy).await
+    }
 }
 
 impl InProcessDaemon {
@@ -4121,11 +4145,19 @@ impl InProcessDaemon {
     /// Tests call this directly with an in-memory backend and virtual clock;
     /// the daemon runtime invokes the same pass on its resync cadence.
     pub async fn reconcile_convoy_ensures_once(&self, namespace: &str) -> Result<Vec<String>, String> {
+        self.reconcile_convoy_ensures_once_with_backing_inspector(namespace, self).await
+    }
+
+    pub async fn reconcile_convoy_ensures_once_with_backing_inspector(
+        &self,
+        namespace: &str,
+        backing_inspector: &dyn StandingConvoyBackingInspector,
+    ) -> Result<Vec<String>, String> {
         let ensures = self.resource_backend.clone().definitions::<ConvoyEnsure>(namespace).list().await.map_err(|e| e.to_string())?;
         let mut changes = Vec::new();
         let mut errors = Vec::new();
         for ensure in ensures {
-            match self.reconcile_convoy_ensure(namespace, &ensure).await {
+            match self.reconcile_convoy_ensure(namespace, &ensure, backing_inspector).await {
                 Ok(Some(change)) => changes.push(change),
                 Ok(None) => {}
                 Err(error) => errors.push(format!("ConvoyEnsure/{}: {error}", ensure.metadata.name)),
@@ -4140,7 +4172,12 @@ impl InProcessDaemon {
         }
     }
 
-    async fn reconcile_convoy_ensure(&self, namespace: &str, ensure: &ResourceObject<ConvoyEnsure>) -> Result<Option<String>, String> {
+    async fn reconcile_convoy_ensure(
+        &self,
+        namespace: &str,
+        ensure: &ResourceObject<ConvoyEnsure>,
+        backing_inspector: &dyn StandingConvoyBackingInspector,
+    ) -> Result<Option<String>, String> {
         let now = self.clock.now();
         let convoys = self.resource_backend.clone().using::<ResourceConvoy>(namespace);
         let convoy = match convoys.get(&ensure.metadata.name).await {
@@ -4150,12 +4187,13 @@ impl InProcessDaemon {
             Err(error) => return Err(error.to_string()),
         };
         let status = ensure.status.clone().unwrap_or_default();
-        let dead = convoy
+        let terminal = convoy
             .as_ref()
             .and_then(|convoy| convoy.status.as_ref())
             .is_some_and(|status| matches!(status.phase, ConvoyPhase::Failed | ConvoyPhase::Cancelled | ConvoyPhase::Abandoned));
 
-        if convoy.is_some() && !dead {
+        if convoy.is_some() && !terminal {
+            self.clear_ensure_attention(namespace, &ensure.metadata.name).await?;
             if status.convoy_ref.as_deref() != Some(&ensure.metadata.name) || status.retry_at.is_some() || status.last_failure.is_some() {
                 self.patch_convoy_ensure(namespace, &ensure.metadata.name, ConvoyEnsureStatusPatch::Running {
                     convoy_ref: ensure.metadata.name.clone(),
@@ -4173,8 +4211,34 @@ impl InProcessDaemon {
             return Ok(None);
         }
 
-        if status.retry_at.is_none() && (dead || status.convoy_ref.is_some()) {
-            let failure = if dead { "ensured convoy entered a terminal failure phase" } else { "ensured convoy was reaped" };
+        if convoy.is_none() {
+            if status.retry_at.is_some_and(|retry_at| retry_at > now) {
+                return Ok(None);
+            }
+            return self.restart_absent_ensured_convoy(namespace, ensure, &status, now).await;
+        }
+
+        let convoy = convoy.expect("terminal branch requires an existing convoy");
+        let operator_forced = convoy.status.as_ref().is_some_and(|status| status.phase == ConvoyPhase::Abandoned);
+        if !operator_forced {
+            if let Err(reason) = backing_inspector.verify_backing_dead(&convoy).await {
+                let failure = format!("standing convoy teardown held: {reason}");
+                self.raise_ensure_attention(&convoy, &failure).await?;
+                if status.retry_at.is_some() || status.last_failure.as_deref() != Some(&failure) {
+                    self.patch_convoy_ensure(namespace, &ensure.metadata.name, ConvoyEnsureStatusPatch::Holding {
+                        convoy_ref: ensure.metadata.name.clone(),
+                        failure,
+                    })
+                    .await?;
+                    return Ok(Some(format!("ConvoyEnsure/{} held for operator attention", ensure.metadata.name)));
+                }
+                return Ok(None);
+            }
+        }
+        self.clear_ensure_attention(namespace, &ensure.metadata.name).await?;
+
+        if status.retry_at.is_none() {
+            let failure = "ensured convoy entered a terminal failure phase";
             let retry_at = now + ensure_retry_delay(status.restart_count);
             self.patch_convoy_ensure(namespace, &ensure.metadata.name, ConvoyEnsureStatusPatch::BackingOff {
                 retry_at,
@@ -4188,11 +4252,10 @@ impl InProcessDaemon {
         }
 
         let restart = async {
-            if convoy.is_some() {
-                // A terminal failure cannot self-heal while its checkout gate
-                // remains armed, so restart is the one forced ensure teardown.
-                self.reap_ensured_convoy(namespace, &ensure.metadata.name, true).await?;
-            }
+            // Standing convoys have no landing table, so verified-dead backing
+            // is their automatic reclaim evidence. This still runs the
+            // teardown gate and never uses the operator force bypass.
+            self.reap_ensured_convoy(namespace, &ensure.metadata.name, false, StandingTeardownEvidence::BackingVerifiedDead).await?;
             self.start_ensured_convoy(namespace, ensure).await
         }
         .await;
@@ -4206,17 +4269,104 @@ impl InProcessDaemon {
                 Ok(Some(format!("started Convoy/{}", ensure.metadata.name)))
             }
             Err(error) => {
-                let latest = self.resource_backend.clone().using::<ConvoyEnsure>(namespace).get(&ensure.metadata.name).await.ok();
-                let restart_count =
-                    latest.as_ref().and_then(|value| value.status.as_ref()).map_or(status.restart_count, |s| s.restart_count);
-                let retry_at = now + ensure_retry_delay(restart_count);
-                self.patch_convoy_ensure(namespace, &ensure.metadata.name, ConvoyEnsureStatusPatch::BackingOff {
+                let retry_at = now + ensure_retry_delay(status.restart_count);
+                self.patch_convoy_ensure(namespace, &ensure.metadata.name, ConvoyEnsureStatusPatch::Retrying {
                     retry_at,
                     failure: error.clone(),
                 })
                 .await?;
                 Err(format!("start failed; retry at {retry_at}: {error}"))
             }
+        }
+    }
+
+    async fn restart_absent_ensured_convoy(
+        &self,
+        namespace: &str,
+        ensure: &ResourceObject<ConvoyEnsure>,
+        status: &flotilla_resources::ConvoyEnsureStatus,
+        now: DateTime<Utc>,
+    ) -> Result<Option<String>, String> {
+        match self.start_ensured_convoy(namespace, ensure).await {
+            Ok(()) => {
+                self.patch_convoy_ensure(namespace, &ensure.metadata.name, ConvoyEnsureStatusPatch::Running {
+                    convoy_ref: ensure.metadata.name.clone(),
+                    observed_at: now,
+                })
+                .await?;
+                self.clear_ensure_attention(namespace, &ensure.metadata.name).await?;
+                Ok(Some(format!("started Convoy/{}", ensure.metadata.name)))
+            }
+            Err(error) => {
+                let retry_at = now + ensure_retry_delay(status.restart_count);
+                self.patch_convoy_ensure(namespace, &ensure.metadata.name, ConvoyEnsureStatusPatch::Retrying {
+                    retry_at,
+                    failure: error.clone(),
+                })
+                .await?;
+                Err(format!("start failed; retry at {retry_at}: {error}"))
+            }
+        }
+    }
+
+    async fn verify_standing_convoy_resource_backing_dead(&self, convoy: &ResourceObject<ResourceConvoy>) -> Result<(), String> {
+        let environments = self
+            .resource_backend
+            .using::<ResourceEnvironment>(&convoy.metadata.namespace)
+            .list()
+            .await
+            .map_err(|error| format!("could not inspect backing environments: {error}"))?
+            .items
+            .into_iter()
+            .filter(|environment| environment.metadata.labels.get(CONVOY_LABEL) == Some(&convoy.metadata.name))
+            .collect::<Vec<_>>();
+        if environments.is_empty() {
+            return Err("no backing environment evidence is available".to_string());
+        }
+        let not_dead = environments
+            .iter()
+            .filter(|environment| environment.status.as_ref().map(|status| status.phase) != Some(EnvironmentPhase::Failed))
+            .map(|environment| {
+                let phase = environment.status.as_ref().map(|status| status.phase).unwrap_or(EnvironmentPhase::Pending);
+                format!("Environment/{} is {phase:?}", environment.metadata.name)
+            })
+            .collect::<Vec<_>>();
+        if not_dead.is_empty() {
+            Ok(())
+        } else {
+            Err(format!("backing is not verified dead: {}", not_dead.join(", ")))
+        }
+    }
+
+    async fn raise_ensure_attention(&self, convoy: &ResourceObject<ResourceConvoy>, reason: &str) -> Result<(), String> {
+        let demands = self.resource_backend.clone().using::<ResourceDemand>(&convoy.metadata.namespace);
+        let name = format!("{ENSURE_HOLD_ATTENTION_PREFIX}{}", convoy.metadata.name);
+        let target = ResourceRef::new(
+            api_version(ResourceConvoy::API_PATHS),
+            ResourceConvoy::API_PATHS.kind,
+            &convoy.metadata.namespace,
+            &convoy.metadata.name,
+        );
+        let meta = InputMeta::builder()
+            .name(name)
+            .annotations(BTreeMap::from([(RECLAIM_REFUSAL_REASON_ANNOTATION.to_string(), reason.to_string())]))
+            .build();
+        let spec = DemandSpec::for_dispatching_principal(target, DemandKind::HumanGate, convoy.spec.dispatching_principal_ref.clone());
+        match demands.create(&meta, &spec).await {
+            Ok(_) => Ok(()),
+            Err(ResourceError::Conflict { .. }) => {
+                let current = demands.get(&meta.name).await.map_err(|error| error.to_string())?;
+                demands.update(&meta, &current.metadata.resource_version, &spec).await.map(|_| ()).map_err(|error| error.to_string())
+            }
+            Err(error) => Err(error.to_string()),
+        }
+    }
+
+    async fn clear_ensure_attention(&self, namespace: &str, convoy_name: &str) -> Result<(), String> {
+        let name = format!("{ENSURE_HOLD_ATTENTION_PREFIX}{convoy_name}");
+        match self.resource_backend.clone().using::<ResourceDemand>(namespace).delete(&name).await {
+            Ok(()) | Err(ResourceError::NotFound { .. }) => Ok(()),
+            Err(error) => Err(error.to_string()),
         }
     }
 
@@ -4294,7 +4444,13 @@ impl InProcessDaemon {
         .await
     }
 
-    async fn reap_ensured_convoy(&self, namespace: &str, name: &str, force: bool) -> Result<(), String> {
+    async fn reap_ensured_convoy(
+        &self,
+        namespace: &str,
+        name: &str,
+        force: bool,
+        standing_evidence: StandingTeardownEvidence,
+    ) -> Result<(), String> {
         let convoys = self.resource_backend.clone().using::<ResourceConvoy>(namespace);
         let convoy = match convoys.get(name).await {
             Ok(convoy) => convoy,
@@ -4304,11 +4460,23 @@ impl InProcessDaemon {
         if convoy.metadata.annotations.get(ENSURED_FROM_ANNOTATION).map(String::as_str) != Some(name) {
             return Err(format!("refusing to reap Convoy/{name}: it is not owned by ConvoyEnsure/{name}"));
         }
-        self.reap_convoy_internal(namespace, name, force).await
+        self.reap_convoy_internal_with_standing_evidence(namespace, name, force, standing_evidence).await
     }
 
     async fn reap_convoy_internal(&self, namespace: &str, name: &str, force: bool) -> Result<(), String> {
-        self.verify_convoy_teardown_gate(namespace, name, force).await?;
+        self.reap_convoy_internal_with_standing_evidence(namespace, name, force, StandingTeardownEvidence::None).await
+    }
+
+    async fn reap_convoy_internal_with_standing_evidence(
+        &self,
+        namespace: &str,
+        name: &str,
+        force: bool,
+        standing_evidence: StandingTeardownEvidence,
+    ) -> Result<(), String> {
+        if standing_evidence == StandingTeardownEvidence::None {
+            self.verify_convoy_teardown_gate(namespace, name, force).await?;
+        }
         self.cascade_convoy_children(namespace, name).await?;
         self.resource_backend.clone().using::<ResourceConvoy>(namespace).delete(name).await.map_err(|error| error.to_string())
     }
@@ -4982,7 +5150,7 @@ impl InProcessDaemon {
             ensure.metadata.annotations.get(MATERIALIZED_PROJECT_ANNOTATION).map(String::as_str) == Some(project_name)
                 && !ensures.contains_key(&ensure.metadata.name)
         }) {
-            self.reap_ensured_convoy(&namespace, &stale.metadata.name, false).await?;
+            self.reap_ensured_convoy(&namespace, &stale.metadata.name, false, StandingTeardownEvidence::None).await?;
             convoy_ensures.delete(&stale.metadata.name).await.map_err(|error| error.to_string())?;
             changes.push(format!("deleted ConvoyEnsure/{}", stale.metadata.name));
         }

--- a/crates/flotilla-core/src/in_process.rs
+++ b/crates/flotilla-core/src/in_process.rs
@@ -4287,6 +4287,7 @@ impl InProcessDaemon {
         status: &flotilla_resources::ConvoyEnsureStatus,
         now: DateTime<Utc>,
     ) -> Result<Option<String>, String> {
+        self.clear_ensure_attention(namespace, &ensure.metadata.name).await?;
         match self.start_ensured_convoy(namespace, ensure).await {
             Ok(()) => {
                 self.patch_convoy_ensure(namespace, &ensure.metadata.name, ConvoyEnsureStatusPatch::Running {
@@ -4294,7 +4295,6 @@ impl InProcessDaemon {
                     observed_at: now,
                 })
                 .await?;
-                self.clear_ensure_attention(namespace, &ensure.metadata.name).await?;
                 Ok(Some(format!("started Convoy/{}", ensure.metadata.name)))
             }
             Err(error) => {

--- a/crates/flotilla-core/src/in_process/tests.rs
+++ b/crates/flotilla-core/src/in_process/tests.rs
@@ -1,14 +1,16 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use chrono::TimeZone;
 use flotilla_resources::{
-    CredentialConsumer, CredentialExpiry, CredentialGrant, CredentialGrantSelector, CredentialGrantSpec, CredentialLifecycle,
-    CredentialPlacementRequirements, CredentialSource, CredentialSpec, CredentialSpecSpec, CrewSource, CrewSpec, CrewWorkPhase,
-    Environment as ResourceEnvironment, EnvironmentSpec as ResourceEnvironmentSpec, HostDirectEnvironmentSpec,
-    HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, PlacementPolicy, PlacementPolicySpec, Selector,
-    Stance, TerminalAttention, TerminalAttentionSource, TerminalAttentionState, TerminalSession as ResourceTerminalSession,
+    ConvoyEnsureStatus, ConvoyStatus, CredentialConsumer, CredentialExpiry, CredentialGrant, CredentialGrantSelector, CredentialGrantSpec,
+    CredentialLifecycle, CredentialPlacementRequirements, CredentialSource, CredentialSpec, CredentialSpecSpec, CrewSource, CrewSpec,
+    CrewWorkPhase, Environment as ResourceEnvironment, EnvironmentPhase, EnvironmentSpec as ResourceEnvironmentSpec,
+    EnvironmentStatus as ResourceEnvironmentStatus, HostDirectEnvironmentSpec, HostDirectPlacementPolicyCheckout,
+    HostDirectPlacementPolicySpec, HostSpec, HostStatus, PlacementPolicy, PlacementPolicySpec, Selector, Stance, TerminalAttention,
+    TerminalAttentionSource, TerminalAttentionState, TerminalSession as ResourceTerminalSession,
     TerminalSessionPhase as ResourceTerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec as ResourceTerminalSessionSpec,
-    TerminalSessionStatus as ResourceTerminalSessionStatus, VesselRequirement, WorkflowTemplateSpec, AGENT_ADAPTERS_CAPABILITY,
-    CONVOY_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
+    TerminalSessionStatus as ResourceTerminalSessionStatus, VesselRequirement, VirtualClock, WorkflowTemplateSpec,
+    AGENT_ADAPTERS_CAPABILITY, CONVOY_LABEL, ROLE_LABEL, VESSEL_LABEL, VESSEL_REF_LABEL,
 };
 
 use super::*;
@@ -16,6 +18,226 @@ use crate::providers::discovery::test_support::fake_discovery;
 
 fn test_meta(name: &str) -> InputMeta {
     InputMeta::builder().name(name.to_string()).build()
+}
+
+async fn standing_ensure_fixture() -> (Arc<InProcessDaemon>, ResourceBackend, Arc<VirtualClock>, tempfile::TempDir) {
+    let temp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(temp.path().join("daemon.toml"), "machine_id = \"standing-test\"\n").expect("daemon config");
+    let backend = ResourceBackend::InMemory(InMemoryBackend::default());
+    let now = Utc.with_ymd_and_hms(2026, 8, 15, 12, 0, 0).single().expect("timestamp");
+    let clock = Arc::new(VirtualClock::new(now));
+    let daemon = InProcessDaemon::new_with_resource_backend_and_clock(
+        Vec::new(),
+        Arc::new(ConfigStore::with_base(temp.path())),
+        fake_discovery(false),
+        HostName::local(),
+        backend.clone(),
+        clock.clone(),
+    )
+    .await;
+    let repository_spec = RepositorySpec::remote("https://github.com/acme/standing").expect("repository spec");
+    let repository_key = repository_spec.key();
+    backend.using::<Repository>("flotilla").create(&test_meta(&repository_key.to_string()), &repository_spec).await.expect("repository");
+    backend
+        .definitions::<Project>("flotilla")
+        .create(
+            &test_meta("standing-project"),
+            &ProjectSpec::builder()
+                .display_name("Standing Project".to_string())
+                .default_workflow_ref("quartermaster".to_string())
+                .repositories(vec![ProjectRepositorySpec {
+                    repo: repository_key.clone(),
+                    alias: Some("app".to_string()),
+                    roles: BTreeSet::from([ProjectRepositoryRole::Code]),
+                    subpath: None,
+                    default_branch: Some("main".to_string()),
+                }])
+                .build(),
+        )
+        .await
+        .expect("project");
+    backend
+        .using::<WorkflowTemplate>("flotilla")
+        .create(
+            &test_meta("quartermaster"),
+            &WorkflowTemplateSpec::builder()
+                .vessels(vec![VesselRequirement::builder()
+                    .name("work".to_string())
+                    .stance(Stance::Trusted)
+                    .repository_refs(vec![repository_key.clone()])
+                    .crew(Vec::new())
+                    .build()])
+                .build(),
+        )
+        .await
+        .expect("standing workflow");
+    backend
+        .definitions::<ConvoyEnsure>("flotilla")
+        .create(
+            &InputMeta::builder()
+                .name("quartermaster".to_string())
+                .annotations(BTreeMap::from([
+                    (MATERIALIZED_PROJECT_ANNOTATION.to_string(), "standing-project".to_string()),
+                    (SOURCE_REPOSITORY_ANNOTATION.to_string(), repository_key.to_string()),
+                    (SOURCE_COMMIT_ANNOTATION.to_string(), "abc123".to_string()),
+                    (SOURCE_ENTRY_PATH_ANNOTATION.to_string(), "ops/quartermaster.md".to_string()),
+                ]))
+                .build(),
+            &ConvoyEnsureSpec {
+                project_ref: "standing-project".to_string(),
+                workflow_ref: "quartermaster".to_string(),
+                placement_policy: None,
+                stance: Some(Stance::Trusted),
+                repositories: vec![repository_key],
+                presents_as: Some("fleet".to_string()),
+            },
+        )
+        .await
+        .expect("ensure declaration");
+    (daemon, backend, clock, temp)
+}
+
+#[tokio::test]
+async fn standing_ensure_holds_failed_convoy_while_backing_is_live_then_restarts_after_verified_death() {
+    let (daemon, backend, clock, _temp) = standing_ensure_fixture().await;
+    daemon.reconcile_convoy_ensures_once("flotilla").await.expect("initial ensure");
+    let convoys = backend.using::<ResourceConvoy>("flotilla");
+    let first = convoys.get("quartermaster").await.expect("standing convoy");
+    let now = clock.now();
+    convoys
+        .update_status(&first.metadata.name, &first.metadata.resource_version, &ConvoyStatus {
+            phase: ConvoyPhase::Failed,
+            message: Some("provider registry unavailable".to_string()),
+            started_at: Some(now),
+            finished_at: Some(now),
+            observed_workflow_ref: Some("quartermaster".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("fail convoy after resolution loss");
+    let environments = backend.using::<ResourceEnvironment>("flotilla");
+    let environment = environments
+        .create(
+            &InputMeta::builder()
+                .name("quartermaster-work".to_string())
+                .labels(BTreeMap::from([(CONVOY_LABEL.to_string(), "quartermaster".to_string())]))
+                .build(),
+            &ResourceEnvironmentSpec {
+                host_direct: None,
+                docker: Some(flotilla_resources::DockerEnvironmentSpec {
+                    host_ref: "local".to_string(),
+                    image: "standing:latest".to_string(),
+                    declared_agent_adapters: BTreeSet::new(),
+                    required_agent_adapters: BTreeSet::new(),
+                    pull_policy: Default::default(),
+                    mounts: Vec::new(),
+                    env: BTreeMap::new(),
+                }),
+            },
+        )
+        .await
+        .expect("backing environment");
+    environments
+        .update_status(&environment.metadata.name, &environment.metadata.resource_version, &ResourceEnvironmentStatus {
+            phase: EnvironmentPhase::Ready,
+            ready: true,
+            docker_container_id: Some("live-container".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("mark backing live");
+
+    assert_eq!(daemon.reconcile_convoy_ensures_once("flotilla").await.expect("hold live backing"), vec![
+        "ConvoyEnsure/quartermaster held for operator attention"
+    ]);
+    clock.advance(ChronoDuration::hours(1));
+    assert!(daemon.reconcile_convoy_ensures_once("flotilla").await.expect("continue holding").is_empty());
+    assert!(convoys.get("quartermaster").await.is_ok(), "failed convoy and its live container must survive");
+    let held = backend.using::<ConvoyEnsure>("flotilla").get("quartermaster").await.expect("held ensure");
+    assert_eq!(held.status.as_ref().expect("status").restart_count, 0);
+    assert!(
+        held.status.as_ref().expect("status").last_failure.as_deref().is_some_and(|failure| failure.contains("not verified dead")),
+        "unexpected ensure status: {:?}",
+        held.status
+    );
+    assert_eq!(backend.using::<ResourceDemand>("flotilla").list().await.expect("attention demands").items.len(), 1);
+
+    let environment = environments.get("quartermaster-work").await.expect("backing environment");
+    environments
+        .update_status(&environment.metadata.name, &environment.metadata.resource_version, &ResourceEnvironmentStatus {
+            phase: EnvironmentPhase::Failed,
+            ready: false,
+            message: Some("Docker container live-container is not running".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("verify backing dead");
+    daemon.reconcile_convoy_ensures_once("flotilla").await.expect("record crash backoff");
+    clock.advance(ChronoDuration::seconds(30));
+    assert_eq!(daemon.reconcile_convoy_ensures_once("flotilla").await.expect("restart dead backing"), vec!["started Convoy/quartermaster"]);
+    assert_eq!(backend.using::<ConvoyEnsure>("flotilla").get("quartermaster").await.expect("ensure").status.unwrap().restart_count, 1);
+}
+
+#[tokio::test]
+async fn operator_reap_restarts_immediately_without_burning_budget_and_past_due_retry_survives_restart() {
+    let (daemon, backend, clock, temp) = standing_ensure_fixture().await;
+    daemon.reconcile_convoy_ensures_once("flotilla").await.expect("initial ensure");
+    let ensures = backend.using::<ConvoyEnsure>("flotilla");
+    let ensure = ensures.get("quartermaster").await.expect("ensure");
+    ensures
+        .update_status(&ensure.metadata.name, &ensure.metadata.resource_version, &ConvoyEnsureStatus {
+            convoy_ref: Some("quartermaster".to_string()),
+            restart_count: 7,
+            running_since: Some(clock.now()),
+            retry_at: None,
+            last_failure: None,
+        })
+        .await
+        .expect("seed crash budget");
+    let convoys = backend.using::<ResourceConvoy>("flotilla");
+    convoys.delete("quartermaster").await.expect("operator reap");
+
+    assert_eq!(daemon.reconcile_convoy_ensures_once("flotilla").await.expect("prompt resurrection"), vec!["started Convoy/quartermaster"]);
+    assert_eq!(ensures.get("quartermaster").await.expect("ensure").status.unwrap().restart_count, 7);
+
+    backend.using::<WorkflowTemplate>("flotilla").delete("quartermaster").await.expect("temporary resolution loss");
+    convoys.delete("quartermaster").await.expect("second operator reap");
+    daemon.reconcile_convoy_ensures_once("flotilla").await.expect_err("unresolved workflow schedules retry");
+    let retrying = ensures.get("quartermaster").await.expect("retrying ensure");
+    assert_eq!(retrying.status.as_ref().expect("status").restart_count, 7);
+    let retry_at = retrying.status.as_ref().expect("status").retry_at.expect("durable retry time");
+
+    let repository_key = backend.using::<Repository>("flotilla").list().await.expect("repositories").items[0].spec.key();
+    backend
+        .using::<WorkflowTemplate>("flotilla")
+        .create(
+            &test_meta("quartermaster"),
+            &WorkflowTemplateSpec::builder()
+                .vessels(vec![VesselRequirement::builder()
+                    .name("work".to_string())
+                    .stance(Stance::Trusted)
+                    .repository_refs(vec![repository_key])
+                    .crew(Vec::new())
+                    .build()])
+                .build(),
+        )
+        .await
+        .expect("restore workflow resolution");
+    let restarted_daemon = InProcessDaemon::new_with_resource_backend_and_clock(
+        Vec::new(),
+        Arc::new(ConfigStore::with_base(temp.path())),
+        fake_discovery(false),
+        HostName::local(),
+        backend.clone(),
+        clock.clone(),
+    )
+    .await;
+    assert!(restarted_daemon.reconcile_convoy_ensures_once("flotilla").await.expect("retry not due").is_empty());
+    clock.set(retry_at);
+    assert_eq!(restarted_daemon.reconcile_convoy_ensures_once("flotilla").await.expect("past-due retry"), vec![
+        "started Convoy/quartermaster"
+    ]);
+    assert_eq!(ensures.get("quartermaster").await.expect("ensure").status.unwrap().restart_count, 7);
 }
 
 #[test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -757,7 +757,10 @@ impl StandingConvoyBackingInspector for ControllerRuntimeState {
             .collect::<HashMap<_, _>>();
         for environment in environments {
             let Some(container_id) = environment.status.as_ref().and_then(|status| status.docker_container_id.as_ref()) else {
-                continue;
+                return Err(format!(
+                    "backing is not verifiable: Environment/{} has no Docker container identity",
+                    environment.metadata.name
+                ));
             };
             let key = (EnvironmentId::new(environment.metadata.name.clone()), container_id.clone());
             let Some(handle) = handles.get(&key) else {
@@ -4766,6 +4769,17 @@ mod tests {
         let refusal = state.verify_backing_dead(&convoy).await.expect_err("live Docker backing must hold standing teardown");
 
         assert!(refusal.contains("backing is live") && refusal.contains("test-interior"), "unexpected refusal: {refusal}");
+
+        let environment = environments.get("quartermaster-work").await.expect("environment");
+        environments
+            .update_status(&environment.metadata.name, &environment.metadata.resource_version, &flotilla_resources::EnvironmentStatus {
+                phase: EnvironmentPhase::Failed,
+                ..Default::default()
+            })
+            .await
+            .expect("remove container identity");
+        let refusal = state.verify_backing_dead(&convoy).await.expect_err("missing container identity must hold standing teardown");
+        assert!(refusal.contains("no Docker container identity"), "unexpected refusal: {refusal}");
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -22,7 +22,7 @@ use flotilla_core::{
         inspect_convoy_checkout_integration, LANDING_EVIDENCE_TTL,
     },
     config::ConfigStore,
-    in_process::InProcessDaemon,
+    in_process::{InProcessDaemon, StandingConvoyBackingInspector},
     path_context::{DaemonHostPath, ExecutionEnvironmentPath},
     placement_policy::reconcile_registered_policy,
     providers::{
@@ -511,11 +511,6 @@ impl DaemonRuntime {
 
         if options.start_controllers {
             tasks.push(spawn_dispatch_reconciler_task(Arc::clone(&daemon), options.namespace.clone(), options.controller_resync_interval));
-            tasks.push(spawn_convoy_ensure_reconciler_task(
-                Arc::clone(&daemon),
-                options.namespace.clone(),
-                options.controller_resync_interval,
-            ));
             let local_repo_root = daemon.tracked_repo_paths().await.into_iter().next().map(ExecutionEnvironmentPath::new);
             let state = Arc::new(
                 ControllerRuntimeState::new(
@@ -533,6 +528,11 @@ impl DaemonRuntime {
             if let Err(error) = reconcile_provisioned_environments(&state, &options.namespace).await {
                 warn!(%error, "failed to restore provisioned environments during startup; periodic reconciliation will retry");
             }
+            tasks.push(spawn_convoy_ensure_reconciler_task(
+                Arc::clone(&state),
+                options.namespace.clone(),
+                options.controller_resync_interval,
+            ));
             tasks.push(spawn_provisioned_environment_reconciliation_task(
                 Arc::clone(&state),
                 options.namespace.clone(),
@@ -709,6 +709,81 @@ impl ControllerRuntimeState {
 
 struct ActiveProvisionedEnvironment {
     handle: EnvironmentHandle,
+}
+
+#[async_trait]
+impl StandingConvoyBackingInspector for ControllerRuntimeState {
+    async fn verify_backing_dead(&self, convoy: &ResourceObject<Convoy>) -> Result<(), String> {
+        let environments = self
+            .daemon
+            .resource_backend()
+            .using::<Environment>(&convoy.metadata.namespace)
+            .list()
+            .await
+            .map_err(|error| format!("could not inspect backing environments: {error}"))?
+            .items
+            .into_iter()
+            .filter(|environment| environment.metadata.labels.get(flotilla_resources::CONVOY_LABEL) == Some(&convoy.metadata.name))
+            .collect::<Vec<_>>();
+        if environments.is_empty() {
+            return Err("no backing environment evidence is available".to_string());
+        }
+        if let Some(environment) = environments.iter().find(|environment| environment.spec.docker.is_none()) {
+            return Err(format!("Environment/{} has no inspectable Docker backing", environment.metadata.name));
+        }
+        if let Some(environment) = environments
+            .iter()
+            .find(|environment| environment.spec.docker.as_ref().is_some_and(|spec| spec.host_ref != self.local_host_ref))
+        {
+            return Err(format!(
+                "Environment/{} is backed by remote host {}",
+                environment.metadata.name,
+                environment.spec.docker.as_ref().expect("Docker environment checked above").host_ref
+            ));
+        }
+        let (_, provider) = self
+            .local_registry
+            .environment_providers
+            .get("docker")
+            .or_else(|| self.local_registry.environment_providers.preferred_with_desc())
+            .ok_or_else(|| "Docker environment provider unavailable for standing-convoy liveness check".to_string())?;
+        let listed = provider.list().await.map_err(|error| format!("Docker backing liveness check failed: {error}"))?;
+        let handles = listed
+            .into_iter()
+            .filter_map(|handle| {
+                let container = handle.container_name()?.to_string();
+                Some(((handle.id().clone(), container), handle))
+            })
+            .collect::<HashMap<_, _>>();
+        for environment in environments {
+            let Some(container_id) = environment.status.as_ref().and_then(|status| status.docker_container_id.as_ref()) else {
+                continue;
+            };
+            let key = (EnvironmentId::new(environment.metadata.name.clone()), container_id.clone());
+            let Some(handle) = handles.get(&key) else {
+                continue;
+            };
+            match handle.status().await {
+                Ok(flotilla_protocol::EnvironmentStatus::Running) => {
+                    return Err(format!("backing is live: Docker container {container_id} for Environment/{}", environment.metadata.name))
+                }
+                Ok(flotilla_protocol::EnvironmentStatus::Stopped | flotilla_protocol::EnvironmentStatus::Failed(_)) => {}
+                Ok(status) => {
+                    return Err(format!(
+                        "backing is not verified dead: Docker container {container_id} for Environment/{} is {status:?}",
+                        environment.metadata.name
+                    ))
+                }
+                Err(error) => {
+                    return Err(format!(
+                        "backing is not verifiable: Docker container {container_id} for Environment/{}: {error}",
+                        environment.metadata.name
+                    ))
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 async fn reconcile_provisioned_environments(state: &Arc<ControllerRuntimeState>, namespace: &str) -> Result<(), String> {
@@ -1272,12 +1347,12 @@ fn spawn_dispatch_reconciler_task(daemon: Arc<InProcessDaemon>, namespace: Strin
     })
 }
 
-fn spawn_convoy_ensure_reconciler_task(daemon: Arc<InProcessDaemon>, namespace: String, interval: Duration) -> JoinHandle<()> {
+fn spawn_convoy_ensure_reconciler_task(state: Arc<ControllerRuntimeState>, namespace: String, interval: Duration) -> JoinHandle<()> {
     spawn_periodic_task(interval, PeriodicTaskStart::Immediate, move || {
-        let daemon = Arc::clone(&daemon);
+        let state = Arc::clone(&state);
         let namespace = namespace.clone();
         async move {
-            if let Err(error) = daemon.reconcile_convoy_ensures_once(&namespace).await {
+            if let Err(error) = state.daemon.reconcile_convoy_ensures_once_with_backing_inspector(&namespace, &*state).await {
                 warn!(%error, "standing convoy ensure reconciliation pass failed");
             }
         }
@@ -4614,6 +4689,83 @@ mod tests {
             .expect("restart teardown should rediscover and destroy the container");
 
         assert!(destroyed.load(Ordering::SeqCst), "the restarted daemon must destroy the still-running lease holder");
+    }
+
+    #[tokio::test]
+    async fn standing_backing_inspection_trusts_live_docker_over_failed_resource_phase() {
+        let temp = TempDir::new().expect("tempdir");
+        let config_base = temp.path().join("config");
+        fs::create_dir_all(&config_base).expect("config directory");
+        fs::write(config_base.join("daemon.toml"), "machine_id = \"standing-backing-test\"\n").expect("daemon config");
+        let config = Arc::new(ConfigStore::with_base(config_base));
+        let daemon = InProcessDaemon::new(
+            Vec::new(),
+            Arc::clone(&config),
+            fake_discovery_with_provider_set(FakeDiscoveryProviders::new()),
+            HostName::new("dinghy"),
+        )
+        .await;
+        let convoy = daemon
+            .resource_backend()
+            .using::<Convoy>(NAMESPACE)
+            .create(&empty_meta("quartermaster"), &ConvoySpec::builder().workflow_ref("standing".to_string()).build())
+            .await
+            .expect("convoy");
+        let environments = daemon.resource_backend().using::<Environment>(NAMESPACE);
+        let environment = environments
+            .create(
+                &empty_meta_with_labels("quartermaster-work", BTreeMap::from([(CONVOY_LABEL.to_string(), "quartermaster".to_string())])),
+                &flotilla_resources::EnvironmentSpec {
+                    host_direct: None,
+                    docker: Some(flotilla_resources::DockerEnvironmentSpec {
+                        host_ref: "host-test".to_string(),
+                        image: "contained-image".to_string(),
+                        declared_agent_adapters: BTreeSet::new(),
+                        required_agent_adapters: BTreeSet::new(),
+                        pull_policy: Default::default(),
+                        mounts: Vec::new(),
+                        env: BTreeMap::new(),
+                    }),
+                },
+            )
+            .await
+            .expect("environment");
+        environments
+            .update_status(&environment.metadata.name, &environment.metadata.resource_version, &flotilla_resources::EnvironmentStatus {
+                phase: EnvironmentPhase::Failed,
+                ready: false,
+                docker_container_id: Some("test-interior".to_string()),
+                message: Some("provider registry unavailable".to_string()),
+                ..Default::default()
+            })
+            .await
+            .expect("failed daemon-side environment phase");
+        let handle: EnvironmentHandle = Arc::new(TestInteriorEnvironment {
+            id: EnvironmentId::new("quartermaster-work"),
+            image: ImageId::new("contained-image"),
+            runner: Arc::new(DiscoveryMockRunner::builder().build()),
+            env_vars: HashMap::new(),
+            destroyed: Arc::new(AtomicBool::new(false)),
+        });
+        let mut registry = ProviderRegistry::new();
+        registry.environment_providers.insert(
+            "docker",
+            ProviderDescriptor::named(ProviderCategory::EnvironmentProvider, "docker"),
+            Arc::new(AdoptionEnvironmentProvider { handles: vec![handle] }),
+        );
+        let state = ControllerRuntimeState::new(
+            daemon,
+            config,
+            Arc::new(registry),
+            Some(DaemonHostPath::new("/tmp/flotilla.sock")),
+            "host-test".to_string(),
+            None,
+            "host-direct-host-test".to_string(),
+        );
+
+        let refusal = state.verify_backing_dead(&convoy).await.expect_err("live Docker backing must hold standing teardown");
+
+        assert!(refusal.contains("backing is live") && refusal.contains("test-interior"), "unexpected refusal: {refusal}");
     }
 
     #[tokio::test]

--- a/crates/flotilla-resources/src/convoy_ensure.rs
+++ b/crates/flotilla-resources/src/convoy_ensure.rs
@@ -48,6 +48,8 @@ pub struct ConvoyEnsureStatus {
 pub enum ConvoyEnsureStatusPatch {
     Running { convoy_ref: String, observed_at: DateTime<Utc> },
     BackingOff { retry_at: DateTime<Utc>, failure: String },
+    Retrying { retry_at: DateTime<Utc>, failure: String },
+    Holding { convoy_ref: String, failure: String },
     ResetBackoff,
 }
 
@@ -65,6 +67,17 @@ impl StatusPatch<ConvoyEnsureStatus> for ConvoyEnsureStatusPatch {
                 status.restart_count = status.restart_count.saturating_add(1);
                 status.running_since = None;
                 status.retry_at = Some(*retry_at);
+                status.last_failure = Some(failure.clone());
+            }
+            Self::Retrying { retry_at, failure } => {
+                status.running_since = None;
+                status.retry_at = Some(*retry_at);
+                status.last_failure = Some(failure.clone());
+            }
+            Self::Holding { convoy_ref, failure } => {
+                status.convoy_ref = Some(convoy_ref.clone());
+                status.running_since = None;
+                status.retry_at = None;
                 status.last_failure = Some(failure.clone());
             }
             Self::ResetBackoff => status.restart_count = 0,


### PR DESCRIPTION
## Summary

- require provider-backed proof that a standing convoy's backing is dead before ensure teardown, and hold live/unknown backing behind persistent attention
- remove the ensure force-delete path and accept verified backing death as the standing-convoy reclaim criterion
- treat operator reap as prompt resurrection without incrementing crash restart count, with durable timed retries surviving daemon restart
- restore provisioned environment resolution before starting the ensure loop

## Tests

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`

Closes #1530
Closes #1523
