### PR TITLE
feat: stamp fleet candidate protocol version

### DIFF
--- a/ci/fleet-candidates/build-candidate.sh
+++ b/ci/fleet-candidates/build-candidate.sh
@@ -37,6 +37,18 @@ sha256_file() {
   fi
 }
 
+read_protocol_version() {
+  local binary="$1"
+  local version
+  version="$("$binary" --version)"
+  if [[ "$version" =~ proto=([0-9]+) ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return
+  fi
+  printf '%s --version did not report a peer protocol version: %s\n' "$binary" "$version" >&2
+  return 1
+}
+
 main() {
 flotilla_sha="$(require_sha FLEET_FLOTILLA_SHA "${FLEET_FLOTILLA_SHA:-}")"
 cleat_sha="$(require_sha FLEET_CLEAT_SHA "${FLEET_CLEAT_SHA:-}")"
@@ -135,12 +147,15 @@ chmod 0755 "$bundle/install.sh"
 wire_generation="${flotilla_sha:0:12}"
 "$bundle/bin/flotilla" --version | grep -F "wire=$wire_generation"
 "$bundle/bin/flotillad" --version | grep -F "wire=$wire_generation"
+protocol_version="$(read_protocol_version "$bundle/bin/flotilla")"
+test "$(read_protocol_version "$bundle/bin/flotillad")" = "$protocol_version"
 "$bundle/bin/cleat" launch --help | grep -q -- --tag
 
 export FLEET_BUNDLE="$bundle"
 export FLEET_PLATFORM="$platform"
 export FLEET_FLOTILLA_SHA="$flotilla_sha"
 export FLEET_CLEAT_SHA="$cleat_sha"
+export FLEET_PROTOCOL_VERSION="$protocol_version"
 python3 - <<'PY'
 import hashlib
 import json
@@ -169,6 +184,7 @@ manifest = {
         "cleat": os.environ["FLEET_CLEAT_SHA"],
     },
     "build_profile": "release",
+    "peer_protocol_version": int(os.environ["FLEET_PROTOCOL_VERSION"]),
     "signed": False,
     "files": files,
 }

--- a/ci/fleet-candidates/test-workflow.sh
+++ b/ci/fleet-candidates/test-workflow.sh
@@ -40,6 +40,17 @@ if require_sha TEST_SHA main >/dev/null 2>&1; then
   exit 1
 fi
 
+fake_flotilla="$(mktemp "${TMPDIR:-/tmp}/fake-flotilla.XXXXXX")"
+printf '#!/bin/sh\nprintf "flotilla 0.1.0 (wire=test, proto=20)\\n"\n' >"$fake_flotilla"
+chmod 0755 "$fake_flotilla"
+test "$(read_protocol_version "$fake_flotilla")" = 20
+printf '#!/bin/sh\nprintf "flotilla 0.1.0 (wire=test)\\n"\n' >"$fake_flotilla"
+if read_protocol_version "$fake_flotilla" >/dev/null 2>&1; then
+  echo 'accepted a binary that did not report its protocol version' >&2
+  exit 1
+fi
+rm -f "$fake_flotilla"
+
 test_root="$(mktemp -d "${TMPDIR:-/tmp}/fleet-candidate-test.XXXXXX")"
 trap 'rm -rf "$test_root"' EXIT
 bundle="$test_root/bundle"
@@ -74,7 +85,7 @@ for path in sorted(bundle.rglob("*")):
             "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
             "size_bytes": path.stat().st_size,
         })
-(bundle / "manifest.json").write_text(json.dumps({"platform": target, "files": files}))
+(bundle / "manifest.json").write_text(json.dumps({"platform": target, "peer_protocol_version": 20, "files": files}))
 PY
 "$bundle/install.sh" "$prefix" >/dev/null
 cmp "$bundle/bin/cleat" "$prefix/bin/cleat"

--- a/src/bin/flotillad.rs
+++ b/src/bin/flotillad.rs
@@ -26,7 +26,9 @@ struct Cli {
 
 fn binary_version() -> &'static str {
     static VERSION: OnceLock<String> = OnceLock::new();
-    VERSION.get_or_init(|| format!("{} (wire={})", env!("CARGO_PKG_VERSION"), flotilla_client::BUILD_ID))
+    VERSION.get_or_init(|| {
+        format!("{} (wire={}, proto={})", env!("CARGO_PKG_VERSION"), flotilla_client::BUILD_ID, flotilla_protocol::PROTOCOL_VERSION)
+    })
 }
 
 impl Cli {

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,9 @@ struct Cli {
 
 fn binary_version() -> &'static str {
     static VERSION: OnceLock<String> = OnceLock::new();
-    VERSION.get_or_init(|| format!("{} (wire={})", env!("CARGO_PKG_VERSION"), flotilla_client::BUILD_ID))
+    VERSION.get_or_init(|| {
+        format!("{} (wire={}, proto={})", env!("CARGO_PKG_VERSION"), flotilla_client::BUILD_ID, flotilla_protocol::PROTOCOL_VERSION)
+    })
 }
 
 #[derive(clap::Subcommand)]

--- a/tests/flotillad_binary.rs
+++ b/tests/flotillad_binary.rs
@@ -9,7 +9,7 @@ fn installed_package_exposes_flotillad_binary() {
 }
 
 #[test]
-fn binaries_report_their_wire_generation() {
+fn binaries_report_their_wire_generation_and_protocol_version() {
     for binary in [env!("CARGO_BIN_EXE_flotilla"), env!("CARGO_BIN_EXE_flotillad")] {
         let output = Command::new(binary).arg("--version").output().expect("binary version should run");
 
@@ -18,6 +18,11 @@ fn binaries_report_their_wire_generation() {
         assert!(
             stdout.contains(&format!("wire={}", flotilla_client::BUILD_ID)),
             "{} should report its wire generation, got {stdout:?}",
+            binary
+        );
+        assert!(
+            stdout.contains(&format!("proto={}", flotilla_protocol::PROTOCOL_VERSION)),
+            "{} should report its peer protocol version, got {stdout:?}",
             binary
         );
     }


### PR DESCRIPTION
## Summary

- report the peer protocol version from both Flotilla binaries' `--version` output
- derive `peer_protocol_version` in candidate manifests from the bundled executables
- reject candidate builds when the CLI and daemon disagree or omit the protocol stamp
- keep the installer contract covered with the extended manifest

## Testing

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `bash ci/fleet-candidates/test-workflow.sh`

Closes #1551
