### PR TITLE
feat: add promoted fleet installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,9 @@ jobs:
           scripts/test-prune-target.sh
           scripts/test-cargo-sweep-mtime.sh
       - name: Test fleet candidate workflow contract
-        run: ci/fleet-candidates/test-workflow.sh
+        run: |
+          ci/fleet-candidates/test-workflow.sh
+          scripts/test-fleet-install.sh
       - name: Check Rust formatting
         run: cargo +nightly-2026-03-12 fmt --check
 

--- a/ci/fleet-candidates/README.md
+++ b/ci/fleet-candidates/README.md
@@ -29,3 +29,39 @@ The later trusted half must consume these exact bytes, sign the Darwin
 derivatives, run pristine-runtime proofs, publish the complete cohort, copy it
 offsite, and only then write an immutable completed generation. It must not
 rebuild either project.
+
+## Promoted generation consumer contract
+
+`scripts/fleet-install` consumes immutable versions of the Forgejo Generic
+Package `lab/flotilla-fleet`. Each version must contain the unchanged candidate
+archive and a `manifest.json` with this shape:
+
+```json
+{
+  "schema_version": 1,
+  "kind": "flotilla-fleet-generation",
+  "generation": "20260815T220000Z-f0123456789ab-cabcdef012345",
+  "peer_protocol_version": 20,
+  "platforms": {
+    "linux-x86_64-gnu2.36": {
+      "artifact": "fleet-candidate-linux-x86_64-gnu2.36.tar.gz",
+      "sha256": "<64 lowercase hexadecimal characters>"
+    }
+  }
+}
+```
+
+The protocol value must be copied from the candidate manifest produced above;
+the consumer rejects disagreement between the generation and candidate
+manifests. On Linux, bootstrap the reviewed script to
+`~/.local/bin/fleet-install`, store the package-read token at
+`~/.config/flotilla/fleet-reader-token` with mode `0600`, and run one of:
+
+```sh
+fleet-install status
+fleet-install latest
+fleet-install <generation>
+fleet-install rollback
+```
+
+Darwin installation remains blocked on flotilla-org/flotilla#1553.

--- a/scripts/fleet-install
+++ b/scripts/fleet-install
@@ -1,0 +1,452 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly FLEET_OWNER="${FLEET_INSTALL_OWNER:-lab}"
+readonly FLEET_PACKAGE="${FLEET_INSTALL_PACKAGE:-flotilla-fleet}"
+readonly FLEET_API_URL="${FLEET_INSTALL_API_URL:-https://forgejo.lab.flotilla.work/api/v1}"
+readonly FLEET_PACKAGE_URL="${FLEET_INSTALL_PACKAGE_URL:-https://forgejo.lab.flotilla.work/api/packages}"
+readonly FLEET_ROOT="${FLEET_INSTALL_ROOT:-$HOME/.local/opt/flotilla-fleet}"
+readonly FLEET_BIN_DIR="${FLEET_INSTALL_BIN_DIR:-$HOME/.local/bin}"
+readonly FLEET_TOKEN_FILE="${FLEET_INSTALL_TOKEN_FILE:-$HOME/.config/flotilla/fleet-reader-token}"
+readonly RELEASES_DIR="$FLEET_ROOT/releases"
+readonly CURRENT_LINK="$FLEET_ROOT/current"
+readonly PREVIOUS_LINK="$FLEET_ROOT/previous"
+readonly PLATFORM="linux-x86_64-gnu2.36"
+AUTH_HEADER_FILE=""
+WORK_DIR=""
+READ_ONLY=0
+
+die() {
+  printf 'fleet-install: %s\n' "$*" >&2
+  exit 1
+}
+
+cleanup() {
+  [[ -z "$WORK_DIR" ]] || rm -rf -- "$WORK_DIR"
+}
+trap cleanup EXIT
+
+require_linux() {
+  local system="${FLEET_INSTALL_UNAME_S:-$(uname -s)}"
+  local machine="${FLEET_INSTALL_UNAME_M:-$(uname -m)}"
+  if [[ "$system" == Darwin ]]; then
+    die 'Darwin installation is not yet supported; follow #1553: https://github.com/flotilla-org/flotilla/issues/1553'
+  fi
+  [[ "$system-$machine" == Linux-x86_64 ]] || die "unsupported platform: $system-$machine (requires $PLATFORM)"
+}
+
+require_generation() {
+  local generation="$1"
+  [[ "$generation" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] || die "invalid generation id: $generation"
+}
+
+make_work_dir() {
+  [[ -n "$WORK_DIR" ]] && return
+  if ((READ_ONLY)); then
+    WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/fleet-install.XXXXXX")"
+  else
+    mkdir -p "$FLEET_ROOT"
+    WORK_DIR="$(mktemp -d "$FLEET_ROOT/.fleet-install.XXXXXX")"
+  fi
+}
+
+prepare_auth() {
+  [[ -n "$AUTH_HEADER_FILE" ]] && return
+  [[ -f "$FLEET_TOKEN_FILE" && ! -L "$FLEET_TOKEN_FILE" ]] || die "package token is missing: $FLEET_TOKEN_FILE"
+  local mode
+  mode="$(stat -c '%a' "$FLEET_TOKEN_FILE")"
+  [[ "$mode" == 600 ]] || die "package token must have mode 0600: $FLEET_TOKEN_FILE (has $mode)"
+  make_work_dir
+  AUTH_HEADER_FILE="$WORK_DIR/authorization.header"
+  umask 077
+  local token
+  token="$(tr -d '\r\n' <"$FLEET_TOKEN_FILE")"
+  [[ -n "$token" ]] || die "package token is empty: $FLEET_TOKEN_FILE"
+  printf 'Authorization: token %s\n' "$token" >"$AUTH_HEADER_FILE"
+}
+
+download() {
+  local url="$1"
+  local destination="$2"
+  prepare_auth
+  curl --fail --silent --show-error --location --header "@$AUTH_HEADER_FILE" --output "$destination" "$url"
+}
+
+latest_generation() {
+  make_work_dir
+  local page=1
+  local all="$WORK_DIR/packages.jsonl"
+  : >"$all"
+  while true; do
+    local response="$WORK_DIR/packages-$page.json"
+    download "$FLEET_API_URL/packages/$FLEET_OWNER?type=generic&q=$FLEET_PACKAGE&limit=100&page=$page" "$response"
+    python3 - "$response" "$FLEET_PACKAGE" >>"$all" <<'PY'
+import json
+import sys
+
+packages = json.load(open(sys.argv[1]))
+if not isinstance(packages, list):
+    raise SystemExit("package listing is not an array")
+for package in packages:
+    if package.get("type") == "generic" and package.get("name") == sys.argv[2]:
+        print(json.dumps([package.get("created_at", ""), package.get("version", "")]))
+print(f"__COUNT__={len(packages)}")
+PY
+    local count
+    count="$(tail -n 1 "$all" | sed -n 's/^__COUNT__=//p')"
+    sed -i '$d' "$all"
+    [[ "$count" =~ ^[0-9]+$ ]] || die 'invalid package listing response'
+    (( count == 100 )) || break
+    ((page += 1))
+  done
+  python3 - "$all" <<'PY'
+import json
+import sys
+
+rows = [json.loads(line) for line in open(sys.argv[1]) if line.strip()]
+rows = [row for row in rows if row[0] and row[1]]
+if not rows:
+    raise SystemExit("no promoted flotilla-fleet generations found")
+print(max(rows)[1])
+PY
+}
+
+fetch_generation_manifest() {
+  local generation="$1"
+  local destination="$2"
+  require_generation "$generation"
+  download "$FLEET_PACKAGE_URL/$FLEET_OWNER/generic/$FLEET_PACKAGE/$generation/manifest.json" "$destination"
+  python3 - "$destination" "$generation" <<'PY'
+import json
+import re
+import sys
+
+manifest = json.load(open(sys.argv[1]))
+generation = sys.argv[2]
+if manifest.get("schema_version") != 1 or manifest.get("kind") != "flotilla-fleet-generation":
+    raise SystemExit("unsupported generation manifest")
+if manifest.get("generation") != generation:
+    raise SystemExit("generation manifest identity mismatch")
+version = manifest.get("peer_protocol_version")
+if not isinstance(version, int) or isinstance(version, bool) or version < 1:
+    raise SystemExit("generation manifest has invalid peer_protocol_version")
+entry = manifest.get("platforms", {}).get("linux-x86_64-gnu2.36")
+if not isinstance(entry, dict):
+    raise SystemExit("generation has no linux-x86_64-gnu2.36 artifact")
+artifact = entry.get("artifact")
+digest = entry.get("sha256")
+if not isinstance(artifact, str) or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", artifact):
+    raise SystemExit("generation manifest has invalid artifact name")
+if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+    raise SystemExit("generation manifest has invalid artifact digest")
+PY
+}
+
+manifest_value() {
+  local manifest="$1"
+  local expression="$2"
+  python3 - "$manifest" "$expression" <<'PY'
+import json
+import sys
+
+value = json.load(open(sys.argv[1]))
+for part in sys.argv[2].split("."):
+    value = value[part]
+print(value)
+PY
+}
+
+platform_value() {
+  local manifest="$1"
+  local field="$2"
+  python3 - "$manifest" "$PLATFORM" "$field" <<'PY'
+import json
+import sys
+
+print(json.load(open(sys.argv[1]))["platforms"][sys.argv[2]][sys.argv[3]])
+PY
+}
+
+sha256_file() {
+  sha256sum "$1" | awk '{print $1}'
+}
+
+extract_and_verify() {
+  local archive="$1"
+  local destination="$2"
+  local generation_manifest="$3"
+  python3 - "$archive" "$destination" "$generation_manifest" <<'PY'
+import hashlib
+import json
+import os
+import shutil
+import sys
+import tarfile
+from pathlib import Path, PurePosixPath
+
+archive, destination, outer_path = map(Path, sys.argv[1:])
+outer = json.loads(outer_path.read_text())
+with tarfile.open(archive, "r:gz") as bundle:
+    members = bundle.getmembers()
+    roots = set()
+    for member in members:
+        path = PurePosixPath(member.name)
+        if path.is_absolute() or ".." in path.parts or not path.parts:
+            raise SystemExit(f"unsafe archive path: {member.name}")
+        if not (member.isfile() or member.isdir()):
+            raise SystemExit(f"unsupported archive entry: {member.name}")
+        roots.add(path.parts[0])
+    if len(roots) != 1:
+        raise SystemExit("archive must contain exactly one bundle directory")
+    bundle.extractall(destination)
+
+root = destination / roots.pop()
+manifest_path = root / "manifest.json"
+manifest = json.loads(manifest_path.read_text())
+if (
+    manifest.get("schema_version") != 1
+    or manifest.get("kind") != "unsigned-fleet-candidate"
+    or manifest.get("platform") != "linux-x86_64-gnu2.36"
+):
+    raise SystemExit("candidate manifest platform or schema mismatch")
+if manifest.get("peer_protocol_version") != outer.get("peer_protocol_version"):
+    raise SystemExit("candidate and generation peer protocol versions differ")
+entries = manifest.get("files")
+if not isinstance(entries, list) or not entries:
+    raise SystemExit("candidate manifest has no files")
+expected = set()
+for entry in entries:
+    rel = entry.get("path")
+    if not isinstance(rel, str) or PurePosixPath(rel).is_absolute() or ".." in PurePosixPath(rel).parts:
+        raise SystemExit("candidate manifest contains an unsafe path")
+    path = root / rel
+    expected.add(rel)
+    if not path.is_file():
+        raise SystemExit(f"candidate file is missing: {rel}")
+    if path.stat().st_size != entry.get("size_bytes"):
+        raise SystemExit(f"candidate size mismatch: {rel}")
+    if hashlib.sha256(path.read_bytes()).hexdigest() != entry.get("sha256"):
+        raise SystemExit(f"candidate checksum mismatch: {rel}")
+actual = {
+    str(path.relative_to(root))
+    for path in root.rglob("*")
+    if path.is_file() and path != manifest_path
+}
+if actual != expected:
+    raise SystemExit("candidate files do not match the manifest")
+for name in ("flotilla", "flotillad", "cleat"):
+    if f"bin/{name}" not in expected:
+        raise SystemExit(f"candidate is missing required binary: {name}")
+shutil.move(str(root), str(destination / "release"))
+PY
+}
+
+verify_installed_release() {
+  local release="$1"
+  local generation_manifest="$2"
+  python3 - "$release" "$generation_manifest" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path, PurePosixPath
+
+root, outer_path = map(Path, sys.argv[1:])
+manifest_path = root / "manifest.json"
+manifest = json.loads(manifest_path.read_text())
+outer = json.loads(outer_path.read_text())
+if (
+    manifest.get("schema_version") != 1
+    or manifest.get("kind") != "unsigned-fleet-candidate"
+    or manifest.get("platform") != "linux-x86_64-gnu2.36"
+):
+    raise SystemExit("installed candidate manifest platform or schema mismatch")
+if manifest.get("peer_protocol_version") != outer.get("peer_protocol_version"):
+    raise SystemExit("installed candidate and generation peer protocol versions differ")
+entries = manifest.get("files")
+if not isinstance(entries, list) or not entries:
+    raise SystemExit("installed candidate manifest has no files")
+expected = set()
+for entry in entries:
+    rel = entry.get("path")
+    if not isinstance(rel, str) or PurePosixPath(rel).is_absolute() or ".." in PurePosixPath(rel).parts:
+        raise SystemExit("installed candidate manifest contains an unsafe path")
+    path = root / rel
+    expected.add(rel)
+    if not path.is_file() or path.stat().st_size != entry.get("size_bytes"):
+        raise SystemExit(f"installed candidate file mismatch: {rel}")
+    if hashlib.sha256(path.read_bytes()).hexdigest() != entry.get("sha256"):
+        raise SystemExit(f"installed candidate checksum mismatch: {rel}")
+actual = {str(path.relative_to(root)) for path in root.rglob("*") if path.is_file() and path != manifest_path}
+if actual != expected:
+    raise SystemExit("installed candidate files do not match the manifest")
+PY
+}
+
+current_generation() {
+  [[ -L "$CURRENT_LINK" ]] || return 0
+  basename "$(readlink -f "$CURRENT_LINK")"
+}
+
+protocol_version() {
+  local link="$1"
+  [[ -f "$link/manifest.json" ]] || return 0
+  python3 - "$link/manifest.json" <<'PY'
+import json
+import sys
+try:
+    print(json.load(open(sys.argv[1])).get("peer_protocol_version", ""))
+except (OSError, ValueError):
+    pass
+PY
+}
+
+write_launcher() {
+  local name="$1"
+  local launcher="$FLEET_BIN_DIR/$name"
+  mkdir -p "$FLEET_BIN_DIR"
+  if [[ -e "$launcher" ]] && ! grep -Fq '# managed by fleet-install' "$launcher" 2>/dev/null; then
+    die "refusing to replace unmanaged launcher: $launcher"
+  fi
+  local temporary
+  temporary="$(mktemp "$FLEET_BIN_DIR/.$name.fleet-install.XXXXXX")"
+  printf '#!/usr/bin/env bash\n# managed by fleet-install\nexec %q/current/bin/%q "$@"\n' "$FLEET_ROOT" "$name" >"$temporary"
+  chmod 0755 "$temporary"
+  mv -f "$temporary" "$launcher"
+}
+
+ensure_launchers_and_path() {
+  local name resolved expected
+  for name in flotilla flotillad cleat; do
+    write_launcher "$name"
+    expected="$(readlink -f "$FLEET_BIN_DIR")/$name"
+    resolved="$(command -v "$name" || true)"
+    [[ -n "$resolved" ]] || die "$name is not reachable through PATH; add $FLEET_BIN_DIR before installing"
+    [[ "$(readlink -f "$resolved")" == "$expected" ]] || die "PATH shadows the fleet launcher for $name: $resolved; put $FLEET_BIN_DIR first"
+  done
+}
+
+daemon_preflight() {
+  pgrep -u "$(id -u)" -x flotillad >/dev/null 2>&1 || return 0
+  local cli
+  if [[ -x "$CURRENT_LINK/bin/flotilla" ]]; then
+    cli="$CURRENT_LINK/bin/flotilla"
+  else
+    cli="$(command -v flotilla || true)"
+  fi
+  [[ -n "$cli" ]] || die 'flotillad is running; install a usable flotilla command and run `flotilla daemon stop`'
+  if ! "$cli" daemon stop; then
+    die 'flotillad is running and could not be stopped; run `flotilla daemon stop`, then retry'
+  fi
+}
+
+atomic_link() {
+  local target="$1"
+  local link="$2"
+  local temporary="$FLEET_ROOT/.$(basename "$link").new.$$"
+  ln -s "$target" "$temporary"
+  mv -Tf "$temporary" "$link"
+}
+
+switch_to() {
+  local generation="$1"
+  local old="$(current_generation)"
+  [[ "$old" != "$generation" ]] || return 0
+  daemon_preflight
+  if [[ -n "$old" ]]; then
+    atomic_link "releases/$old" "$PREVIOUS_LINK"
+  fi
+  atomic_link "releases/$generation" "$CURRENT_LINK"
+}
+
+install_generation() {
+  local generation="$1"
+  require_generation "$generation"
+  mkdir -p "$RELEASES_DIR"
+  local old="$(current_generation)"
+  printf 'fleet-install: %s -> %s\n' "${old:-<none>}" "$generation"
+  if [[ -d "$RELEASES_DIR/$generation" ]]; then
+    make_work_dir
+    local installed_outer="$WORK_DIR/installed-manifest.json"
+    fetch_generation_manifest "$generation" "$installed_outer"
+    verify_installed_release "$RELEASES_DIR/$generation" "$installed_outer"
+    ensure_launchers_and_path
+    switch_to "$generation"
+    printf 'fleet-install: generation %s is installed\n' "$generation"
+    return
+  fi
+  make_work_dir
+  local outer="$WORK_DIR/manifest.json"
+  local archive="$WORK_DIR/artifact.tar.gz"
+  local unpack="$WORK_DIR/unpack"
+  fetch_generation_manifest "$generation" "$outer"
+  local artifact expected actual
+  artifact="$(platform_value "$outer" artifact)"
+  expected="$(platform_value "$outer" sha256)"
+  download "$FLEET_PACKAGE_URL/$FLEET_OWNER/generic/$FLEET_PACKAGE/$generation/$artifact" "$archive"
+  actual="$(sha256_file "$archive")"
+  [[ "$actual" == "$expected" ]] || die "archive digest mismatch for $generation: expected $expected, got $actual"
+  mkdir -p "$unpack"
+  extract_and_verify "$archive" "$unpack" "$outer"
+  mv "$unpack/release" "$RELEASES_DIR/$generation"
+  chmod -R a-w "$RELEASES_DIR/$generation"
+  ensure_launchers_and_path
+  switch_to "$generation"
+  printf 'fleet-install: generation %s is installed\n' "$generation"
+}
+
+show_status() {
+  make_work_dir
+  local current latest target_manifest current_version target_version
+  current="$(current_generation)"
+  latest="$(latest_generation)"
+  target_manifest="$WORK_DIR/latest-manifest.json"
+  fetch_generation_manifest "$latest" "$target_manifest"
+  current_version="$(protocol_version "$CURRENT_LINK")"
+  target_version="$(manifest_value "$target_manifest" peer_protocol_version)"
+  printf 'current: %s (peer protocol %s)\n' "${current:-<none>}" "${current_version:-unknown}"
+  printf 'latest:  %s (peer protocol %s)\n' "$latest" "$target_version"
+  if [[ -n "$current_version" && "$current_version" != "$target_version" ]]; then
+    printf 'warning: peer protocol changes from %s to %s; mixed generations may not peer\n' "$current_version" "$target_version"
+  fi
+}
+
+rollback() {
+  [[ -L "$CURRENT_LINK" ]] || die 'no current generation to roll back'
+  [[ -L "$PREVIOUS_LINK" ]] || die 'no previous generation to roll back to'
+  local current previous
+  current="$(current_generation)"
+  previous="$(basename "$(readlink -f "$PREVIOUS_LINK")")"
+  [[ -d "$RELEASES_DIR/$previous" ]] || die "previous generation is missing: $previous"
+  printf 'fleet-install: %s -> %s (rollback)\n' "$current" "$previous"
+  daemon_preflight
+  atomic_link "releases/$previous" "$CURRENT_LINK"
+  atomic_link "releases/$current" "$PREVIOUS_LINK"
+}
+
+usage() {
+  echo 'usage: fleet-install status | latest | <generation> | rollback' >&2
+  exit 2
+}
+
+main() {
+  [[ $# -eq 1 ]] || usage
+  require_linux
+  case "$1" in
+    status)
+      READ_ONLY=1
+      show_status
+      ;;
+    latest)
+      local generation
+      generation="$(latest_generation)"
+      install_generation "$generation"
+      ;;
+    rollback) rollback ;;
+    -h|--help) usage ;;
+    *) install_generation "$1" ;;
+  esac
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/fleet-install
+++ b/scripts/fleet-install
@@ -58,11 +58,10 @@ prepare_auth() {
   [[ "$mode" == 600 ]] || die "package token must have mode 0600: $FLEET_TOKEN_FILE (has $mode)"
   make_work_dir
   AUTH_HEADER_FILE="$WORK_DIR/authorization.header"
-  umask 077
   local token
   token="$(tr -d '\r\n' <"$FLEET_TOKEN_FILE")"
   [[ -n "$token" ]] || die "package token is empty: $FLEET_TOKEN_FILE"
-  printf 'Authorization: token %s\n' "$token" >"$AUTH_HEADER_FILE"
+  (umask 077 && printf 'Authorization: token %s\n' "$token" >"$AUTH_HEADER_FILE")
 }
 
 download() {

--- a/scripts/fleet-install
+++ b/scripts/fleet-install
@@ -15,6 +15,7 @@ readonly PLATFORM="linux-x86_64-gnu2.36"
 AUTH_HEADER_FILE=""
 WORK_DIR=""
 READ_ONLY=0
+INSTALL_LOCK_FD=""
 
 die() {
   printf 'fleet-install: %s\n' "$*" >&2
@@ -48,6 +49,12 @@ make_work_dir() {
     mkdir -p "$FLEET_ROOT"
     WORK_DIR="$(mktemp -d "$FLEET_ROOT/.fleet-install.XXXXXX")"
   fi
+}
+
+acquire_install_lock() {
+  mkdir -p "$FLEET_ROOT"
+  exec {INSTALL_LOCK_FD}>"$FLEET_ROOT/.install.lock"
+  flock -n "$INSTALL_LOCK_FD" || die 'another fleet-install mutation is already running'
 }
 
 prepare_auth() {
@@ -360,6 +367,7 @@ switch_to() {
 install_generation() {
   local generation="$1"
   require_generation "$generation"
+  acquire_install_lock
   mkdir -p "$RELEASES_DIR"
   local old="$(current_generation)"
   printf 'fleet-install: %s -> %s\n' "${old:-<none>}" "$generation"
@@ -386,7 +394,7 @@ install_generation() {
   [[ "$actual" == "$expected" ]] || die "archive digest mismatch for $generation: expected $expected, got $actual"
   mkdir -p "$unpack"
   extract_and_verify "$archive" "$unpack" "$outer"
-  mv "$unpack/release" "$RELEASES_DIR/$generation"
+  mv -T "$unpack/release" "$RELEASES_DIR/$generation"
   chmod -R a-w "$RELEASES_DIR/$generation"
   ensure_launchers_and_path
   switch_to "$generation"
@@ -410,6 +418,7 @@ show_status() {
 }
 
 rollback() {
+  acquire_install_lock
   [[ -L "$CURRENT_LINK" ]] || die 'no current generation to roll back'
   [[ -L "$PREVIOUS_LINK" ]] || die 'no previous generation to roll back to'
   local current previous

--- a/scripts/test-fleet-install.sh
+++ b/scripts/test-fleet-install.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+installer="$repo_root/scripts/fleet-install"
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/fleet-install-test.XXXXXX")"
+cleanup() {
+  chmod -R u+w "$test_root" 2>/dev/null || true
+  rm -rf "$test_root"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "fleet-install contract failed: $*" >&2
+  exit 1
+}
+
+generation_one="20260815T210000Z-f111111111111-caaaaaaaaaaaa"
+generation_two="20260815T220000Z-f222222222222-cbbbbbbbbbbbb"
+fixture_root="$test_root/packages"
+fake_bin="$test_root/fake-bin"
+mkdir -p "$test_root/home/.config/flotilla" "$fixture_root" "$fake_bin"
+printf 'test-token\n' >"$test_root/home/.config/flotilla/fleet-reader-token"
+chmod 0600 "$test_root/home/.config/flotilla/fleet-reader-token"
+
+make_generation() {
+  local generation="$1"
+  local protocol="$2"
+  local platform="${3:-linux-x86_64-gnu2.36}"
+  local corrupt_inner="${4:-no}"
+  local directory="$fixture_root/$generation"
+  local bundle="$test_root/bundle-$generation/fleet-candidate-linux-x86_64-gnu2.36"
+  mkdir -p "$directory" "$bundle/bin" "$bundle/lib"
+  for name in flotilla flotillad cleat; do
+    printf '#!/usr/bin/env bash\nif [[ "${1:-}" == daemon && "${2:-}" == stop ]]; then exit "${STOP_FAIL:-0}"; fi\nprintf "%s from %s\\n"\n' "$name" "$generation" >"$bundle/bin/$name"
+    chmod 0755 "$bundle/bin/$name"
+  done
+  printf 'ghostty\n' >"$bundle/lib/libghostty-vt.so.0"
+  TEST_BUNDLE="$bundle" TEST_PLATFORM="$platform" TEST_PROTOCOL="$protocol" TEST_CORRUPT_INNER="$corrupt_inner" python3 - <<'PY'
+import hashlib
+import json
+import os
+from pathlib import Path
+
+bundle = Path(os.environ["TEST_BUNDLE"])
+files = []
+for path in sorted(bundle.rglob("*")):
+    if path.is_file():
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        if os.environ["TEST_CORRUPT_INNER"] == "yes" and path.name == "cleat":
+            digest = "0" * 64
+        files.append({"path": str(path.relative_to(bundle)), "sha256": digest, "size_bytes": path.stat().st_size})
+(bundle / "manifest.json").write_text(json.dumps({
+    "schema_version": 1,
+    "kind": "unsigned-fleet-candidate",
+    "platform": os.environ["TEST_PLATFORM"],
+    "peer_protocol_version": int(os.environ["TEST_PROTOCOL"]),
+    "files": files,
+}, sort_keys=True) + "\n")
+PY
+  local artifact="fleet-candidate-linux-x86_64-gnu2.36.tar.gz"
+  tar -C "$(dirname "$bundle")" -czf "$directory/$artifact" "$(basename "$bundle")"
+  local digest
+  digest="$(sha256sum "$directory/$artifact" | awk '{print $1}')"
+  TEST_GENERATION="$generation" TEST_PROTOCOL="$protocol" TEST_PLATFORM="$platform" TEST_ARTIFACT="$artifact" TEST_DIGEST="$digest" TEST_DIRECTORY="$directory" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+manifest = {
+    "schema_version": 1,
+    "kind": "flotilla-fleet-generation",
+    "generation": os.environ["TEST_GENERATION"],
+    "peer_protocol_version": int(os.environ["TEST_PROTOCOL"]),
+    "platforms": {
+        os.environ["TEST_PLATFORM"]: {
+            "artifact": os.environ["TEST_ARTIFACT"],
+            "sha256": os.environ["TEST_DIGEST"],
+        }
+    },
+}
+(Path(os.environ["TEST_DIRECTORY"]) / "manifest.json").write_text(json.dumps(manifest, sort_keys=True) + "\n")
+PY
+}
+
+make_generation "$generation_one" 20
+make_generation "$generation_two" 21
+
+cat >"$fixture_root/packages-page-1.json" <<JSON
+[
+  {"type":"generic","name":"flotilla-fleet","version":"$generation_one","created_at":"2026-08-15T21:00:00Z"},
+  {"type":"generic","name":"another-package","version":"ignored","created_at":"2026-08-15T23:00:00Z"},
+  {"type":"generic","name":"flotilla-fleet","version":"$generation_two","created_at":"2026-08-15T22:00:00Z"}
+]
+JSON
+
+cat >"$fake_bin/curl" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+destination=""
+url=""
+while (($#)); do
+  case "$1" in
+    --output) destination="$2"; shift 2 ;;
+    --header) shift 2 ;;
+    --fail|--silent|--show-error|--location) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+[[ -n "$destination" && -n "$url" ]]
+if [[ "$url" == *'/api/v1/packages/'* ]]; then
+  page="${url##*page=}"
+  source="$FIXTURE_ROOT/packages-page-$page.json"
+  if [[ ! -f "$source" ]]; then printf '[]\n' >"$destination"; else cp "$source" "$destination"; fi
+  exit 0
+fi
+generation="$(basename "$(dirname "$url")")"
+file="$(basename "$url")"
+source="$FIXTURE_ROOT/$generation/$file"
+if [[ "${FAIL_ARTIFACT_FOR:-}" == "$generation" && "$file" == *.tar.gz ]]; then
+  printf 'interrupted' >"$destination"
+  exit 56
+fi
+cp "$source" "$destination"
+SH
+chmod 0755 "$fake_bin/curl"
+
+cat >"$fake_bin/pgrep" <<'SH'
+#!/usr/bin/env bash
+[[ "${DAEMON_RUNNING:-0}" == 1 ]]
+SH
+chmod 0755 "$fake_bin/pgrep"
+
+run_installer() {
+  HOME="$test_root/home" \
+    PATH="$test_root/home/.local/bin:$fake_bin:$PATH" \
+    FIXTURE_ROOT="$fixture_root" \
+    FLEET_INSTALL_API_URL="https://test.invalid/api/v1" \
+    FLEET_INSTALL_PACKAGE_URL="https://test.invalid/api/packages" \
+    "$installer" "$@"
+}
+
+if HOME="$test_root/home" FLEET_INSTALL_UNAME_S=Darwin FLEET_INSTALL_UNAME_M=arm64 "$installer" status >"$test_root/darwin.out" 2>&1; then
+  fail 'Darwin did not fail closed'
+fi
+grep -Fq '#1553' "$test_root/darwin.out" || fail 'Darwin refusal did not point at #1553'
+
+status_home="$test_root/status-home"
+mkdir -p "$status_home/.config/flotilla"
+cp "$test_root/home/.config/flotilla/fleet-reader-token" "$status_home/.config/flotilla/fleet-reader-token"
+HOME="$status_home" PATH="$status_home/.local/bin:$fake_bin:$PATH" FIXTURE_ROOT="$fixture_root" \
+  FLEET_INSTALL_API_URL=https://test.invalid/api/v1 FLEET_INSTALL_PACKAGE_URL=https://test.invalid/api/packages \
+  "$installer" status >"$test_root/fresh-status.out"
+test ! -e "$status_home/.local/opt/flotilla-fleet" || fail 'status mutated the install root'
+
+run_installer "$generation_one" >"$test_root/install-one.out"
+test "$(basename "$(readlink -f "$test_root/home/.local/opt/flotilla-fleet/current")")" = "$generation_one" || fail 'exact generation was not selected'
+test -x "$test_root/home/.local/opt/flotilla-fleet/releases/$generation_one/bin/flotilla" || fail 'candidate binaries were not staged'
+test ! -w "$test_root/home/.local/opt/flotilla-fleet/releases/$generation_one/manifest.json" || fail 'selected generation is writable'
+for name in flotilla flotillad cleat; do
+  grep -Fq '# managed by fleet-install' "$test_root/home/.local/bin/$name" || fail "missing stable $name launcher"
+done
+
+status="$(run_installer status)"
+grep -Fq "current: $generation_one (peer protocol 20)" <<<"$status" || fail 'status omitted current manifest protocol'
+grep -Fq "latest:  $generation_two (peer protocol 21)" <<<"$status" || fail 'status selected the wrong promoted generation'
+grep -Fq 'warning: peer protocol changes from 20 to 21' <<<"$status" || fail 'status omitted wire-bump warning'
+
+before_manifest="$(sha256sum "$test_root/home/.local/opt/flotilla-fleet/releases/$generation_one/manifest.json")"
+run_installer "$generation_one" >/dev/null
+after_manifest="$(sha256sum "$test_root/home/.local/opt/flotilla-fleet/releases/$generation_one/manifest.json")"
+[[ "$before_manifest" == "$after_manifest" ]] || fail 'exact-generation reinstall mutated the release'
+
+if FAIL_ARTIFACT_FOR="$generation_two" run_installer "$generation_two" >"$test_root/interrupted.out" 2>&1; then
+  fail 'interrupted download was accepted'
+fi
+test "$(basename "$(readlink -f "$test_root/home/.local/opt/flotilla-fleet/current")")" = "$generation_one" || fail 'interrupted download switched current'
+test ! -e "$test_root/home/.local/opt/flotilla-fleet/releases/$generation_two" || fail 'interrupted download published a release'
+
+if DAEMON_RUNNING=1 STOP_FAIL=1 run_installer "$generation_two" >"$test_root/daemon.out" 2>&1; then
+  fail 'daemon stop refusal was ignored'
+fi
+grep -Fq 'flotilla daemon stop' "$test_root/daemon.out" || fail 'daemon refusal omitted recovery instruction'
+test "$(basename "$(readlink -f "$test_root/home/.local/opt/flotilla-fleet/current")")" = "$generation_one" || fail 'failed daemon preflight switched current'
+
+run_installer latest >"$test_root/latest.out"
+grep -Fq "$generation_one -> $generation_two" "$test_root/latest.out" || fail 'latest did not print the exact transition'
+test "$(basename "$(readlink -f "$test_root/home/.local/opt/flotilla-fleet/current")")" = "$generation_two" || fail 'latest did not select newest promoted generation'
+test "$(basename "$(readlink -f "$test_root/home/.local/opt/flotilla-fleet/previous")")" = "$generation_one" || fail 'switch did not record previous generation'
+
+run_installer rollback >"$test_root/rollback.out"
+test "$(basename "$(readlink -f "$test_root/home/.local/opt/flotilla-fleet/current")")" = "$generation_one" || fail 'rollback did not restore previous generation'
+test "$(basename "$(readlink -f "$test_root/home/.local/opt/flotilla-fleet/previous")")" = "$generation_two" || fail 'rollback did not retain displaced generation'
+
+bad_digest="20260815T230000Z-f333333333333-ccccccccccccc"
+make_generation "$bad_digest" 21
+python3 - "$fixture_root/$bad_digest/manifest.json" <<'PY'
+import json
+import sys
+path = sys.argv[1]
+manifest = json.load(open(path))
+manifest["platforms"]["linux-x86_64-gnu2.36"]["sha256"] = "0" * 64
+open(path, "w").write(json.dumps(manifest) + "\n")
+PY
+if run_installer "$bad_digest" >"$test_root/digest.out" 2>&1; then
+  fail 'outer digest mismatch was accepted'
+fi
+test ! -e "$test_root/home/.local/opt/flotilla-fleet/releases/$bad_digest" || fail 'digest rejection published a release'
+
+bad_manifest="20260815T231000Z-f444444444444-cdddddddddddd"
+make_generation "$bad_manifest" 21 linux-x86_64-gnu2.36 yes
+if run_installer "$bad_manifest" >"$test_root/manifest.out" 2>&1; then
+  fail 'inner manifest mismatch was accepted'
+fi
+test ! -e "$test_root/home/.local/opt/flotilla-fleet/releases/$bad_manifest" || fail 'manifest rejection published a release'
+
+bad_platform="20260815T232000Z-f555555555555-ceeeeeeeeeeee"
+make_generation "$bad_platform" 21 darwin-aarch64
+if run_installer "$bad_platform" >"$test_root/platform.out" 2>&1; then
+  fail 'wrong-platform generation was accepted'
+fi
+grep -Fq 'no linux-x86_64-gnu2.36 artifact' "$test_root/platform.out" || fail 'wrong-platform error was unclear'
+
+shadow_home="$test_root/shadow-home"
+shadow_bin="$test_root/shadow-bin"
+mkdir -p "$shadow_home/.config/flotilla" "$shadow_bin"
+cp "$test_root/home/.config/flotilla/fleet-reader-token" "$shadow_home/.config/flotilla/fleet-reader-token"
+for name in flotilla flotillad cleat; do
+  printf '#!/bin/sh\nexit 0\n' >"$shadow_bin/$name"
+  chmod 0755 "$shadow_bin/$name"
+done
+if HOME="$shadow_home" PATH="$shadow_bin:$shadow_home/.local/bin:$fake_bin:$PATH" FIXTURE_ROOT="$fixture_root" \
+  FLEET_INSTALL_API_URL=https://test.invalid/api/v1 FLEET_INSTALL_PACKAGE_URL=https://test.invalid/api/packages \
+  "$installer" "$generation_one" >"$test_root/shadow.out" 2>&1; then
+  fail 'PATH shadow was accepted'
+fi
+grep -Fq 'PATH shadows the fleet launcher' "$test_root/shadow.out" || fail 'PATH shadow error was unclear'
+test ! -L "$shadow_home/.local/opt/flotilla-fleet/current" || fail 'PATH shadow switched current'
+
+echo 'fleet-install contract passed'

--- a/scripts/test-fleet-install.sh
+++ b/scripts/test-fleet-install.sh
@@ -157,6 +157,7 @@ run_installer "$generation_one" >"$test_root/install-one.out"
 test "$(basename "$(readlink -f "$test_root/home/.local/opt/flotilla-fleet/current")")" = "$generation_one" || fail 'exact generation was not selected'
 test -x "$test_root/home/.local/opt/flotilla-fleet/releases/$generation_one/bin/flotilla" || fail 'candidate binaries were not staged'
 test ! -w "$test_root/home/.local/opt/flotilla-fleet/releases/$generation_one/manifest.json" || fail 'selected generation is writable'
+test "$(stat -c '%a' "$test_root/home/.local/bin")" = 755 || fail 'credential umask leaked into the launcher directory'
 for name in flotilla flotillad cleat; do
   grep -Fq '# managed by fleet-install' "$test_root/home/.local/bin/$name" || fail "missing stable $name launcher"
 done

--- a/scripts/test-fleet-install.sh
+++ b/scripts/test-fleet-install.sh
@@ -32,7 +32,7 @@ make_generation() {
   local bundle="$test_root/bundle-$generation/fleet-candidate-linux-x86_64-gnu2.36"
   mkdir -p "$directory" "$bundle/bin" "$bundle/lib"
   for name in flotilla flotillad cleat; do
-    printf '#!/usr/bin/env bash\nif [[ "${1:-}" == daemon && "${2:-}" == stop ]]; then exit "${STOP_FAIL:-0}"; fi\nprintf "%s from %s\\n"\n' "$name" "$generation" >"$bundle/bin/$name"
+    printf '#!/usr/bin/env bash\nif [[ "${1:-}" == daemon && "${2:-}" == stop ]]; then echo "daemon stop requested"; exit "${STOP_FAIL:-0}"; fi\nprintf "%s from %s\\n"\n' "$name" "$generation" >"$bundle/bin/$name"
     chmod 0755 "$bundle/bin/$name"
   done
   printf 'ghostty\n' >"$bundle/lib/libghostty-vt.so.0"
@@ -184,8 +184,9 @@ fi
 grep -Fq 'flotilla daemon stop' "$test_root/daemon.out" || fail 'daemon refusal omitted recovery instruction'
 test "$(basename "$(readlink -f "$test_root/home/.local/opt/flotilla-fleet/current")")" = "$generation_one" || fail 'failed daemon preflight switched current'
 
-run_installer latest >"$test_root/latest.out"
+DAEMON_RUNNING=1 STOP_FAIL=0 run_installer latest >"$test_root/latest.out"
 grep -Fq "$generation_one -> $generation_two" "$test_root/latest.out" || fail 'latest did not print the exact transition'
+grep -Fq 'daemon stop requested' "$test_root/latest.out" || fail 'running daemon was not stopped before switching'
 test "$(basename "$(readlink -f "$test_root/home/.local/opt/flotilla-fleet/current")")" = "$generation_two" || fail 'latest did not select newest promoted generation'
 test "$(basename "$(readlink -f "$test_root/home/.local/opt/flotilla-fleet/previous")")" = "$generation_one" || fail 'switch did not record previous generation'
 

--- a/scripts/test-fleet-install.sh
+++ b/scripts/test-fleet-install.sh
@@ -172,6 +172,15 @@ run_installer "$generation_one" >/dev/null
 after_manifest="$(sha256sum "$test_root/home/.local/opt/flotilla-fleet/releases/$generation_one/manifest.json")"
 [[ "$before_manifest" == "$after_manifest" ]] || fail 'exact-generation reinstall mutated the release'
 
+exec 9>"$test_root/home/.local/opt/flotilla-fleet/.install.lock"
+flock -n 9
+if run_installer "$generation_one" >"$test_root/locked.out" 2>&1; then
+  fail 'concurrent mutation lock was ignored'
+fi
+flock -u 9
+exec 9>&-
+grep -Fq 'another fleet-install mutation is already running' "$test_root/locked.out" || fail 'concurrent mutation error was unclear'
+
 if FAIL_ARTIFACT_FOR="$generation_two" run_installer "$generation_two" >"$test_root/interrupted.out" 2>&1; then
   fail 'interrupted download was accepted'
 fi


### PR DESCRIPTION
## Summary

- add the Linux fleet installer for status, latest, exact-generation install, and rollback
- verify the immutable generation digest and complete candidate manifest before atomically switching the current release
- stop a running daemon before switches, detect PATH shadowing, and fail closed on Darwin
- document the promotion manifest consumed by the installer and run its offline contract suite in CI

## Validation

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
- `ci/fleet-candidates/test-workflow.sh`
- `scripts/test-fleet-install.sh`

Real promoted-generation validation remains the separate Debian/udder deployment step and is not claimed here.

Closes #1565
