### PR TITLE
Add graceful daemon shutdown

### DIFF
--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -126,6 +126,18 @@ impl SocketDaemon {
         from_session_stateful_bounded(socket_path, session, None).await
     }
 
+    /// Ask the connected daemon to shut down gracefully.
+    ///
+    /// Success means the daemon accepted the request. The server sends this
+    /// acknowledgement before it closes listeners and drains active work.
+    pub async fn shutdown(&self) -> Result<(), String> {
+        let result = send_request(&self.session, &self.pending, &self.next_id, Request::Shutdown).await?;
+        match into_success_response(result)? {
+            Response::Shutdown => Ok(()),
+            other => Err(format!("unexpected shutdown response: {other:?}")),
+        }
+    }
+
     pub async fn connect_with_surface(socket_path: &Path, surface: SurfaceDeclaration) -> Result<Arc<Self>, String> {
         let session = connect_unix_message_session(socket_path).await?;
         from_session_stateful_bounded(socket_path, session, Some(&surface)).await

--- a/crates/flotilla-core/tests/in_process_daemon.rs
+++ b/crates/flotilla-core/tests/in_process_daemon.rs
@@ -55,9 +55,10 @@ use flotilla_resources::{
     CredentialSpecSpec, DockerCheckoutStrategy, DockerPerVesselPlacementPolicySpec, Host as ResourceHost,
     HostDirectPlacementPolicyCheckout, HostDirectPlacementPolicySpec, HostSpec, HostStatus, InputMeta, LifecycleAuthority,
     ObservedCheckoutSpec, PlacementPolicy, PlacementPolicySpec, Project, ProjectRepositorySpec, ProjectSpec, Regard, RegardExpiryPolicy,
-    RegardSource, Repository, RepositoryRelation, RepositorySpec, ResourceBackend, ResourceError, Stance, TypedResolver, WatchEvent,
-    WatchStart, WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate, AGENT_ADAPTERS_CAPABILITY, HELD_CREDENTIALS_CAPABILITY,
-    REPO_KEY_LABEL, REPO_LABEL,
+    RegardSource, Repository, RepositoryRelation, RepositorySpec, ResourceBackend, ResourceError, SqliteBackend, Stance, TerminalSession,
+    TerminalSessionPhase, TerminalSessionSource, TerminalSessionSpec, TerminalSessionStatusPatch, TypedResolver, WatchEvent, WatchStart,
+    WorkPhase, WorkState, WorkflowSnapshot, WorkflowTemplate, AGENT_ADAPTERS_CAPABILITY, HELD_CREDENTIALS_CAPABILITY, REPO_KEY_LABEL,
+    REPO_LABEL,
 };
 use futures::StreamExt;
 use tokio::sync::Notify;
@@ -3746,6 +3747,80 @@ async fn daemon_uses_persisted_local_environment_id() {
     let restarted =
         InProcessDaemon::new(vec![repo], test_config_store(temp.path().join("config")), fake_discovery(false), HostName::local()).await;
     assert_eq!(restarted.local_environment_id().as_str(), "test-local-environment-id");
+}
+
+#[tokio::test]
+async fn daemon_restart_preserves_standing_convoy_and_terminal_session() {
+    let temp = tempfile::tempdir().expect("create tempdir");
+    let config = test_config_store(temp.path().join("config"));
+    let database_path = temp.path().join("resources.sqlite");
+    let backend = ResourceBackend::Sqlite(SqliteBackend::open(&database_path).expect("open resource store"));
+    let daemon = InProcessDaemon::new_with_resource_backend(
+        Vec::new(),
+        Arc::clone(&config),
+        fake_discovery(false),
+        HostName::local(),
+        backend.clone(),
+    )
+    .await;
+
+    let convoys = backend.clone().using::<ResourceConvoy>("flotilla");
+    convoys
+        .create(
+            &InputMeta::builder().name("standing-convoy".to_string()).build(),
+            &flotilla_resources::ConvoySpec::builder().workflow_ref("standing".to_string()).build(),
+        )
+        .await
+        .expect("create standing convoy");
+    apply_status_patch(&convoys, "standing-convoy", &flotilla_resources::ConvoyStatusPatch::RollUpPhase {
+        phase: ConvoyPhase::Active,
+        started_at: Some(chrono::Utc::now()),
+        finished_at: None,
+    })
+    .await
+    .expect("mark convoy active");
+
+    let terminals = backend.clone().using::<TerminalSession>("flotilla");
+    terminals
+        .create(
+            &InputMeta::builder().name("standing-cleat-session".to_string()).build(),
+            &TerminalSessionSpec::builder()
+                .env_ref("host-direct-test".to_string())
+                .role("coder".to_string())
+                .source(TerminalSessionSource::Tool { command: "cleat attach standing".to_string() })
+                .cwd("/workspace".to_string())
+                .pool("cleat".to_string())
+                .build(),
+        )
+        .await
+        .expect("create terminal session");
+    apply_status_patch(&terminals, "standing-cleat-session", &TerminalSessionStatusPatch::MarkRunning {
+        session_id: "cleat-standing".to_string(),
+        pid: None,
+        started_at: chrono::Utc::now(),
+        crew: None,
+        launch_command: "cleat attach standing".to_string(),
+        delivered_message_id: None,
+    })
+    .await
+    .expect("mark terminal running");
+
+    drop(daemon);
+    drop(convoys);
+    drop(terminals);
+    drop(backend);
+
+    let restarted_backend = ResourceBackend::Sqlite(SqliteBackend::open(&database_path).expect("reopen resource store"));
+    let _restarted =
+        InProcessDaemon::new_with_resource_backend(Vec::new(), config, fake_discovery(false), HostName::local(), restarted_backend.clone())
+            .await;
+
+    let convoy =
+        restarted_backend.clone().using::<ResourceConvoy>("flotilla").get("standing-convoy").await.expect("standing convoy after restart");
+    assert_eq!(convoy.status.expect("convoy status").phase, ConvoyPhase::Active);
+    let terminal =
+        restarted_backend.using::<TerminalSession>("flotilla").get("standing-cleat-session").await.expect("terminal session after restart");
+    assert_eq!(terminal.status.expect("terminal status").phase, TerminalSessionPhase::Running);
 }
 
 #[tokio::test]

--- a/crates/flotilla-daemon/src/peer/manager.rs
+++ b/crates/flotilla-daemon/src/peer/manager.rs
@@ -581,7 +581,7 @@ impl PeerManager {
             }
             PeerWireMessage::Routed(msg) => self.handle_routed(env.connection_peer, env.connection_generation, msg),
             PeerWireMessage::Goodbye { reason } => match reason {
-                GoodbyeReason::Superseded => {
+                GoodbyeReason::Superseded | GoodbyeReason::Shutdown => {
                     self.reconnect_suppressed_until
                         .insert(env.connection_peer.clone(), Instant::now() + Self::GOODBYE_RECONNECT_SUPPRESSION);
                     HandleResult::ReconnectSuppressed { peer: env.connection_peer }

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -24,12 +24,13 @@ use std::{
 use flotilla_core::{
     agents::SharedAgentStateStore, config::ConfigStore, in_process::InProcessDaemon, providers::discovery::DiscoveryRuntime,
 };
-use flotilla_protocol::{ConfigLabel, ConnectionRole, EnvironmentId, HostName, Message, NodeId, PROTOCOL_VERSION};
+use flotilla_protocol::{ConfigLabel, ConnectionRole, EnvironmentId, GoodbyeReason, HostName, Message, NodeId, PROTOCOL_VERSION};
 use flotilla_resources::{ResourceBackend, SqliteBackend};
 use flotilla_transport::message::{unix_message_session_with_prefix, MessageSession};
 use tokio::{
     net::UnixListener,
     sync::{mpsc, watch, Mutex, Notify},
+    task::JoinSet,
 };
 use tracing::{error, info, warn};
 
@@ -309,6 +310,8 @@ pub struct DaemonServer {
     idle_timeout: Duration,
     client_count: Arc<AtomicUsize>,
     client_notify: Arc<Notify>,
+    shutdown_request_tx: mpsc::UnboundedSender<()>,
+    shutdown_request_rx: Option<mpsc::UnboundedReceiver<()>>,
     shutdown_tx: watch::Sender<bool>,
     shutdown_rx: watch::Receiver<bool>,
     /// Channel for inbound peer wire messages tagged with connection authority.
@@ -360,6 +363,7 @@ impl DaemonServer {
         let peer_manager = build_peer_manager(&daemon, &config, &socket_path)?;
         sync_peer_query_state(&peer_manager, &daemon).await;
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let (shutdown_request_tx, shutdown_request_rx) = mpsc::unbounded_channel();
         let (inbound_peer_tx, inbound_peer_rx) = mpsc::channel(256);
 
         let agent_state_store = Arc::clone(daemon.agent_state_store());
@@ -372,6 +376,8 @@ impl DaemonServer {
             idle_timeout,
             client_count: Arc::new(AtomicUsize::new(0)),
             client_notify: Arc::new(Notify::new()),
+            shutdown_request_tx,
+            shutdown_request_rx: Some(shutdown_request_rx),
             shutdown_tx,
             shutdown_rx,
             inbound_peer_tx,
@@ -430,6 +436,8 @@ impl DaemonServer {
         let client_count = self.client_count;
         let shutdown_tx = self.shutdown_tx;
         let mut shutdown_rx = self.shutdown_rx;
+        let shutdown_request_tx = self.shutdown_request_tx;
+        let mut shutdown_request_rx = self.shutdown_request_rx.take().expect("shutdown request receiver available once");
         let idle_timeout = self.idle_timeout;
         let client_notify = self.client_notify;
         let inbound_peer_tx = self.inbound_peer_tx;
@@ -440,7 +448,7 @@ impl DaemonServer {
         remote_command_router.resume_pending_crew_completions().await;
 
         let idle_client_count = Arc::clone(&client_count);
-        let idle_shutdown_tx = shutdown_tx.clone();
+        let idle_shutdown_request_tx = shutdown_request_tx.clone();
         let idle_notify = Arc::clone(&client_notify);
         tokio::spawn(async move {
             loop {
@@ -452,7 +460,7 @@ impl DaemonServer {
                     () = tokio::time::sleep(idle_timeout) => {
                         if idle_client_count.load(Ordering::SeqCst) == 0 {
                             info!("idle timeout reached, shutting down");
-                            let _ = idle_shutdown_tx.send(true);
+                            let _ = idle_shutdown_request_tx.send(());
                             return;
                         }
                     }
@@ -462,7 +470,7 @@ impl DaemonServer {
         });
 
         let peer_manager = self.peer_manager;
-        let (_peer_runtime_handle, peer_connected_tx) = spawn_peer_networking_runtime(
+        let (peer_runtime_handle, peer_connected_tx) = spawn_peer_networking_runtime(
             Arc::clone(&daemon),
             Arc::clone(&peer_manager),
             inbound_peer_rx,
@@ -478,6 +486,7 @@ impl DaemonServer {
         // Accept loop
         let mut accept_error_backoff = AcceptErrorBackoff::default();
         let mut accept_retry_at = None;
+        let mut connection_tasks = JoinSet::new();
         loop {
             tokio::select! {
                 accept_result = listener.accept(), if accept_retry_at.is_none() => {
@@ -494,10 +503,12 @@ impl DaemonServer {
                             let peer_connected_tx = peer_connected_tx.clone();
                             let agent_state_store = Arc::clone(&agent_state_store);
 
-                            tokio::spawn(async move {
+                            let shutdown_request_tx = shutdown_request_tx.clone();
+                            connection_tasks.spawn(async move {
                                 handle_client(
                                     stream,
                                     daemon,
+                                    shutdown_request_tx,
                                     shutdown_rx,
                                     inbound_peer_tx,
                                     peer_manager,
@@ -537,6 +548,10 @@ impl DaemonServer {
                         break;
                     }
                 }
+                Some(()) = shutdown_request_rx.recv() => {
+                    info!("graceful shutdown request received");
+                    break;
+                }
                 _ = tokio::signal::ctrl_c() => {
                     info!("received SIGINT — shutting down");
                     break;
@@ -545,6 +560,28 @@ impl DaemonServer {
                     info!("received SIGTERM — shutting down");
                     break;
                 }
+            }
+        }
+
+        // Stop peer reconnect loops deliberately and tell every connected peer
+        // why the transport is closing before connection tasks see shutdown.
+        let peer_senders = peer_manager.lock().await.active_peer_senders();
+        for (peer, sender) in peer_senders {
+            if let Err(error) = sender.retire(GoodbyeReason::Shutdown).await {
+                warn!(%peer, %error, "failed to send shutdown goodbye to peer");
+            }
+        }
+        peer_manager.lock().await.disconnect_all().await;
+        peer_runtime_handle.abort();
+        let _ = peer_runtime_handle.await;
+
+        // SIGINT/SIGTERM enter the common path without having touched the
+        // channel. Broadcasting here closes client, peer, handshake, and HTTP
+        // connection handlers after any request they are currently serving.
+        let _ = shutdown_tx.send(true);
+        while let Some(result) = connection_tasks.join_next().await {
+            if let Err(error) = result {
+                warn!(%error, "daemon connection task failed while draining");
             }
         }
 
@@ -588,7 +625,8 @@ fn spawn_peer_networking_runtime(
 async fn handle_client(
     mut stream: tokio::net::UnixStream,
     daemon: Arc<InProcessDaemon>,
-    shutdown_rx: watch::Receiver<bool>,
+    shutdown_request_tx: mpsc::UnboundedSender<()>,
+    mut shutdown_rx: watch::Receiver<bool>,
     inbound_peer_tx: mpsc::Sender<InboundPeerEnvelope>,
     peer_manager: Arc<Mutex<PeerManager>>,
     remote_command_router: RemoteCommandRouter,
@@ -605,8 +643,13 @@ async fn handle_client(
             return;
         }
         Ok(Ok(_)) if first_byte[0].is_ascii_uppercase() => {
-            if let Err(error) = resource_http::serve_resource_http(stream, first_byte[0], daemon.resource_backend().clone()).await {
-                warn!(%error, "resource HTTP connection failed");
+            tokio::select! {
+                result = resource_http::serve_resource_http(stream, first_byte[0], daemon.resource_backend().clone()) => {
+                    if let Err(error) = result {
+                        warn!(%error, "resource HTTP connection failed");
+                    }
+                }
+                _ = shutdown_rx.changed() => {}
             }
             return;
         }
@@ -619,6 +662,7 @@ async fn handle_client(
     handle_client_session(
         unix_message_session_with_prefix(stream, first_byte.to_vec()),
         daemon,
+        shutdown_request_tx,
         shutdown_rx,
         inbound_peer_tx,
         peer_manager,
@@ -636,6 +680,7 @@ async fn handle_client(
 async fn handle_client_session(
     session: MessageSession,
     daemon: Arc<InProcessDaemon>,
+    shutdown_request_tx: mpsc::UnboundedSender<()>,
     mut shutdown_rx: watch::Receiver<bool>,
     inbound_peer_tx: mpsc::Sender<InboundPeerEnvelope>,
     peer_manager: Arc<Mutex<PeerManager>>,
@@ -714,9 +759,17 @@ async fn handle_client_session(
                     Some(surface) => surface,
                     None => flotilla_protocol::SurfaceDeclaration::focal_for_namespace(daemon.provisioning_namespace().await),
                 };
-                ClientConnection::new(daemon, shutdown_rx, remote_command_router, client_count, client_notify, agent_state_store)
-                    .run_stateful(Arc::clone(&session), session_id, surface)
-                    .await;
+                ClientConnection::new(
+                    daemon,
+                    shutdown_request_tx,
+                    shutdown_rx,
+                    remote_command_router,
+                    client_count,
+                    client_notify,
+                    agent_state_store,
+                )
+                .run_stateful(Arc::clone(&session), session_id, surface)
+                .await;
             } else {
                 // Peer path (ConnectionRole::Peer or None) — existing behavior.
                 PeerConnection::new(daemon, shutdown_rx, inbound_peer_tx, peer_manager, peer_connected_tx, client_count, client_notify)

--- a/crates/flotilla-daemon/src/server/client_connection.rs
+++ b/crates/flotilla-daemon/src/server/client_connection.rs
@@ -30,6 +30,7 @@ fn event_subscribed(event: &DaemonEvent, subscriptions: &QuerySubscriptions, ses
 
 pub(super) struct ClientConnection {
     daemon: Arc<InProcessDaemon>,
+    shutdown_request_tx: tokio::sync::mpsc::UnboundedSender<()>,
     shutdown_rx: watch::Receiver<bool>,
     remote_command_router: RemoteCommandRouter,
     client_count: Arc<AtomicUsize>,
@@ -40,13 +41,14 @@ pub(super) struct ClientConnection {
 impl ClientConnection {
     pub(super) fn new(
         daemon: Arc<InProcessDaemon>,
+        shutdown_request_tx: tokio::sync::mpsc::UnboundedSender<()>,
         shutdown_rx: watch::Receiver<bool>,
         remote_command_router: RemoteCommandRouter,
         client_count: Arc<AtomicUsize>,
         client_notify: Arc<Notify>,
         agent_state_store: SharedAgentStateStore,
     ) -> Self {
-        Self { daemon, shutdown_rx, remote_command_router, client_count, client_notify, agent_state_store }
+        Self { daemon, shutdown_request_tx, shutdown_rx, remote_command_router, client_count, client_notify, agent_state_store }
     }
 
     /// Run a stateful client session that began with a Hello handshake.
@@ -55,7 +57,7 @@ impl ClientConnection {
     /// the loop starts by awaiting the next message.
     pub(super) async fn run_stateful(self, session: Arc<MessageSession>, client_session_id: uuid::Uuid, surface: SurfaceDeclaration) {
         let (event_task, request_dispatcher, mut shutdown_rx) = self.start_session(&session, client_session_id, surface);
-        request_loop(&session, &request_dispatcher, &mut shutdown_rx).await;
+        request_loop(&session, &request_dispatcher, &self.shutdown_request_tx, &mut shutdown_rx).await;
         self.finish_session(event_task, client_session_id).await;
     }
 
@@ -124,7 +126,12 @@ impl ClientConnection {
 /// Extracted as a free function to avoid borrow conflicts between the
 /// `RequestDispatcher` (which borrows fields of `ClientConnection`) and the
 /// mutable `shutdown_rx` receiver.
-async fn request_loop(session: &Arc<MessageSession>, request_dispatcher: &RequestDispatcher<'_>, shutdown_rx: &mut watch::Receiver<bool>) {
+async fn request_loop(
+    session: &Arc<MessageSession>,
+    request_dispatcher: &RequestDispatcher<'_>,
+    shutdown_request_tx: &tokio::sync::mpsc::UnboundedSender<()>,
+    shutdown_rx: &mut watch::Receiver<bool>,
+) {
     loop {
         tokio::select! {
             message_result = session.read() => {
@@ -132,8 +139,14 @@ async fn request_loop(session: &Arc<MessageSession>, request_dispatcher: &Reques
                     Ok(Some(msg)) => {
                         match msg {
                             Message::Request { id, request } => {
+                                let shutdown_requested = matches!(request, flotilla_protocol::Request::Shutdown);
                                 let response = request_dispatcher.dispatch(id, request).await;
                                 if session.write(response).await.is_err() {
+                                    break;
+                                }
+                                if shutdown_requested {
+                                    info!("graceful shutdown requested by client");
+                                    let _ = shutdown_request_tx.send(());
                                     break;
                                 }
                             }

--- a/crates/flotilla-daemon/src/server/request_dispatch.rs
+++ b/crates/flotilla-daemon/src/server/request_dispatch.rs
@@ -31,6 +31,7 @@ impl<'a> RequestDispatcher<'a> {
 
     pub(super) async fn dispatch(&self, id: u64, request: Request) -> Message {
         match request {
+            Request::Shutdown => Message::ok_response(id, Response::Shutdown),
             Request::ListRepos => match self.daemon.list_repos().await {
                 Ok(repos) => Message::ok_response(id, Response::ListRepos(repos)),
                 Err(e) => Message::error_response(id, e),

--- a/crates/flotilla-daemon/src/server/test_support.rs
+++ b/crates/flotilla-daemon/src/server/test_support.rs
@@ -143,6 +143,7 @@ async fn spawn_in_memory_request_topology_stateful_with_optional_surface(
     // because from_session_stateful sends Hello and blocks waiting for the reply.
     let (client_session, server_session) = flotilla_transport::message::message_session_pair();
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (shutdown_request_tx, _shutdown_request_rx) = mpsc::unbounded_channel();
     let client_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let client_notify = Arc::new(Notify::new());
     let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
@@ -156,6 +157,7 @@ async fn spawn_in_memory_request_topology_stateful_with_optional_surface(
         handle_client_session(
             server_session,
             leader_for_client,
+            shutdown_request_tx,
             shutdown_rx,
             leader_inbound_peer_tx_for_client,
             leader_peer_manager_for_client,

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -63,6 +63,7 @@ use super::{
     AcceptErrorBackoff, BoundSocketGuard, DaemonServer, PeerConnectionEvent, ACCEPT_ERROR_INITIAL_BACKOFF, ACCEPT_ERROR_MAX_BACKOFF,
     CONNECTION_PREFACE_TIMEOUT, HELLO_HANDSHAKE_TIMEOUT,
 };
+use crate::peer::{ConnectionDirection, ConnectionMeta};
 
 #[tokio::test]
 async fn socket_guard_does_not_unlink_replacement_listener() {
@@ -613,11 +614,12 @@ async fn empty_daemon() -> (tempfile::TempDir, Arc<InProcessDaemon>) {
 }
 
 async fn spawn_test_client_handler(
-) -> (tempfile::TempDir, tokio::net::UnixStream, tokio::task::JoinHandle<()>, Arc<AtomicUsize>, watch::Sender<bool>) {
+) -> (tempfile::TempDir, tokio::net::UnixStream, tokio::task::JoinHandle<()>, Arc<AtomicUsize>, mpsc::UnboundedReceiver<()>) {
     let (tmp, daemon) = empty_daemon().await;
     let (peer_data_tx, _peer_data_rx) = mpsc::channel(16);
     let peer_manager = Arc::new(Mutex::new(PeerManager::new(NodeId::new("local"))));
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (shutdown_request_tx, shutdown_request_rx) = mpsc::unbounded_channel();
     let client_count = Arc::new(AtomicUsize::new(0));
     let client_notify = Arc::new(Notify::new());
     let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
@@ -627,10 +629,12 @@ async fn spawn_test_client_handler(
     let pm = Arc::clone(&peer_manager);
     let count_ref = Arc::clone(&client_count);
     let handle = tokio::spawn(async move {
+        let _shutdown_tx = shutdown_tx;
         let remote_command_router = empty_remote_command_router(&daemon_for_task, &pm);
         handle_client(
             server_stream,
             daemon_for_task,
+            shutdown_request_tx,
             shutdown_rx,
             peer_data_tx,
             pm,
@@ -643,7 +647,7 @@ async fn spawn_test_client_handler(
         )
         .await;
     });
-    (tmp, client_stream, handle, client_count, shutdown_tx)
+    (tmp, client_stream, handle, client_count, shutdown_request_rx)
 }
 
 async fn empty_daemon_named(host_name: &str) -> (tempfile::TempDir, Arc<InProcessDaemon>) {
@@ -723,7 +727,8 @@ impl PeerSender for CapturePeerSender {
         Ok(())
     }
 
-    async fn retire(&self, _reason: flotilla_protocol::GoodbyeReason) -> Result<(), String> {
+    async fn retire(&self, reason: flotilla_protocol::GoodbyeReason) -> Result<(), String> {
+        self.0.lock().expect("capture sender lock").push(PeerWireMessage::Goodbye { reason });
         Ok(())
     }
 }
@@ -3086,6 +3091,7 @@ async fn handle_client_forwards_peer_link_state_and_registers_peer() {
     let (peer_data_tx, mut peer_data_rx) = mpsc::channel(16);
     let peer_manager = Arc::new(Mutex::new(PeerManager::new(NodeId::new("local"))));
     let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (shutdown_request_tx, _shutdown_request_rx) = mpsc::unbounded_channel();
     let client_count = Arc::new(AtomicUsize::new(0));
     let client_notify = Arc::new(Notify::new());
     let (peer_connected_tx, mut peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
@@ -3102,6 +3108,7 @@ async fn handle_client_forwards_peer_link_state_and_registers_peer() {
         handle_client(
             server_stream,
             daemon_for_task,
+            shutdown_request_tx,
             shutdown_rx,
             peer_data_tx,
             pm,
@@ -3266,6 +3273,7 @@ async fn handle_client_streams_daemon_events_to_request_clients() {
     let (peer_data_tx, _peer_data_rx) = mpsc::channel(16);
     let peer_manager = Arc::new(Mutex::new(PeerManager::new(NodeId::new("local"))));
     let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (shutdown_request_tx, _shutdown_request_rx) = mpsc::unbounded_channel();
     let client_count = Arc::new(AtomicUsize::new(0));
     let client_notify = Arc::new(Notify::new());
     let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
@@ -3280,6 +3288,7 @@ async fn handle_client_streams_daemon_events_to_request_clients() {
         handle_client(
             server_stream,
             daemon_for_task,
+            shutdown_request_tx,
             shutdown_rx,
             peer_data_tx,
             pm,
@@ -3355,6 +3364,7 @@ async fn handle_client_session_dispatches_request_messages() {
     let (peer_data_tx, _peer_data_rx) = mpsc::channel(16);
     let peer_manager = Arc::new(Mutex::new(PeerManager::new(NodeId::new("local"))));
     let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (shutdown_request_tx, _shutdown_request_rx) = mpsc::unbounded_channel();
     let client_count = Arc::new(AtomicUsize::new(0));
     let client_notify = Arc::new(Notify::new());
     let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
@@ -3369,6 +3379,7 @@ async fn handle_client_session_dispatches_request_messages() {
         handle_client_session(
             server_session,
             daemon_for_task,
+            shutdown_request_tx,
             shutdown_rx,
             peer_data_tx,
             pm,
@@ -3395,11 +3406,39 @@ async fn handle_client_session_dispatches_request_messages() {
 }
 
 #[tokio::test]
+async fn shutdown_request_is_acknowledged_before_the_connection_closes() {
+    let (_tmp, client_stream, handle, client_count, mut shutdown_requests) = spawn_test_client_handler().await;
+    let (read_half, write_half) = client_stream.into_split();
+    let mut reader = BufReader::new(read_half).lines();
+    let mut writer = BufWriter::new(write_half);
+
+    flotilla_protocol::framing::write_message_line(&mut writer, &current_client_hello()).await.expect("write client hello");
+    let hello = reader.next_line().await.expect("read hello").expect("hello payload");
+    assert!(matches!(serde_json::from_str::<Message>(&hello).expect("parse hello"), Message::Hello { .. }));
+
+    flotilla_protocol::framing::write_message_line(&mut writer, &Message::Request { id: 7, request: Request::Shutdown })
+        .await
+        .expect("write shutdown request");
+    let response = reader.next_line().await.expect("read response").expect("shutdown response payload");
+    match ok_response(serde_json::from_str(&response).expect("parse shutdown response"), 7) {
+        Response::Shutdown => {}
+        other => panic!("expected shutdown response, got {other:?}"),
+    }
+    assert_eq!(shutdown_requests.recv().await, Some(()), "server should begin shutdown only after acknowledging the request");
+
+    let eof = reader.next_line().await.expect("read shutdown EOF");
+    assert!(eof.is_none(), "shutdown requester should receive a clean EOF");
+    handle.await.expect("join shutdown connection");
+    assert_eq!(client_count.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
 async fn handle_client_session_streams_daemon_events_to_request_clients() {
     let (_tmp, daemon) = empty_daemon().await;
     let (peer_data_tx, _peer_data_rx) = mpsc::channel(16);
     let peer_manager = Arc::new(Mutex::new(PeerManager::new(NodeId::new("local"))));
     let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (shutdown_request_tx, _shutdown_request_rx) = mpsc::unbounded_channel();
     let client_count = Arc::new(AtomicUsize::new(0));
     let client_notify = Arc::new(Notify::new());
     let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
@@ -3414,6 +3453,7 @@ async fn handle_client_session_streams_daemon_events_to_request_clients() {
         handle_client_session(
             server_session,
             daemon_for_task,
+            shutdown_request_tx,
             shutdown_rx,
             peer_data_tx,
             pm,
@@ -3469,6 +3509,7 @@ async fn assert_client_hello_rejected(protocol_version: u32, display_name: Strin
     let (peer_data_tx, _peer_data_rx) = mpsc::channel(16);
     let peer_manager = Arc::new(Mutex::new(PeerManager::new(NodeId::new("local"))));
     let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (shutdown_request_tx, _shutdown_request_rx) = mpsc::unbounded_channel();
     let client_count = Arc::new(AtomicUsize::new(0));
     let client_notify = Arc::new(Notify::new());
     let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
@@ -3483,6 +3524,7 @@ async fn assert_client_hello_rejected(protocol_version: u32, display_name: Strin
         handle_client(
             server_stream,
             daemon_for_task,
+            shutdown_request_tx,
             shutdown_rx,
             peer_data_tx,
             pm,
@@ -3612,6 +3654,42 @@ async fn live_daemon_reaps_partial_peer_dial_churn() {
     server_task.await.expect("join daemon server").expect("daemon server should stop cleanly");
 }
 
+#[tokio::test]
+async fn live_daemon_sends_goodbye_before_shutdown_completes() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let socket_dir = TestSocketDir::new();
+    let socket_path = socket_dir.socket_path("graceful-goodbye.sock");
+    let config = test_config_store(tmp.path().join("config"));
+    let server = DaemonServer::new(Vec::new(), config, fake_discovery(false), socket_path.clone(), StdDuration::from_secs(60))
+        .await
+        .expect("create daemon server");
+    let captured = Arc::new(StdMutex::new(Vec::new()));
+    server.peer_manager.lock().await.activate_connection(
+        NodeId::new("peer"),
+        Arc::new(CapturePeerSender(Arc::clone(&captured))),
+        ConnectionMeta {
+            direction: ConnectionDirection::Outbound,
+            config_label: None,
+            expected_peer: Some(NodeId::new("peer")),
+            config_backed: false,
+        },
+    );
+    let shutdown_tx = server.shutdown_tx.clone();
+    let server_task = tokio::spawn(server.run());
+    while !socket_path.exists() {
+        tokio::task::yield_now().await;
+    }
+
+    shutdown_tx.send(true).expect("request daemon shutdown");
+    server_task.await.expect("join daemon server").expect("daemon server should stop cleanly");
+
+    assert!(captured
+        .lock()
+        .expect("capture sender lock")
+        .iter()
+        .any(|message| { matches!(message, PeerWireMessage::Goodbye { reason: flotilla_protocol::GoodbyeReason::Shutdown }) }));
+}
+
 #[test]
 fn accept_errors_back_off_exponentially_and_reset_after_success() {
     let mut backoff = AcceptErrorBackoff::default();
@@ -3632,6 +3710,7 @@ async fn handle_client_session_filters_query_events_until_subscribed() {
     let (peer_data_tx, _peer_data_rx) = mpsc::channel(16);
     let peer_manager = Arc::new(Mutex::new(PeerManager::new(NodeId::new("local"))));
     let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (shutdown_request_tx, _shutdown_request_rx) = mpsc::unbounded_channel();
     let client_count = Arc::new(AtomicUsize::new(0));
     let client_notify = Arc::new(Notify::new());
     let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
@@ -3646,6 +3725,7 @@ async fn handle_client_session_filters_query_events_until_subscribed() {
         handle_client_session(
             server_session,
             daemon_for_task,
+            shutdown_request_tx,
             shutdown_rx,
             peer_data_tx,
             pm,
@@ -3881,6 +3961,7 @@ async fn handle_client_relays_outbound_peer_messages() {
     let (peer_data_tx, _peer_data_rx) = mpsc::channel(16);
     let peer_manager = Arc::new(Mutex::new(PeerManager::new(NodeId::new("local"))));
     let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (shutdown_request_tx, _shutdown_request_rx) = mpsc::unbounded_channel();
     let client_count = Arc::new(AtomicUsize::new(0));
     let client_notify = Arc::new(Notify::new());
     let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
@@ -3896,6 +3977,7 @@ async fn handle_client_relays_outbound_peer_messages() {
         handle_client(
             server_stream,
             daemon,
+            shutdown_request_tx,
             shutdown_rx,
             peer_data_tx,
             pm,
@@ -3961,6 +4043,7 @@ async fn duplicate_inbound_peer_receives_goodbye_on_rejection() {
     let (peer_data_tx, _peer_data_rx) = mpsc::channel(16);
     let peer_manager = Arc::new(Mutex::new(PeerManager::new(NodeId::new("local"))));
     let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+    let (shutdown_request_tx, _shutdown_request_rx) = mpsc::unbounded_channel();
     let client_count = Arc::new(AtomicUsize::new(0));
     let client_notify = Arc::new(Notify::new());
     let (peer_connected_tx, _peer_connected_rx) = mpsc::unbounded_channel::<PeerConnectionEvent>();
@@ -3981,6 +4064,8 @@ async fn duplicate_inbound_peer_receives_goodbye_on_rejection() {
     let notify_b = Arc::clone(&client_notify);
     let shutdown_rx_a = shutdown_rx.clone();
     let shutdown_rx_b = shutdown_rx.clone();
+    let shutdown_request_tx_a = shutdown_request_tx.clone();
+    let shutdown_request_tx_b = shutdown_request_tx;
     let peer_connected_tx_a = peer_connected_tx.clone();
     let peer_connected_tx_b = peer_connected_tx.clone();
 
@@ -3989,6 +4074,7 @@ async fn duplicate_inbound_peer_receives_goodbye_on_rejection() {
         handle_client(
             server_stream_a,
             daemon_a,
+            shutdown_request_tx_a,
             shutdown_rx_a,
             tx_a,
             pm_a,
@@ -4006,6 +4092,7 @@ async fn duplicate_inbound_peer_receives_goodbye_on_rejection() {
         handle_client(
             server_stream_b,
             daemon_b,
+            shutdown_request_tx_b,
             shutdown_rx_b,
             tx_b,
             pm_b,

--- a/crates/flotilla-protocol/src/lib.rs
+++ b/crates/flotilla-protocol/src/lib.rs
@@ -183,7 +183,7 @@ pub use snapshot::{CategoryLabels, ProviderError, RepoInfo, RepoKey, RepoLabels,
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ConfigLabel(pub String);
 
-pub const PROTOCOL_VERSION: u32 = 19;
+pub const PROTOCOL_VERSION: u32 = 20;
 
 const BUILD_ID_SEPARATOR: &str = "\u{1f}flotilla-build:";
 
@@ -240,6 +240,8 @@ pub struct QueryCursor {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", content = "params", rename_all = "snake_case")]
 pub enum Request {
+    /// Ask this daemon process to finish active work and exit cleanly.
+    Shutdown,
     ListRepos,
     Execute {
         command: Command,
@@ -293,6 +295,7 @@ pub enum Request {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", content = "data", rename_all = "snake_case")]
 pub enum Response {
+    Shutdown,
     ListRepos(Vec<RepoInfo>),
     Execute {
         command_id: u64,

--- a/crates/flotilla-protocol/src/peer.rs
+++ b/crates/flotilla-protocol/src/peer.rs
@@ -31,6 +31,7 @@ pub enum PeerWireMessage {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum GoodbyeReason {
     Superseded,
+    Shutdown,
 }
 
 /// Targeted peer control messages that are routed hop-by-hop rather than flooded.

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,6 +7,13 @@ The daemon's canonical structured log is
 `~/.local/state/flotilla/log/flotillad.jsonl` when `XDG_STATE_HOME` is unset.
 Older size-rotated generations use numeric suffixes such as
 `flotillad.jsonl.1` through `flotillad.jsonl.4` with the default configuration.
+
+Stop a running daemon with `flotilla daemon stop`. The command is idempotent
+when no daemon socket exists and asks a live daemon to finish active requests,
+retire peer connections, close its socket, and exit cleanly. Deploy and install
+scripts should use this command before replacing the `flotilla`/`flotillad`
+binary pair; do not use `pkill` for daemon restarts.
+
 For example, show warnings from the peer subsystem with:
 
 ```bash

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,8 @@ fn binary_version() -> &'static str {
 enum SubCommand {
     /// Run the daemon server
     Daemon {
+        #[command(subcommand)]
+        command: Option<DaemonSubCommand>,
         /// Idle timeout in seconds (0 = no timeout)
         #[arg(long, default_value = "300")]
         timeout: u64,
@@ -216,6 +218,12 @@ enum SubCommand {
         #[arg(value_enum)]
         shell: CompletionShell,
     },
+}
+
+#[derive(clap::Subcommand)]
+enum DaemonSubCommand {
+    /// Gracefully stop the running daemon
+    Stop,
 }
 
 #[derive(Clone, clap::ValueEnum)]
@@ -533,7 +541,8 @@ async fn main() -> Result<()> {
             };
             run_tui(cli, Some(address)).await
         }
-        Some(SubCommand::Daemon { timeout }) => run_daemon(&cli, timeout).await,
+        Some(SubCommand::Daemon { command: Some(DaemonSubCommand::Stop), .. }) => run_daemon_stop(&cli).await,
+        Some(SubCommand::Daemon { command: None, timeout }) => run_daemon(&cli, timeout).await,
         Some(SubCommand::Status) => run_status(&cli, format).await,
         Some(SubCommand::Watch) => run_watch(&cli, format).await,
         Some(SubCommand::Wait { leaves, namespace, fresher_than, timeout }) => {
@@ -881,6 +890,28 @@ async fn run_daemon(cli: &Cli, timeout_secs: u64) -> Result<()> {
             status.code().map(|code| code.to_string()).unwrap_or_else(|| "signal".to_string())
         ))
     }
+}
+
+async fn run_daemon_stop(cli: &Cli) -> Result<()> {
+    let socket_path = cli.socket_path();
+    if !socket_path.exists() {
+        println!("Daemon is not running.");
+        return Ok(());
+    }
+    let daemon = flotilla_tui::socket::SocketDaemon::connect(&socket_path)
+        .await
+        .map_err(|error| color_eyre::eyre::eyre!("cannot connect to daemon at {}: {error}", socket_path.display()))?;
+    daemon.shutdown().await.map_err(|error| color_eyre::eyre::eyre!("could not stop daemon: {error}"))?;
+    drop(daemon);
+    tokio::time::timeout(Duration::from_secs(30), async {
+        while socket_path.exists() {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .map_err(|_| color_eyre::eyre::eyre!("daemon accepted shutdown but did not exit within 30s"))?;
+    println!("Daemon stopped.");
+    Ok(())
 }
 
 fn resolve_flotillad_binary() -> Result<PathBuf> {
@@ -1941,8 +1972,8 @@ mod tests {
         client_dirs_from, confirm_command, daemon_paths_from, default_project_landing, format_human_resource_value,
         host_daemon_socket_required, provisioning_target_for_environment, replace_host_ids, run_replica_snapshot, select_host_target,
         select_startup_repo_roots, should_exec_convoy_attach, should_reexec_for_incompatible_daemon, show_startup_splash, socket_path_from,
-        Cli, CliPaths, CommandValue, ResourceApplyArgs, ResourceDeleteArgs, ResourceGetArgs, ResourceListArgs, ResourceStatusPatchArgs,
-        ResourceSubCommand, ResourceWatchArgs, SubCommand,
+        Cli, CliPaths, CommandValue, DaemonSubCommand, ResourceApplyArgs, ResourceDeleteArgs, ResourceGetArgs, ResourceListArgs,
+        ResourceStatusPatchArgs, ResourceSubCommand, ResourceWatchArgs, SubCommand,
     };
 
     #[test]
@@ -2459,6 +2490,15 @@ mod tests {
             .expect("paired overrides should parse")
             .client_paths()
             .is_ok());
+    }
+
+    #[test]
+    fn daemon_stop_is_a_nested_daemon_command() {
+        let cli = Cli::try_parse_from(["flotilla", "daemon", "stop"]).expect("daemon stop should parse");
+        assert!(matches!(cli.command, Some(SubCommand::Daemon { command: Some(DaemonSubCommand::Stop), .. })));
+
+        let foreground = Cli::try_parse_from(["flotilla", "daemon", "--timeout", "0"]).expect("foreground daemon should still parse");
+        assert!(matches!(foreground.command, Some(SubCommand::Daemon { command: None, timeout: 0 })));
     }
 
     #[test]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -123,12 +123,12 @@ def start_daemon(service: str, compose_file: str = COMPOSE_FILE):
 
 
 def stop_daemon(service: str, compose_file: str = COMPOSE_FILE):
-    """Stop the recorded flotillad process, if it is still running."""
+    """Gracefully stop the recorded flotillad process, if it is still running."""
     result = docker_exec(
         service,
         "if test -f ~/.config/flotilla/flotillad.pid; then "
         "pid=$(cat ~/.config/flotilla/flotillad.pid); "
-        'kill "$pid" 2>/dev/null || true; '
+        'flotilla daemon stop || exit 1; '
         "for attempt in $(seq 1 50); do "
         'state=$(ps -o stat= -p "$pid" 2>/dev/null || true); '
         "case \"$state\" in ''|Z*) exit 0 ;; esac; sleep 0.1; "


### PR DESCRIPTION
## Summary

- add a typed shutdown RPC and `flotilla daemon stop` command
- acknowledge shutdown before draining client, peer, HTTP, and networking tasks
- send peers an explicit shutdown goodbye and preserve daemon-backed state across restart
- switch the real-daemon integration restart seam and deployment documentation to graceful shutdown

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- real-binary smoke test confirming the stop acknowledgement, zero exit status, socket removal, and clean lifecycle marker

Closes #1546
