### PR TITLE
fix: admit daemon shutdown across same-protocol builds

### DIFF
--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -53,14 +53,24 @@ impl SpawnLockGuard {
 /// Sends a `Hello` with `ConnectionRole::Client` and a fresh `session_id`,
 /// then waits for the server's Hello reply.
 async fn do_client_hello(session: &MessageSession) -> Result<Option<String>, String> {
-    do_client_hello_with_surface(session, None).await
+    do_client_hello_with_surface(session, None, WireGenerationPolicy::RequireMatch).await
 }
 
 async fn do_client_hello_with_declared_surface(session: &MessageSession, surface: SurfaceDeclaration) -> Result<Option<String>, String> {
-    do_client_hello_with_surface(session, Some(surface)).await
+    do_client_hello_with_surface(session, Some(surface), WireGenerationPolicy::RequireMatch).await
 }
 
-async fn do_client_hello_with_surface(session: &MessageSession, surface: Option<SurfaceDeclaration>) -> Result<Option<String>, String> {
+#[derive(Clone, Copy)]
+enum WireGenerationPolicy {
+    RequireMatch,
+    AllowMismatchForShutdown,
+}
+
+async fn do_client_hello_with_surface(
+    session: &MessageSession,
+    surface: Option<SurfaceDeclaration>,
+    wire_generation_policy: WireGenerationPolicy,
+) -> Result<Option<String>, String> {
     let session_id = uuid::Uuid::new_v4();
     session
         .write(Message::Hello {
@@ -85,7 +95,9 @@ async fn do_client_hello_with_surface(session: &MessageSession, surface: Option<
         }
         Some(Message::Hello { display_name, .. }) => {
             let daemon_generation = flotilla_protocol::hello_build_id(&display_name).unwrap_or("unknown");
-            if !flotilla_protocol::wire_generations_match(daemon_generation, BUILD_ID) {
+            if !flotilla_protocol::wire_generations_match(daemon_generation, BUILD_ID)
+                && matches!(wire_generation_policy, WireGenerationPolicy::RequireMatch)
+            {
                 return Err(format!(
                     "wire generation mismatch: client built {} speaks proto {PROTOCOL_VERSION}; daemon built {daemon_generation} speaks \
                      proto {PROTOCOL_VERSION} — rebuild/reinstall the CLI",
@@ -96,6 +108,43 @@ async fn do_client_hello_with_surface(session: &MessageSession, surface: Option<
         }
         Some(other) => Err(format!("expected Hello reply, got: {other:?}")),
         None => Err("connection closed before Hello reply".into()),
+    }
+}
+
+/// Stop an existing daemon through the same-protocol deployment seam.
+///
+/// Normal client sessions still require an identical wire generation. This
+/// path permits a build mismatch only long enough to send the typed shutdown
+/// request and receive its typed acknowledgement. Protocol mismatches remain
+/// rejected by the Hello handshake.
+pub async fn shutdown_existing(socket_path: &Path) -> Result<(), String> {
+    let session = connect_unix_message_session(socket_path).await?;
+    tokio::time::timeout(
+        HELLO_HANDSHAKE_TIMEOUT,
+        do_client_hello_with_surface(&session, None, WireGenerationPolicy::AllowMismatchForShutdown),
+    )
+    .await
+    .map_err(|_| {
+        format!(
+            "daemon at {} accepted the connection but did not complete the Hello handshake within {}s",
+            socket_path.display(),
+            HELLO_HANDSHAKE_TIMEOUT.as_secs()
+        )
+    })??;
+
+    const REQUEST_ID: u64 = 1;
+    const SHUTDOWN_ACK_TIMEOUT: Duration = Duration::from_secs(30);
+    session.write(Message::Request { id: REQUEST_ID, request: Request::Shutdown }).await?;
+    let response = tokio::time::timeout(SHUTDOWN_ACK_TIMEOUT, session.read())
+        .await
+        .map_err(|_| format!("daemon did not acknowledge shutdown within {}s", SHUTDOWN_ACK_TIMEOUT.as_secs()))??;
+    match response {
+        Some(Message::Response { id: REQUEST_ID, response }) => match into_success_response(*response)? {
+            Response::Shutdown => Ok(()),
+            other => Err(format!("unexpected shutdown response: {other:?}")),
+        },
+        Some(other) => Err(format!("expected shutdown response, got: {other:?}")),
+        None => Err("connection closed before shutdown acknowledgement".into()),
     }
 }
 

--- a/crates/flotilla-client/src/lib.rs
+++ b/crates/flotilla-client/src/lib.rs
@@ -175,18 +175,6 @@ impl SocketDaemon {
         from_session_stateful_bounded(socket_path, session, None).await
     }
 
-    /// Ask the connected daemon to shut down gracefully.
-    ///
-    /// Success means the daemon accepted the request. The server sends this
-    /// acknowledgement before it closes listeners and drains active work.
-    pub async fn shutdown(&self) -> Result<(), String> {
-        let result = send_request(&self.session, &self.pending, &self.next_id, Request::Shutdown).await?;
-        match into_success_response(result)? {
-            Response::Shutdown => Ok(()),
-            other => Err(format!("unexpected shutdown response: {other:?}")),
-        }
-    }
-
     pub async fn connect_with_surface(socket_path: &Path, surface: SurfaceDeclaration) -> Result<Arc<Self>, String> {
         let session = connect_unix_message_session(socket_path).await?;
         from_session_stateful_bounded(socket_path, session, Some(&surface)).await

--- a/crates/flotilla-client/src/lib/tests.rs
+++ b/crates/flotilla-client/src/lib/tests.rs
@@ -1,5 +1,48 @@
 use super::*;
 
+async fn hello_result(protocol_version: u32, daemon_build: &str, policy: WireGenerationPolicy) -> Result<Option<String>, String> {
+    let (client, server) = flotilla_transport::message::message_session_pair();
+    let display_name = flotilla_protocol::hello_display_name("daemon", daemon_build);
+    let server_task = tokio::spawn(async move {
+        assert!(matches!(server.read().await.expect("read client hello"), Some(Message::Hello { .. })));
+        server
+            .write(Message::Hello {
+                protocol_version,
+                node_id: NodeId::new("daemon"),
+                display_name,
+                session_id: uuid::Uuid::nil(),
+                connection_role: Some(ConnectionRole::Client),
+                surface: None,
+            })
+            .await
+            .expect("write daemon hello");
+    });
+    let result = do_client_hello_with_surface(&client, None, policy).await;
+    server_task.await.expect("join hello server");
+    result
+}
+
+#[tokio::test]
+async fn shutdown_hello_allows_only_same_protocol_build_mismatch() {
+    let different_build = "different-build";
+    assert_eq!(
+        hello_result(PROTOCOL_VERSION, different_build, WireGenerationPolicy::AllowMismatchForShutdown)
+            .await
+            .expect("same-protocol shutdown hello"),
+        Some(different_build.to_string())
+    );
+
+    let strict_error = hello_result(PROTOCOL_VERSION, different_build, WireGenerationPolicy::RequireMatch)
+        .await
+        .expect_err("normal session must reject a build mismatch");
+    assert!(strict_error.contains("wire generation mismatch"), "unexpected error: {strict_error}");
+
+    let version_error = hello_result(PROTOCOL_VERSION + 1, different_build, WireGenerationPolicy::AllowMismatchForShutdown)
+        .await
+        .expect_err("shutdown must reject a protocol mismatch");
+    assert!(version_error.contains("protocol version mismatch"), "unexpected error: {version_error}");
+}
+
 #[test]
 fn replay_cursors_preserve_host_and_query_streams() {
     let host = StreamKey::Host { environment_id: flotilla_protocol::EnvironmentId::new("env-1") };

--- a/crates/flotilla-daemon/src/server.rs
+++ b/crates/flotilla-daemon/src/server.rs
@@ -752,8 +752,9 @@ async fn handle_client_session(
                         expected = BUILD_ID,
                         got = client_generation,
                         %node_id,
-                        "rejecting client with wire generation mismatch"
+                        "restricting client with wire generation mismatch to shutdown"
                     );
+                    run_shutdown_only_session(&session, &shutdown_request_tx, &mut shutdown_rx).await;
                     return;
                 }
                 let surface = match surface {
@@ -781,6 +782,36 @@ async fn handle_client_session(
         other => {
             warn!(msg = ?other, "rejecting connection without Hello handshake");
         }
+    }
+}
+
+/// Serve the stable deployment seam available to same-protocol clients from a
+/// different build. No other request crosses the wire-generation gate.
+async fn run_shutdown_only_session(
+    session: &MessageSession,
+    shutdown_request_tx: &mpsc::UnboundedSender<()>,
+    shutdown_rx: &mut watch::Receiver<bool>,
+) {
+    tokio::select! {
+        message = session.read() => {
+            match message {
+                Ok(Some(Message::Request { id, request: flotilla_protocol::Request::Shutdown })) => {
+                    if session.write(Message::ok_response(id, flotilla_protocol::Response::Shutdown)).await.is_ok() {
+                        info!("graceful shutdown requested by same-protocol client from a different build");
+                        let _ = shutdown_request_tx.send(());
+                    }
+                }
+                Ok(Some(Message::Request { id, .. })) => {
+                    let _ = session
+                        .write(Message::error_response(id, "wire generation mismatch: only daemon shutdown is available across builds"))
+                        .await;
+                }
+                Ok(Some(other)) => warn!(msg = ?other, "unexpected message from shutdown-only client"),
+                Ok(None) => {}
+                Err(error) => warn!(%error, "failed to read request from shutdown-only client"),
+            }
+        }
+        _ = shutdown_rx.changed() => {}
     }
 }
 

--- a/crates/flotilla-daemon/src/server/tests.rs
+++ b/crates/flotilla-daemon/src/server/tests.rs
@@ -3590,13 +3590,68 @@ async fn handle_client_rejects_client_hello_with_version_mismatch() {
 }
 
 #[tokio::test]
-async fn handle_client_rejects_client_hello_with_wire_generation_mismatch() {
-    assert_client_hello_rejected(
-        PROTOCOL_VERSION,
-        flotilla_protocol::hello_display_name("client", "stale-client-generation"),
-        "wire generation",
-    )
-    .await;
+async fn wire_generation_mismatched_client_can_request_shutdown() {
+    let (_tmp, client_stream, handle, client_count, mut shutdown_requests) = spawn_test_client_handler().await;
+    let (read_half, write_half) = client_stream.into_split();
+    let mut reader = BufReader::new(read_half).lines();
+    let mut writer = BufWriter::new(write_half);
+
+    let hello = Message::Hello {
+        protocol_version: PROTOCOL_VERSION,
+        node_id: NodeId::new("newer-client"),
+        display_name: flotilla_protocol::hello_display_name("client", "newer-client-generation"),
+        session_id: uuid::Uuid::nil(),
+        connection_role: Some(flotilla_protocol::ConnectionRole::Client),
+        surface: None,
+    };
+    flotilla_protocol::framing::write_message_line(&mut writer, &hello).await.expect("write client hello");
+    let hello = reader.next_line().await.expect("read hello").expect("hello payload");
+    assert!(matches!(serde_json::from_str::<Message>(&hello).expect("parse hello"), Message::Hello { .. }));
+
+    flotilla_protocol::framing::write_message_line(&mut writer, &Message::Request { id: 7, request: Request::Shutdown })
+        .await
+        .expect("write shutdown request");
+    let response = reader.next_line().await.expect("read response").expect("shutdown response payload");
+    assert!(matches!(ok_response(serde_json::from_str(&response).expect("parse shutdown response"), 7), Response::Shutdown));
+    assert_eq!(shutdown_requests.recv().await, Some(()), "server should begin shutdown only after acknowledging the request");
+
+    let eof = reader.next_line().await.expect("read shutdown EOF");
+    assert!(eof.is_none(), "shutdown requester should receive a clean EOF");
+    handle.await.expect("join shutdown connection");
+    assert_eq!(client_count.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn wire_generation_mismatched_client_cannot_request_rich_rpc() {
+    let (_tmp, client_stream, handle, _client_count, mut shutdown_requests) = spawn_test_client_handler().await;
+    let (read_half, write_half) = client_stream.into_split();
+    let mut reader = BufReader::new(read_half).lines();
+    let mut writer = BufWriter::new(write_half);
+
+    let hello = Message::Hello {
+        protocol_version: PROTOCOL_VERSION,
+        node_id: NodeId::new("newer-client"),
+        display_name: flotilla_protocol::hello_display_name("client", "newer-client-generation"),
+        session_id: uuid::Uuid::nil(),
+        connection_role: Some(flotilla_protocol::ConnectionRole::Client),
+        surface: None,
+    };
+    flotilla_protocol::framing::write_message_line(&mut writer, &hello).await.expect("write client hello");
+    let _hello = reader.next_line().await.expect("read hello").expect("hello payload");
+
+    flotilla_protocol::framing::write_message_line(&mut writer, &Message::Request { id: 8, request: Request::ListRepos })
+        .await
+        .expect("write rich request");
+    let response = reader.next_line().await.expect("read response").expect("error response payload");
+    match serde_json::from_str::<Message>(&response).expect("parse response") {
+        Message::Response { id: 8, response } => match *response {
+            ResponseResult::Err { message } => assert!(message.contains("only daemon shutdown"), "unexpected error: {message}"),
+            other => panic!("expected error response, got {other:?}"),
+        },
+        other => panic!("expected response, got {other:?}"),
+    }
+    assert!(shutdown_requests.try_recv().is_err(), "rich request must not initiate shutdown");
+    handle.await.expect("join restricted connection");
 }
 
 #[tokio::test(start_paused = true)]

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,8 +11,13 @@ Older size-rotated generations use numeric suffixes such as
 Stop a running daemon with `flotilla daemon stop`. The command is idempotent
 when no daemon socket exists and asks a live daemon to finish active requests,
 retire peer connections, close its socket, and exit cleanly. Deploy and install
-scripts should use this command before replacing the `flotilla`/`flotillad`
-binary pair; do not use `pkill` for daemon restarts.
+scripts may replace the CLI first, then use this command before replacing the
+daemon: shutdown is the one typed RPC admitted between different builds when
+both speak the same `PROTOCOL_VERSION`, and it waits for acknowledgement before
+reporting success. All other RPCs still require matching build identities. A
+cross-protocol stop is refused with a protocol-version mismatch, so deploys
+that cross a protocol bump must retain the old CLI until its daemon has stopped.
+Do not use `pkill` for daemon restarts.
 
 For example, show warnings from the peer subsystem with:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -906,11 +906,9 @@ async fn run_daemon_stop(cli: &Cli) -> Result<()> {
         println!("Daemon is not running.");
         return Ok(());
     }
-    let daemon = flotilla_tui::socket::SocketDaemon::connect(&socket_path)
+    flotilla_tui::socket::shutdown_existing(&socket_path)
         .await
-        .map_err(|error| color_eyre::eyre::eyre!("cannot connect to daemon at {}: {error}", socket_path.display()))?;
-    daemon.shutdown().await.map_err(|error| color_eyre::eyre::eyre!("could not stop daemon: {error}"))?;
-    drop(daemon);
+        .map_err(|error| color_eyre::eyre::eyre!("could not stop daemon at {}: {error}", socket_path.display()))?;
     tokio::time::timeout(Duration::from_secs(30), async {
         while socket_path.exists() {
             tokio::time::sleep(Duration::from_millis(25)).await;


### PR DESCRIPTION
Closes #1566.

## Summary

- add a shutdown-specific client handshake policy that accepts different build IDs only when the protocol version matches
- restrict same-protocol/different-build server sessions to the typed `Shutdown` RPC and its acknowledgement; rich RPCs retain the build-identity gate
- keep cross-protocol shutdown refused with the existing explicit protocol-version mismatch
- document the verified deployment sequence where the CLI is replaced before stopping the older daemon

The root cause was independent strict build-identity checks on both sides of the normal client handshake. The server closed before reading `Shutdown`, while the client rejected the server Hello before it could send the request.

## Verification

- `cargo +nightly-2026-03-12 fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `TMPDIR="$PWD/.codex-tmp" cargo test --workspace --locked --features flotilla-daemon/skip-no-sandbox-tests`
