### PR TITLE
fix: recover contained CLI after daemon upgrade

### DIFF
--- a/crates/flotilla-core/src/providers/environment/tests.rs
+++ b/crates/flotilla-core/src/providers/environment/tests.rs
@@ -570,6 +570,47 @@ async fn create_delivers_tool_assets_and_applies_tool_environment() {
 }
 
 #[tokio::test]
+async fn create_mounts_the_flotilla_binary_directory_so_atomic_replacements_stay_visible() {
+    use flotilla_protocol::ImageId;
+
+    let runner = Arc::new(RecordingRunner::new_ok("container-id-123"));
+    let provider = DockerEnvironmentProvider::new(runner.clone());
+    let image = ImageId::new("ubuntu:22.04");
+    let tool = EnvironmentTool::new("flotilla", "/usr/local/bin/flotilla")
+        .with_asset(EnvironmentToolAsset::new(
+            "/host/flotilla/bin",
+            "/opt/flotilla/bin",
+            EnvironmentToolAssetKind::Directory,
+            EnvironmentToolAssetAccess::ReadOnly,
+            "the flotilla CLI",
+        ))
+        .with_asset(EnvironmentToolAsset::new(
+            "/host/flotilla/launcher",
+            "/usr/local/bin/flotilla",
+            EnvironmentToolAssetKind::File,
+            EnvironmentToolAssetAccess::ReadOnly,
+            "the flotilla CLI launcher",
+        ));
+    let opts = CreateOpts {
+        tokens: Vec::new(),
+        working_directory: None,
+        provisioned_mounts: Vec::new(),
+        tools: vec![tool],
+        image_pull_policy: ImagePullPolicy::IfNotPresent,
+        docker_config_dir: None,
+    };
+
+    provider.create(EnvironmentId::new("upgrade-visible"), &image, opts).await.expect("create environment");
+
+    let args = &runner.calls()[0].1;
+    assert!(args.contains(&"/host/flotilla/bin:/opt/flotilla/bin:ro".to_string()), "binary parent must be the bind source: {args:?}");
+    assert!(
+        !args.contains(&"/host/flotilla/bin/flotilla:/opt/flotilla/bin/flotilla:ro".to_string()),
+        "binary inode must not be pinned: {args:?}"
+    );
+}
+
+#[tokio::test]
 async fn create_uses_requested_mount_modes_in_docker_arguments() {
     use flotilla_protocol::ImageId;
 

--- a/crates/flotilla-daemon/src/environment_tools.rs
+++ b/crates/flotilla-daemon/src/environment_tools.rs
@@ -19,7 +19,10 @@ use flotilla_core::{
 };
 use tokio::sync::OnceCell;
 
+pub(crate) const ENVIRONMENT_FLOTILLA_DIRECTORY: &str = "/opt/flotilla/bin";
 pub(crate) const ENVIRONMENT_FLOTILLA_PATH: &str = "/usr/local/bin/flotilla";
+const FLOTILLA_LAUNCHER_NAME: &str = "contained-flotilla-launcher";
+const FLOTILLA_LAUNCHER: &str = "#!/bin/sh\nexec /opt/flotilla/bin/flotilla \"$@\"\n";
 #[cfg(test)]
 pub(crate) const ENVIRONMENT_DAEMON_SOCKET_PATH: &str = "/run/flotilla-daemon/flotilla.sock";
 pub(crate) const ENVIRONMENT_CLEAT_PATH: &str = "/usr/local/bin/cleat";
@@ -125,10 +128,25 @@ impl EnvironmentToolFactory for FlotillaCliTool {
             self.binary_path.as_ref().map_err(|error| format!("flotilla CLI unavailable for environment provisioning: {error}"))?;
         let daemon_socket_path =
             self.daemon_socket_path.as_ref().map_err(|error| format!("flotilla CLI unavailable for environment provisioning: {error}"))?;
+        let binary_directory =
+            binary_path.as_path().parent().ok_or_else(|| format!("flotilla CLI binary has no parent directory: {binary_path}"))?;
+        let launcher_path = daemon_socket_path
+            .as_path()
+            .parent()
+            .ok_or_else(|| format!("daemon socket has no parent directory: {daemon_socket_path}"))?
+            .join(FLOTILLA_LAUNCHER_NAME);
+        ensure_flotilla_launcher(&launcher_path).await?;
         let environment_socket_path = contained_daemon_socket_path(daemon_socket_path.as_path());
         Ok(EnvironmentTool::new("flotilla", ENVIRONMENT_FLOTILLA_PATH)
             .with_asset(EnvironmentToolAsset::new(
-                binary_path.as_path().to_path_buf(),
+                binary_directory.to_path_buf(),
+                ENVIRONMENT_FLOTILLA_DIRECTORY,
+                EnvironmentToolAssetKind::Directory,
+                EnvironmentToolAssetAccess::ReadOnly,
+                "the flotilla CLI",
+            ))
+            .with_asset(EnvironmentToolAsset::new(
+                launcher_path,
                 ENVIRONMENT_FLOTILLA_PATH,
                 EnvironmentToolAssetKind::File,
                 EnvironmentToolAssetAccess::ReadOnly,
@@ -148,6 +166,29 @@ impl EnvironmentToolFactory for FlotillaCliTool {
             ))
             .with_environment(EnvironmentVariableUpdate::set(CONTAINED_DAEMON_REQUIRED_ENV, "1", "the contained host-daemon requirement")))
     }
+}
+
+async fn ensure_flotilla_launcher(path: &Path) -> Result<(), String> {
+    let current = tokio::fs::read(path).await.ok();
+    if current.as_deref() != Some(FLOTILLA_LAUNCHER.as_bytes()) {
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|error| format!("create flotilla CLI launcher directory {}: {error}", parent.display()))?;
+        }
+        tokio::fs::write(path, FLOTILLA_LAUNCHER)
+            .await
+            .map_err(|error| format!("write flotilla CLI launcher {}: {error}", path.display()))?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+            .await
+            .map_err(|error| format!("make flotilla CLI launcher executable at {}: {error}", path.display()))?;
+    }
+    Ok(())
 }
 
 struct CleatTool {
@@ -341,6 +382,26 @@ mod tests {
         let error = adjacent_flotilla_binary(&daemon_binary).expect_err("non-executable flotilla binary should be rejected");
 
         assert_eq!(error, format!("flotilla binary is not executable: {}", flotilla_binary.display()));
+    }
+
+    #[tokio::test]
+    async fn flotilla_cli_uses_a_directory_mount_for_upgrade_visibility() {
+        let temp = TempDir::new().expect("tempdir");
+        let socket_path = temp.path().join("flotilla.sock");
+        let tool = FlotillaCliTool {
+            binary_path: Ok(DaemonHostPath::new("/opt/flotilla/bin/flotilla")),
+            daemon_socket_path: Ok(DaemonHostPath::new(socket_path)),
+        }
+        .prepare("contained-work")
+        .await
+        .expect("prepare flotilla CLI");
+
+        assert_eq!(tool.executable.as_path(), Path::new("/usr/local/bin/flotilla"));
+        assert_eq!(tool.assets[0].host_path.as_path(), Path::new("/opt/flotilla/bin"));
+        assert_eq!(tool.assets[0].environment_path.as_path(), Path::new("/opt/flotilla/bin"));
+        assert_eq!(tool.assets[0].kind, EnvironmentToolAssetKind::Directory);
+        assert_eq!(tool.assets[1].environment_path.as_path(), Path::new("/usr/local/bin/flotilla"));
+        assert_eq!(fs::read_to_string(tool.assets[1].host_path.as_path()).expect("read launcher"), FLOTILLA_LAUNCHER);
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/environment_tools.rs
+++ b/crates/flotilla-daemon/src/environment_tools.rs
@@ -57,10 +57,12 @@ impl EnvironmentToolProvisioner {
             .map(|path| resolve_host_binary(path.as_path()))
             .transpose()
             .and_then(|path| path.ok_or_else(|| "binary unavailable for contained environment delivery".to_string()));
+        let flotilla_binary_path = running_daemon_flotilla_binary()
+            .and_then(|path| stage_flotilla_binary(&path, config.state_dir().join("environment-tools/flotilla-bin").as_path()));
         let runner = daemon.local_command_runner();
         Self::new(vec![
             Arc::new(FlotillaCliTool {
-                binary_path: running_daemon_flotilla_binary(),
+                binary_path: flotilla_binary_path,
                 daemon_socket_path: daemon_socket_path.ok_or_else(|| "daemon socket path unavailable".to_string()),
             }),
             Arc::new(CleatTool {
@@ -169,6 +171,9 @@ impl EnvironmentToolFactory for FlotillaCliTool {
 }
 
 async fn ensure_flotilla_launcher(path: &Path) -> Result<(), String> {
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
     let current = tokio::fs::read(path).await.ok();
     if current.as_deref() != Some(FLOTILLA_LAUNCHER.as_bytes()) {
         if let Some(parent) = path.parent() {
@@ -176,19 +181,40 @@ async fn ensure_flotilla_launcher(path: &Path) -> Result<(), String> {
                 .await
                 .map_err(|error| format!("create flotilla CLI launcher directory {}: {error}", parent.display()))?;
         }
-        tokio::fs::write(path, FLOTILLA_LAUNCHER)
+        let temporary_path = path.with_file_name(format!(".{FLOTILLA_LAUNCHER_NAME}-{}.tmp", uuid::Uuid::new_v4()));
+        tokio::fs::write(&temporary_path, FLOTILLA_LAUNCHER)
             .await
-            .map_err(|error| format!("write flotilla CLI launcher {}: {error}", path.display()))?;
+            .map_err(|error| format!("write flotilla CLI launcher {}: {error}", temporary_path.display()))?;
+        #[cfg(unix)]
+        tokio::fs::set_permissions(&temporary_path, std::fs::Permissions::from_mode(0o755))
+            .await
+            .map_err(|error| format!("make flotilla CLI launcher executable at {}: {error}", temporary_path.display()))?;
+        if let Err(error) = tokio::fs::rename(&temporary_path, path).await {
+            let _ = tokio::fs::remove_file(&temporary_path).await;
+            return Err(format!("publish flotilla CLI launcher at {}: {error}", path.display()));
+        }
     }
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-
         tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
             .await
             .map_err(|error| format!("make flotilla CLI launcher executable at {}: {error}", path.display()))?;
     }
     Ok(())
+}
+
+fn stage_flotilla_binary(binary_path: &DaemonHostPath, staging_directory: &Path) -> Result<DaemonHostPath, String> {
+    std::fs::create_dir_all(staging_directory)
+        .map_err(|error| format!("create flotilla CLI staging directory {}: {error}", staging_directory.display()))?;
+    let staged_path = staging_directory.join("flotilla");
+    let temporary_path = staging_directory.join(format!(".flotilla-{}.tmp", uuid::Uuid::new_v4()));
+    std::fs::copy(binary_path.as_path(), &temporary_path)
+        .map_err(|error| format!("stage flotilla CLI from {} to {}: {error}", binary_path.as_path().display(), temporary_path.display()))?;
+    if let Err(error) = std::fs::rename(&temporary_path, &staged_path) {
+        let _ = std::fs::remove_file(&temporary_path);
+        return Err(format!("publish staged flotilla CLI at {}: {error}", staged_path.display()));
+    }
+    Ok(DaemonHostPath::new(staged_path))
 }
 
 struct CleatTool {
@@ -382,6 +408,27 @@ mod tests {
         let error = adjacent_flotilla_binary(&daemon_binary).expect_err("non-executable flotilla binary should be rejected");
 
         assert_eq!(error, format!("flotilla binary is not executable: {}", flotilla_binary.display()));
+    }
+
+    #[test]
+    fn stages_only_the_flotilla_cli_for_contained_directory_mounts() {
+        let temp = TempDir::new().expect("tempdir");
+        let source_directory = temp.path().join("target/debug");
+        let staging_directory = temp.path().join("state/environment-tools/flotilla-bin");
+        fs::create_dir_all(&source_directory).expect("source directory");
+        let source = source_directory.join("flotilla");
+        fs::write(&source, b"old cli").expect("source CLI");
+        fs::write(source_directory.join("unrelated-test-binary"), b"must not be exposed").expect("unrelated binary");
+
+        let staged = stage_flotilla_binary(&DaemonHostPath::new(&source), &staging_directory).expect("stage CLI");
+
+        assert_eq!(staged.as_path(), staging_directory.join("flotilla"));
+        assert_eq!(fs::read(staged.as_path()).expect("staged CLI"), b"old cli");
+        assert_eq!(fs::read_dir(&staging_directory).expect("staging directory").count(), 1);
+
+        fs::write(&source, b"new cli").expect("replace source CLI");
+        stage_flotilla_binary(&DaemonHostPath::new(source), &staging_directory).expect("restage CLI");
+        assert_eq!(fs::read(staged.as_path()).expect("updated staged CLI"), b"new cli");
     }
 
     #[tokio::test]

--- a/crates/flotilla-daemon/src/peer/ssh_transport.rs
+++ b/crates/flotilla-daemon/src/peer/ssh_transport.rs
@@ -563,7 +563,7 @@ fn parse_remote_socket_path(stdout: &[u8]) -> Result<PathBuf, String> {
 
 fn remote_socket_path_command() -> String {
     format!(
-        "path=$(cat \"$HOME/.config/flotilla/{DAEMON_SOCKET_DISCOVERY_RELATIVE_PATH}\") || exit; printf '{REMOTE_SOCKET_PATH_PREFIX}%s\\n' \"$path\""
+        "discovery=\"$HOME/.config/flotilla/{DAEMON_SOCKET_DISCOVERY_RELATIVE_PATH}\"; path=$(cat \"$discovery\") || exit; case \"$path\" in /*) ;; *) path=\"$(dirname \"$discovery\")/$path\" ;; esac; printf '{REMOTE_SOCKET_PATH_PREFIX}%s\\n' \"$path\""
     )
 }
 
@@ -800,6 +800,7 @@ mod tests {
     fn remote_socket_path_command_uses_shared_discovery_contract() {
         let command = remote_socket_path_command();
         assert!(command.contains("$HOME/.config/flotilla/run/socket-path"));
+        assert!(command.contains("dirname"), "relative advertisements must be resolved beside the discovery file: {command}");
         assert!(command.contains(REMOTE_SOCKET_PATH_PREFIX));
     }
 

--- a/crates/flotilla-daemon/src/runtime.rs
+++ b/crates/flotilla-daemon/src/runtime.rs
@@ -4306,7 +4306,7 @@ mod tests {
         assert!(opts.tokens.is_empty(), "tool environment belongs to the tool description");
         assert_eq!(opts.tools.iter().map(|tool| tool.name.as_str()).collect::<Vec<_>>(), vec!["flotilla", "cleat"]);
         assert_eq!(opts.tools[0].executable.as_path(), Path::new(ENVIRONMENT_FLOTILLA_PATH));
-        assert_eq!(opts.tools[0].assets[1].environment_path.as_path(), Path::new(ENVIRONMENT_DAEMON_SOCKET_PATH));
+        assert_eq!(opts.tools[0].assets[2].environment_path.as_path(), Path::new(ENVIRONMENT_DAEMON_SOCKET_PATH));
         assert_eq!(
             opts.tools[0].environment[1],
             EnvironmentVariableUpdate::set("FLOTILLA_CONTAINED_HOST_DAEMON", "1", "the contained host-daemon requirement",),

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -595,7 +595,8 @@ fn publish_socket_path(discovery_path: &Path, socket_path: &Path) -> Result<(), 
         discovery_path.parent().ok_or_else(|| format!("daemon socket discovery path has no parent: {}", discovery_path.display()))?;
     std::fs::create_dir_all(parent).map_err(|error| format!("failed to create daemon socket discovery directory: {error}"))?;
     let temporary_path = parent.join(format!(".socket-path-{}.tmp", uuid::Uuid::new_v4()));
-    std::fs::write(&temporary_path, format!("{}\n", socket_path.display()))
+    let advertised_path = socket_path.strip_prefix(parent).unwrap_or(socket_path);
+    std::fs::write(&temporary_path, format!("{}\n", advertised_path.display()))
         .map_err(|error| format!("failed to write daemon socket discovery file at {}: {error}", temporary_path.display()))?;
     if let Err(error) = std::fs::rename(&temporary_path, discovery_path) {
         let _ = std::fs::remove_file(&temporary_path);

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -100,6 +100,18 @@ fn daemon_publishes_its_actual_socket_path_for_remote_dialers() {
     assert_eq!(std::fs::read_dir(tmp.path().join("config/run")).expect("read discovery directory").count(), 1);
 }
 
+#[test]
+fn daemon_publishes_a_container_portable_socket_path_when_it_shares_the_discovery_directory() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let run_directory = tmp.path().join("config/run");
+    let discovery_path = run_directory.join("socket-path");
+    let socket_path = run_directory.join("flotilla.sock");
+
+    publish_socket_path(&discovery_path, &socket_path).expect("publish socket path");
+
+    assert_eq!(std::fs::read_to_string(discovery_path).expect("read discovery file"), "flotilla.sock\n");
+}
+
 #[tokio::test]
 async fn daemon_discovery_path_is_independent_of_its_config_and_socket_paths() {
     let tmp = tempfile::tempdir().expect("tempdir");

--- a/src/main.rs
+++ b/src/main.rs
@@ -597,7 +597,9 @@ async fn main() -> Result<()> {
         let already_reexecuted = std::env::var(flotilla_tui::socket::reconnect::REEXEC_BUILD_ENV).ok();
         if should_reexec_for_incompatible_daemon(&message, already_reexecuted.as_deref()) {
             std::env::set_var(flotilla_tui::socket::reconnect::REEXEC_BUILD_ENV, flotilla_tui::socket::BUILD_ID);
-            reexec_current_process()?;
+            if let Err(reexec_error) = reexec_current_process() {
+                return Err(color_eyre::eyre::eyre!(incompatible_daemon_reexec_failure(&message, &reexec_error)));
+            }
         }
     }
     result
@@ -605,6 +607,10 @@ async fn main() -> Result<()> {
 
 fn should_reexec_for_incompatible_daemon(error: &str, already_reexecuted_build: Option<&str>) -> bool {
     flotilla_tui::socket::reconnect::is_incompatible_daemon_error(error) && already_reexecuted_build != Some(flotilla_tui::socket::BUILD_ID)
+}
+
+fn incompatible_daemon_reexec_failure(incompatibility: &str, reexec_error: &dyn std::fmt::Display) -> String {
+    format!("{incompatibility}; re-exec could not reach a matching build: {reexec_error}")
 }
 
 fn reexec_current_process() -> Result<()> {
@@ -1970,10 +1976,11 @@ mod tests {
 
     use super::{
         client_dirs_from, confirm_command, daemon_paths_from, default_project_landing, format_human_resource_value,
-        host_daemon_socket_required, provisioning_target_for_environment, replace_host_ids, run_replica_snapshot, select_host_target,
-        select_startup_repo_roots, should_exec_convoy_attach, should_reexec_for_incompatible_daemon, show_startup_splash, socket_path_from,
-        Cli, CliPaths, CommandValue, DaemonSubCommand, ResourceApplyArgs, ResourceDeleteArgs, ResourceGetArgs, ResourceListArgs,
-        ResourceStatusPatchArgs, ResourceSubCommand, ResourceWatchArgs, SubCommand,
+        host_daemon_socket_required, incompatible_daemon_reexec_failure, provisioning_target_for_environment, replace_host_ids,
+        run_replica_snapshot, select_host_target, select_startup_repo_roots, should_exec_convoy_attach,
+        should_reexec_for_incompatible_daemon, show_startup_splash, socket_path_from, Cli, CliPaths, CommandValue, DaemonSubCommand,
+        ResourceApplyArgs, ResourceDeleteArgs, ResourceGetArgs, ResourceListArgs, ResourceStatusPatchArgs, ResourceSubCommand,
+        ResourceWatchArgs, SubCommand,
     };
 
     #[test]
@@ -2057,6 +2064,17 @@ mod tests {
         assert!(should_reexec_for_incompatible_daemon(mismatch, None));
         assert!(!should_reexec_for_incompatible_daemon(mismatch, Some(flotilla_tui::socket::BUILD_ID)));
         assert!(!should_reexec_for_incompatible_daemon("daemon unavailable", None));
+    }
+
+    #[test]
+    fn failed_incompatible_daemon_reexec_names_both_builds_and_protocols() {
+        let mismatch = "daemon protocol version mismatch: client built cli-old speaks proto 19; daemon built daemon-new speaks proto 20";
+
+        let message = incompatible_daemon_reexec_failure(mismatch, &std::io::Error::from_raw_os_error(libc::ENOENT));
+
+        assert!(message.contains("client built cli-old speaks proto 19"), "{message}");
+        assert!(message.contains("daemon built daemon-new speaks proto 20"), "{message}");
+        assert!(message.contains("re-exec could not reach a matching build"), "{message}");
     }
 
     #[test]


### PR DESCRIPTION
Closes #1557

## What changed

- deliver the contained Flotilla CLI through a directory bind mount, with a stable launcher at `/usr/local/bin/flotilla`, so host-side atomic binary replacement is visible to standing vessels
- preserve the daemon/client build IDs and protocol versions when incompatible-daemon re-exec fails, and explain that no matching build could be reached
- publish daemon socket discovery paths relative to the shared runtime directory when possible, while resolving them to absolute paths for SSH peer dialers
- add behavior coverage at the injected Docker runner seam for replacement-visible mounts

## Root cause

A single-file bind mount pinned the old CLI inode inside a vessel. Replacing the host binary left `/proc/self/exe` referring to a deleted inode, so protocol-mismatch recovery failed with raw `ENOENT`. The shared socket discovery file also advertised a host-only absolute path inside the mounted runtime directory.

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `mkdir -p .codex-tmp && TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- `cargo test -p flotilla-daemon --lib --locked`