### PR TITLE
feat: install promoted fleet generations on macOS

### DIFF
--- a/ci/fleet-candidates/README.md
+++ b/ci/fleet-candidates/README.md
@@ -45,29 +45,60 @@ central-signing linkage.
   "schema_version": 1,
   "kind": "internal-promoted-fleet-generation",
   "generation": "20260815T233635Z-r84-f63871b20ec6f-c4e78c7c83873",
+  "source_generation": "20260815T223755Z-r84-f63871b20ec6f-c4e78c7c83873",
   "sources": {
     "flotilla": "63871b20ec6f5a9e41308b5d56a90a4fefd41f8e",
     "cleat": "4e78c7c83873916dcb2342a51001bdfed3d63eda"
   },
   "peer_protocol_version": 20,
+  "central_signing": {
+    "derivative_package": "lab-signing/flotilla-fleet-darwin-signed",
+    "derivative_version": "20260815T223755Z-r84-f63871b20ec6f-c4e78c7c83873",
+    "attestation": "darwin-signing-attestation.json",
+    "attestation_sha256": "<64 lowercase hexadecimal characters>",
+    "cms": "darwin-signing-attestation.cms",
+    "cms_sha256": "<64 lowercase hexadecimal characters>",
+    "certificate": "darwin-signing-certificate.pem",
+    "certificate_sha256": "dffbf762cdba4dab884d89df2350a50f324daada53d86d55068c311fbbf59c4e",
+    "signing": {
+      "identity": "Apple Development: Robert Wittams (DYYMCPD885)",
+      "team_id": "973L4GV58R",
+      "certificate_sha256": "dffbf762cdba4dab884d89df2350a50f324daada53d86d55068c311fbbf59c4e",
+      "entitlements_sha256": "c706e295c8d105efa39a488b2fb7da1256f5652721633b37da9077c1d9145e32",
+      "options": ["runtime", "timestamp=none"]
+    }
+  },
   "platforms": {
     "linux-x86_64-gnu2.36": {
       "artifact": "fleet-candidate-linux-x86_64-gnu2.36.tar.gz",
-      "sha256": "<64 lowercase hexadecimal characters>",
+      "sha256": "13624dbe98d2bda4032609a649a733e01277081a0ceb6ab175c39e681a88d13d",
       "size_bytes": 53949764,
       "signed": false,
       "state": "installable-internal"
     },
     "darwin-aarch64": {
       "artifact": "fleet-signed-darwin-aarch64.tar.gz",
-      "sha256": "<64 lowercase hexadecimal characters>",
+      "sha256": "1cd34a5c34e3742dc9d3abfe261792dffe2ebc407035e76b6b7fbbd97cf28a39",
       "size_bytes": 45027363,
       "signed": true,
-      "state": "installable-internal"
+      "state": "installable-internal",
+      "source_artifact": "fleet-candidate-darwin-aarch64.tar.gz",
+      "source_artifact_sha256": "<64 lowercase hexadecimal characters>",
+      "signing": {
+        "identity": "Apple Development: Robert Wittams (DYYMCPD885)",
+        "team_id": "973L4GV58R",
+        "certificate_sha256": "dffbf762cdba4dab884d89df2350a50f324daada53d86d55068c311fbbf59c4e",
+        "entitlements_sha256": "c706e295c8d105efa39a488b2fb7da1256f5652721633b37da9077c1d9145e32",
+        "options": ["runtime", "timestamp=none"]
+      }
     }
   }
 }
 ```
+
+Angle-bracketed digests above are abbreviated metavariables. The two
+`signing` objects must be byte-for-byte equal, and their certificate digest
+must also equal `central_signing.certificate_sha256`.
 
 Bootstrap the reviewed command and package-read-only credential on each
 consumer:

--- a/ci/fleet-candidates/README.md
+++ b/ci/fleet-candidates/README.md
@@ -33,29 +33,55 @@ rebuild either project.
 ## Promoted generation consumer contract
 
 `scripts/fleet-install` consumes immutable versions of the Forgejo Generic
-Package `lab/flotilla-fleet`. Each version must contain the unchanged candidate
-archive and a `manifest.json` with this shape:
+Package `lab/flotilla-fleet`. Each completed version contains
+`generation.json`, the unchanged Linux candidate, and, once centrally signed,
+an attested Darwin derivative. The generation document uses the promoter's
+`internal-promoted-fleet-generation` contract and records the exact source
+commits, peer protocol, artifact sizes and SHA-256 values, signing state, and
+central-signing linkage.
 
 ```json
 {
   "schema_version": 1,
-  "kind": "flotilla-fleet-generation",
-  "generation": "20260815T220000Z-f0123456789ab-cabcdef012345",
+  "kind": "internal-promoted-fleet-generation",
+  "generation": "20260815T233635Z-r84-f63871b20ec6f-c4e78c7c83873",
+  "sources": {
+    "flotilla": "63871b20ec6f5a9e41308b5d56a90a4fefd41f8e",
+    "cleat": "4e78c7c83873916dcb2342a51001bdfed3d63eda"
+  },
   "peer_protocol_version": 20,
   "platforms": {
     "linux-x86_64-gnu2.36": {
       "artifact": "fleet-candidate-linux-x86_64-gnu2.36.tar.gz",
-      "sha256": "<64 lowercase hexadecimal characters>"
+      "sha256": "<64 lowercase hexadecimal characters>",
+      "size_bytes": 53949764,
+      "signed": false,
+      "state": "installable-internal"
+    },
+    "darwin-aarch64": {
+      "artifact": "fleet-signed-darwin-aarch64.tar.gz",
+      "sha256": "<64 lowercase hexadecimal characters>",
+      "size_bytes": 45027363,
+      "signed": true,
+      "state": "installable-internal"
     }
   }
 }
 ```
 
-The protocol value must be copied from the candidate manifest produced above;
-the consumer rejects disagreement between the generation and candidate
-manifests. On Linux, bootstrap the reviewed script to
-`~/.local/bin/fleet-install`, store the package-read token at
-`~/.config/flotilla/fleet-reader-token` with mode `0600`, and run one of:
+Bootstrap the reviewed command and package-read-only credential on each
+consumer:
+
+```sh
+install -d "$HOME/.local/bin" "$HOME/.config/flotilla"
+install -m 0755 scripts/fleet-install "$HOME/.local/bin/fleet-install"
+install -m 0600 /path/to/fleet-reader-token \
+  "$HOME/.config/flotilla/fleet-reader-token"
+```
+
+`~/.local/bin` must be the first Flotilla/Cleat location in `PATH`; the
+installer refuses to leave an older binary shadowing its stable launchers.
+Pulls are operator initiated and never move a fleet-wide desired-state pin:
 
 ```sh
 fleet-install status
@@ -64,4 +90,17 @@ fleet-install <generation>
 fleet-install rollback
 ```
 
-Darwin installation remains blocked on flotilla-org/flotilla#1553.
+The consumer verifies the outer size and digest, safely extracts the archive,
+and verifies every inner file against its manifest before atomically selecting
+the read-only generation. Linux requires the exact unsigned candidate selected
+by the trusted promoter. Darwin additionally requires the completed central
+derivative, fixed Apple team `973L4GV58R`, matching source/signing metadata,
+strict Apple signature and designated-requirement verification, the recorded
+authority, and empty entitlements on all three executables and every bundled
+dynamic library. Consumer Macs hold no signing credential.
+
+The first live proof installed generation
+`20260815T233635Z-r84-f63871b20ec6f-c4e78c7c83873` into isolated roots on
+Kiwi and Udder. All three programs reported their versions on both platforms;
+Cleat resolved its bundled Ghostty library through the relative runtime path.
+The proof did not replace either host's active binaries or move `current`.

--- a/scripts/fleet-install
+++ b/scripts/fleet-install
@@ -11,11 +11,13 @@ readonly FLEET_TOKEN_FILE="${FLEET_INSTALL_TOKEN_FILE:-$HOME/.config/flotilla/fl
 readonly RELEASES_DIR="$FLEET_ROOT/releases"
 readonly CURRENT_LINK="$FLEET_ROOT/current"
 readonly PREVIOUS_LINK="$FLEET_ROOT/previous"
-readonly PLATFORM="linux-x86_64-gnu2.36"
+readonly TRUSTED_APPLE_TEAM_ID="973L4GV58R"
+PLATFORM=""
 AUTH_HEADER_FILE=""
 WORK_DIR=""
 READ_ONLY=0
-INSTALL_LOCK_FD=""
+INSTALL_LOCK_DIR=""
+INSTALL_LOCK_HELD=0
 
 die() {
   printf 'fleet-install: %s\n' "$*" >&2
@@ -24,16 +26,21 @@ die() {
 
 cleanup() {
   [[ -z "$WORK_DIR" ]] || rm -rf -- "$WORK_DIR"
+  if ((INSTALL_LOCK_HELD)); then
+    rm -f -- "$INSTALL_LOCK_DIR/pid"
+    rmdir "$INSTALL_LOCK_DIR" 2>/dev/null || true
+  fi
 }
 trap cleanup EXIT
 
-require_linux() {
+host_platform() {
   local system="${FLEET_INSTALL_UNAME_S:-$(uname -s)}"
   local machine="${FLEET_INSTALL_UNAME_M:-$(uname -m)}"
-  if [[ "$system" == Darwin ]]; then
-    die 'Darwin installation is not yet supported; follow #1553: https://github.com/flotilla-org/flotilla/issues/1553'
-  fi
-  [[ "$system-$machine" == Linux-x86_64 ]] || die "unsupported platform: $system-$machine (requires $PLATFORM)"
+  case "$system-$machine" in
+    Linux-x86_64) printf 'linux-x86_64-gnu2.36\n' ;;
+    Darwin-arm64) printf 'darwin-aarch64\n' ;;
+    *) die "unsupported platform: $system-$machine" ;;
+  esac
 }
 
 require_generation() {
@@ -53,21 +60,32 @@ make_work_dir() {
 
 acquire_install_lock() {
   mkdir -p "$FLEET_ROOT"
-  exec {INSTALL_LOCK_FD}>"$FLEET_ROOT/.install.lock"
-  flock -n "$INSTALL_LOCK_FD" || die 'another fleet-install mutation is already running'
+  INSTALL_LOCK_DIR="$FLEET_ROOT/.install.lock"
+  mkdir "$INSTALL_LOCK_DIR" 2>/dev/null \
+    || die "another fleet-install mutation is already running, or a stale lock remains: $INSTALL_LOCK_DIR"
+  INSTALL_LOCK_HELD=1
+  printf '%s\n' "$$" >"$INSTALL_LOCK_DIR/pid"
 }
 
 prepare_auth() {
   [[ -n "$AUTH_HEADER_FILE" ]] && return
   [[ -f "$FLEET_TOKEN_FILE" && ! -L "$FLEET_TOKEN_FILE" ]] || die "package token is missing: $FLEET_TOKEN_FILE"
   local mode
-  mode="$(stat -c '%a' "$FLEET_TOKEN_FILE")"
+  mode="$(python3 - "$FLEET_TOKEN_FILE" <<'PY'
+import os
+import stat
+import sys
+
+print(format(stat.S_IMODE(os.stat(sys.argv[1]).st_mode), "o"))
+PY
+)"
   [[ "$mode" == 600 ]] || die "package token must have mode 0600: $FLEET_TOKEN_FILE (has $mode)"
   make_work_dir
   AUTH_HEADER_FILE="$WORK_DIR/authorization.header"
   local token
-  token="$(tr -d '\r\n' <"$FLEET_TOKEN_FILE")"
-  [[ -n "$token" ]] || die "package token is empty: $FLEET_TOKEN_FILE"
+  token="$(<"$FLEET_TOKEN_FILE")"
+  [[ -n "$token" && ! "$token" =~ [[:space:]] ]] \
+    || die "package token is empty or malformed: $FLEET_TOKEN_FILE"
   (umask 077 && printf 'Authorization: token %s\n' "$token" >"$AUTH_HEADER_FILE")
 }
 
@@ -75,7 +93,7 @@ download() {
   local url="$1"
   local destination="$2"
   prepare_auth
-  curl --fail --silent --show-error --location --header "@$AUTH_HEADER_FILE" --output "$destination" "$url"
+  curl --fail --silent --show-error --header "@$AUTH_HEADER_FILE" --output "$destination" "$url"
 }
 
 latest_generation() {
@@ -86,65 +104,142 @@ latest_generation() {
   while true; do
     local response="$WORK_DIR/packages-$page.json"
     download "$FLEET_API_URL/packages/$FLEET_OWNER?type=generic&q=$FLEET_PACKAGE&limit=100&page=$page" "$response"
-    python3 - "$response" "$FLEET_PACKAGE" >>"$all" <<'PY'
+    local count
+    count="$(python3 - "$response" "$FLEET_PACKAGE" "$all" <<'PY'
 import json
 import sys
 
 packages = json.load(open(sys.argv[1]))
 if not isinstance(packages, list):
     raise SystemExit("package listing is not an array")
-for package in packages:
-    if package.get("type") == "generic" and package.get("name") == sys.argv[2]:
-        print(json.dumps([package.get("created_at", ""), package.get("version", "")]))
-print(f"__COUNT__={len(packages)}")
+with open(sys.argv[3], "a") as output:
+    for package in packages:
+        if package.get("type") == "generic" and package.get("name") == sys.argv[2]:
+            print(json.dumps([package.get("created_at", ""), package.get("version", "")]), file=output)
+print(len(packages))
 PY
-    local count
-    count="$(tail -n 1 "$all" | sed -n 's/^__COUNT__=//p')"
-    sed -i '$d' "$all"
+)"
     [[ "$count" =~ ^[0-9]+$ ]] || die 'invalid package listing response'
     (( count == 100 )) || break
     ((page += 1))
   done
-  python3 - "$all" <<'PY'
+  local candidate index=0
+  while IFS= read -r candidate; do
+    index=$((index + 1))
+    if fetch_generation_manifest "$candidate" "$WORK_DIR/latest-$index-generation.json" >/dev/null 2>&1; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done < <(python3 - "$all" <<'PY'
 import json
 import sys
 
 rows = [json.loads(line) for line in open(sys.argv[1]) if line.strip()]
 rows = [row for row in rows if row[0] and row[1]]
-if not rows:
-    raise SystemExit("no promoted flotilla-fleet generations found")
-print(max(rows)[1])
+for row in sorted(rows, reverse=True):
+    print(row[1])
 PY
+)
+  die "Forgejo has no completed $PLATFORM flotilla-fleet generations"
 }
 
 fetch_generation_manifest() {
   local generation="$1"
   local destination="$2"
   require_generation "$generation"
-  download "$FLEET_PACKAGE_URL/$FLEET_OWNER/generic/$FLEET_PACKAGE/$generation/manifest.json" "$destination"
-  python3 - "$destination" "$generation" <<'PY'
+  download "$FLEET_PACKAGE_URL/$FLEET_OWNER/generic/$FLEET_PACKAGE/$generation/generation.json" "$destination"
+  python3 - "$destination" "$generation" "$PLATFORM" "$TRUSTED_APPLE_TEAM_ID" <<'PY'
 import json
 import re
 import sys
 
 manifest = json.load(open(sys.argv[1]))
 generation = sys.argv[2]
-if manifest.get("schema_version") != 1 or manifest.get("kind") != "flotilla-fleet-generation":
+platform = sys.argv[3]
+trusted_team = sys.argv[4]
+identity = re.fullmatch(r"\d{8}T\d{6}Z-r\d+-f([0-9a-f]{12})-c([0-9a-f]{12})", generation)
+if identity is None:
+    raise SystemExit("invalid generation id")
+if manifest.get("schema_version") != 1 or manifest.get("kind") != "internal-promoted-fleet-generation":
     raise SystemExit("unsupported generation manifest")
 if manifest.get("generation") != generation:
     raise SystemExit("generation manifest identity mismatch")
+sources = manifest.get("sources")
+if (
+    not isinstance(sources, dict)
+    or set(sources) != {"flotilla", "cleat"}
+    or not all(isinstance(value, str) and re.fullmatch(r"[0-9a-f]{40}", value) for value in sources.values())
+    or sources["flotilla"][:12] != identity.group(1)
+    or sources["cleat"][:12] != identity.group(2)
+):
+    raise SystemExit("generation manifest has invalid source commits")
 version = manifest.get("peer_protocol_version")
 if not isinstance(version, int) or isinstance(version, bool) or version < 1:
     raise SystemExit("generation manifest has invalid peer_protocol_version")
-entry = manifest.get("platforms", {}).get("linux-x86_64-gnu2.36")
+entry = manifest.get("platforms", {}).get(platform)
 if not isinstance(entry, dict):
-    raise SystemExit("generation has no linux-x86_64-gnu2.36 artifact")
+    raise SystemExit(f"generation has no {platform} artifact")
+if entry.get("state") != "installable-internal":
+    raise SystemExit(f"generation artifact for {platform} is not installable-internal")
 artifact = entry.get("artifact")
 digest = entry.get("sha256")
-if not isinstance(artifact, str) or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", artifact):
+size = entry.get("size_bytes")
+expected_artifact = (
+    "fleet-signed-darwin-aarch64.tar.gz"
+    if platform == "darwin-aarch64"
+    else "fleet-candidate-linux-x86_64-gnu2.36.tar.gz"
+)
+if artifact != expected_artifact:
     raise SystemExit("generation manifest has invalid artifact name")
 if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
     raise SystemExit("generation manifest has invalid artifact digest")
+if not isinstance(size, int) or isinstance(size, bool) or size < 1:
+    raise SystemExit("generation manifest has invalid artifact size")
+if platform == "linux-x86_64-gnu2.36":
+    if entry.get("signed") is not False:
+        raise SystemExit("Linux generation has an unexpected signing state")
+else:
+    if entry.get("signed") is not True:
+        raise SystemExit("Darwin generation is not centrally signed")
+    source_generation = manifest.get("source_generation")
+    source_identity = re.fullmatch(
+        r"\d{8}T\d{6}Z-r\d+-f([0-9a-f]{12})-c([0-9a-f]{12})", source_generation or ""
+    )
+    if source_identity is None:
+        raise SystemExit("Darwin generation has an invalid source generation")
+    if sources["flotilla"][:12] != source_identity.group(1) or sources["cleat"][:12] != source_identity.group(2):
+        raise SystemExit("Darwin source generation does not match the recorded source commits")
+    if entry.get("source_artifact") != "fleet-candidate-darwin-aarch64.tar.gz":
+        raise SystemExit("Darwin generation has an invalid source artifact")
+    if not re.fullmatch(r"[0-9a-f]{64}", entry.get("source_artifact_sha256", "")):
+        raise SystemExit("Darwin generation has an invalid source artifact digest")
+    central = manifest.get("central_signing")
+    if not isinstance(central, dict):
+        raise SystemExit("Darwin generation has no central-signing record")
+    expected = {
+        "derivative_package": "lab-signing/flotilla-fleet-darwin-signed",
+        "derivative_version": source_generation,
+        "attestation": "darwin-signing-attestation.json",
+        "cms": "darwin-signing-attestation.cms",
+        "certificate": "darwin-signing-certificate.pem",
+    }
+    if any(central.get(field) != value for field, value in expected.items()):
+        raise SystemExit("Darwin generation has invalid central-signing linkage")
+    for field in ("attestation_sha256", "cms_sha256", "certificate_sha256"):
+        if not re.fullmatch(r"[0-9a-f]{64}", central.get(field, "")):
+            raise SystemExit(f"Darwin generation has invalid {field}")
+    signing = central.get("signing")
+    if not isinstance(signing, dict) or signing.get("team_id") != trusted_team:
+        raise SystemExit(f"Darwin generation is not signed by trusted Apple team {trusted_team}")
+    if not isinstance(signing.get("identity"), str) or not signing["identity"]:
+        raise SystemExit("Darwin generation has invalid signing identity")
+    if signing.get("options") != ["runtime", "timestamp=none"]:
+        raise SystemExit("Darwin generation has invalid signing options")
+    for field in ("certificate_sha256", "entitlements_sha256"):
+        if not re.fullmatch(r"[0-9a-f]{64}", signing.get(field, "")):
+            raise SystemExit(f"Darwin generation has invalid signing {field}")
+    if central["certificate_sha256"] != signing["certificate_sha256"] or entry.get("signing") != signing:
+        raise SystemExit("Darwin generation has inconsistent signing metadata")
 PY
 }
 
@@ -174,123 +269,211 @@ PY
 }
 
 sha256_file() {
-  sha256sum "$1" | awk '{print $1}'
+  python3 - "$1" <<'PY'
+import hashlib
+import sys
+
+digest = hashlib.sha256()
+with open(sys.argv[1], "rb") as source:
+    for block in iter(lambda: source.read(1024 * 1024), b""):
+        digest.update(block)
+print(digest.hexdigest())
+PY
+}
+
+file_size() {
+  python3 - "$1" <<'PY'
+import os
+import sys
+
+print(os.path.getsize(sys.argv[1]))
+PY
 }
 
 extract_and_verify() {
   local archive="$1"
   local destination="$2"
   local generation_manifest="$3"
-  python3 - "$archive" "$destination" "$generation_manifest" <<'PY'
-import hashlib
-import json
-import os
+  python3 - "$archive" "$destination" "$PLATFORM" <<'PY'
 import shutil
 import sys
 import tarfile
 from pathlib import Path, PurePosixPath
 
-archive, destination, outer_path = map(Path, sys.argv[1:])
-outer = json.loads(outer_path.read_text())
+archive = Path(sys.argv[1])
+destination = Path(sys.argv[2])
+platform = sys.argv[3]
+expected_root = "fleet-signed-darwin-aarch64" if platform == "darwin-aarch64" else f"fleet-candidate-{platform}"
 with tarfile.open(archive, "r:gz") as bundle:
     members = bundle.getmembers()
+    names = set()
     roots = set()
     for member in members:
         path = PurePosixPath(member.name)
-        if path.is_absolute() or ".." in path.parts or not path.parts:
-            raise SystemExit(f"unsafe archive path: {member.name}")
+        normalized = str(path)
+        if path.is_absolute() or ".." in path.parts or not path.parts or normalized in names:
+            raise SystemExit(f"unsafe or duplicate archive path: {member.name}")
         if not (member.isfile() or member.isdir()):
             raise SystemExit(f"unsupported archive entry: {member.name}")
+        names.add(normalized)
         roots.add(path.parts[0])
-    if len(roots) != 1:
-        raise SystemExit("archive must contain exactly one bundle directory")
-    bundle.extractall(destination)
-
-root = destination / roots.pop()
-manifest_path = root / "manifest.json"
-manifest = json.loads(manifest_path.read_text())
-if (
-    manifest.get("schema_version") != 1
-    or manifest.get("kind") != "unsigned-fleet-candidate"
-    or manifest.get("platform") != "linux-x86_64-gnu2.36"
-):
-    raise SystemExit("candidate manifest platform or schema mismatch")
-if manifest.get("peer_protocol_version") != outer.get("peer_protocol_version"):
-    raise SystemExit("candidate and generation peer protocol versions differ")
-entries = manifest.get("files")
-if not isinstance(entries, list) or not entries:
-    raise SystemExit("candidate manifest has no files")
-expected = set()
-for entry in entries:
-    rel = entry.get("path")
-    if not isinstance(rel, str) or PurePosixPath(rel).is_absolute() or ".." in PurePosixPath(rel).parts:
-        raise SystemExit("candidate manifest contains an unsafe path")
-    path = root / rel
-    expected.add(rel)
-    if not path.is_file():
-        raise SystemExit(f"candidate file is missing: {rel}")
-    if path.stat().st_size != entry.get("size_bytes"):
-        raise SystemExit(f"candidate size mismatch: {rel}")
-    if hashlib.sha256(path.read_bytes()).hexdigest() != entry.get("sha256"):
-        raise SystemExit(f"candidate checksum mismatch: {rel}")
-actual = {
-    str(path.relative_to(root))
-    for path in root.rglob("*")
-    if path.is_file() and path != manifest_path
-}
-if actual != expected:
-    raise SystemExit("candidate files do not match the manifest")
-for name in ("flotilla", "flotillad", "cleat"):
-    if f"bin/{name}" not in expected:
-        raise SystemExit(f"candidate is missing required binary: {name}")
-shutil.move(str(root), str(destination / "release"))
+    if roots != {expected_root}:
+        raise SystemExit(f"archive has an unexpected bundle directory: expected {expected_root}, got {sorted(roots)}")
+    for member in members:
+        target = destination.joinpath(*PurePosixPath(member.name).parts)
+        if member.isdir():
+            target.mkdir(parents=True, exist_ok=True)
+            target.chmod(member.mode & 0o777)
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        source = bundle.extractfile(member)
+        if source is None:
+            raise SystemExit(f"archive entry cannot be read: {member.name}")
+        with source, target.open("wb") as output:
+            shutil.copyfileobj(source, output)
+        target.chmod(member.mode & 0o777)
+shutil.move(str(destination / expected_root), str(destination / "release"))
 PY
+  verify_release "$destination/release" "$generation_manifest"
+  cp "$generation_manifest" "$destination/release/.generation.json"
 }
 
-verify_installed_release() {
+verify_release() {
   local release="$1"
   local generation_manifest="$2"
-  python3 - "$release" "$generation_manifest" <<'PY'
+  python3 - "$release" "$generation_manifest" "$PLATFORM" <<'PY'
 import hashlib
 import json
+import os
+import re
 import sys
 from pathlib import Path, PurePosixPath
 
-root, outer_path = map(Path, sys.argv[1:])
+root = Path(sys.argv[1])
+outer_path = Path(sys.argv[2])
+platform = sys.argv[3]
 manifest_path = root / "manifest.json"
 manifest = json.loads(manifest_path.read_text())
 outer = json.loads(outer_path.read_text())
-if (
-    manifest.get("schema_version") != 1
-    or manifest.get("kind") != "unsigned-fleet-candidate"
-    or manifest.get("platform") != "linux-x86_64-gnu2.36"
-):
-    raise SystemExit("installed candidate manifest platform or schema mismatch")
-if manifest.get("peer_protocol_version") != outer.get("peer_protocol_version"):
-    raise SystemExit("installed candidate and generation peer protocol versions differ")
+expected_kind = "signed-fleet-derivative" if platform == "darwin-aarch64" else "unsigned-fleet-candidate"
+if manifest.get("schema_version") != 1 or manifest.get("kind") != expected_kind or manifest.get("platform") != platform:
+    raise SystemExit("release manifest platform or schema mismatch")
+if manifest.get("peer_protocol_version") != outer.get("peer_protocol_version") or manifest.get("sources") != outer.get("sources"):
+    raise SystemExit("release and generation metadata differ")
+if platform == "darwin-aarch64":
+    entry = outer["platforms"][platform]
+    if (
+        manifest.get("signed") is not True
+        or manifest.get("source_generation") != outer.get("source_generation")
+        or manifest.get("source_artifact_sha256") != entry.get("source_artifact_sha256")
+        or manifest.get("signing") != outer.get("central_signing", {}).get("signing")
+    ):
+        raise SystemExit("signed Darwin derivative does not match its completed generation")
+elif manifest.get("signed") is not False:
+    raise SystemExit("Linux candidate has an unexpected signing state")
 entries = manifest.get("files")
 if not isinstance(entries, list) or not entries:
-    raise SystemExit("installed candidate manifest has no files")
+    raise SystemExit("release manifest has no files")
 expected = set()
 for entry in entries:
     rel = entry.get("path")
-    if not isinstance(rel, str) or PurePosixPath(rel).is_absolute() or ".." in PurePosixPath(rel).parts:
-        raise SystemExit("installed candidate manifest contains an unsafe path")
+    relative = PurePosixPath(rel) if isinstance(rel, str) else None
+    if relative is None or relative.is_absolute() or ".." in relative.parts or not relative.parts or rel in expected:
+        raise SystemExit("release manifest contains an unsafe or duplicate path")
+    digest = entry.get("sha256")
+    size = entry.get("size_bytes")
+    if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise SystemExit(f"release manifest has an invalid digest: {rel}")
+    if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+        raise SystemExit(f"release manifest has an invalid size: {rel}")
     path = root / rel
     expected.add(rel)
-    if not path.is_file() or path.stat().st_size != entry.get("size_bytes"):
-        raise SystemExit(f"installed candidate file mismatch: {rel}")
-    if hashlib.sha256(path.read_bytes()).hexdigest() != entry.get("sha256"):
-        raise SystemExit(f"installed candidate checksum mismatch: {rel}")
-actual = {str(path.relative_to(root)) for path in root.rglob("*") if path.is_file() and path != manifest_path}
+    if not path.is_file() or path.stat().st_size != size:
+        raise SystemExit(f"release file mismatch: {rel}")
+    if hashlib.sha256(path.read_bytes()).hexdigest() != digest:
+        raise SystemExit(f"release checksum mismatch: {rel}")
+actual = {
+    str(path.relative_to(root))
+    for path in root.rglob("*")
+    if path.is_file() and path not in {manifest_path, root / ".generation.json"}
+}
 if actual != expected:
-    raise SystemExit("installed candidate files do not match the manifest")
+    raise SystemExit("release files do not match the manifest")
+required = {"bin/flotilla", "bin/flotillad", "bin/cleat", "install.sh"}
+if not required.issubset(expected):
+    raise SystemExit("release is missing a required payload")
+for rel in ("bin/flotilla", "bin/flotillad", "bin/cleat"):
+    if not os.access(root / rel, os.X_OK):
+        raise SystemExit(f"release binary is not executable: {rel}")
+if platform == "darwin-aarch64":
+    allowed = required | {rel for rel in expected if rel.startswith("lib/") and rel.endswith(".dylib")}
+    if expected != allowed:
+        raise SystemExit("signed Darwin derivative contains an unexpected payload set")
 PY
+  if [[ "$PLATFORM" == darwin-aarch64 ]]; then
+    verify_darwin_signatures "$release" "$generation_manifest"
+  fi
+}
+
+verify_installed_release() {
+  verify_release "$1" "$2"
+}
+
+codesign_program() {
+  if [[ "${FLEET_INSTALL_TESTING:-0}" == 1 && -n "${FLEET_INSTALL_TEST_CODESIGN:-}" ]]; then
+    printf '%s\n' "$FLEET_INSTALL_TEST_CODESIGN"
+  else
+    printf '/usr/bin/codesign\n'
+  fi
+}
+
+verify_darwin_signatures() {
+  local release="$1"
+  local generation_manifest="$2"
+  local identity requirement codesign
+  identity="$(manifest_value "$generation_manifest" central_signing.signing.identity)"
+  requirement="=designated => anchor apple generic and certificate leaf[subject.OU] = \"$TRUSTED_APPLE_TEAM_ID\""
+  codesign="$(codesign_program)"
+  local targets=("$release"/lib/*.dylib "$release"/bin/flotilla "$release"/bin/flotillad "$release"/bin/cleat)
+  local path relative verification details entitlements
+  for path in "${targets[@]}"; do
+    [[ -f "$path" ]] || continue
+    relative="${path#"$release"/}"
+    verification="$WORK_DIR/codesign-verify-${relative//\//-}"
+    "$codesign" --verify --strict --verbose=2 --requirements "$requirement" "$path" \
+      >"$verification" 2>&1 \
+      || die "strict signature verification failed: $relative"
+    details="$WORK_DIR/codesign-details-${relative//\//-}"
+    "$codesign" -d --verbose=4 "$path" >"$details" 2>&1 \
+      || die "signature inspection failed: $relative"
+    grep -Fxq "Authority=$identity" "$details" \
+      || die "signed Darwin payload has an unexpected authority: $relative"
+    grep -Fxq "TeamIdentifier=$TRUSTED_APPLE_TEAM_ID" "$details" \
+      || die "signed Darwin payload has an unexpected team: $relative"
+    entitlements="$WORK_DIR/codesign-entitlements-${relative//\//-}.plist"
+    "$codesign" --display --entitlements - --xml "$path" >"$entitlements" 2>/dev/null \
+      || die "entitlements inspection failed: $relative"
+    python3 - "$entitlements" "$relative" <<'PY'
+import plistlib
+import sys
+
+content = open(sys.argv[1], "rb").read()
+try:
+    entitlements = plistlib.loads(content) if content.strip() else {}
+except plistlib.InvalidFileException as error:
+    raise SystemExit(f"signed Darwin payload has unreadable entitlements: {sys.argv[2]}: {error}")
+if entitlements != {}:
+    raise SystemExit(f"signed Darwin payload has unexpected entitlements: {sys.argv[2]}")
+PY
+  done
 }
 
 current_generation() {
   [[ -L "$CURRENT_LINK" ]] || return 0
-  basename "$(readlink -f "$CURRENT_LINK")"
+  local target
+  target="$(readlink "$CURRENT_LINK")"
+  [[ "$target" =~ ^releases/[^/]+$ ]] || die "current has an unsafe target: $target"
+  printf '%s\n' "${target#releases/}"
 }
 
 protocol_version() {
@@ -324,10 +507,23 @@ ensure_launchers_and_path() {
   local name resolved expected
   for name in flotilla flotillad cleat; do
     write_launcher "$name"
-    expected="$(readlink -f "$FLEET_BIN_DIR")/$name"
+    expected="$(python3 - "$FLEET_BIN_DIR/$name" <<'PY'
+import os
+import sys
+
+print(os.path.realpath(sys.argv[1]))
+PY
+)"
     resolved="$(command -v "$name" || true)"
     [[ -n "$resolved" ]] || die "$name is not reachable through PATH; add $FLEET_BIN_DIR before installing"
-    [[ "$(readlink -f "$resolved")" == "$expected" ]] || die "PATH shadows the fleet launcher for $name: $resolved; put $FLEET_BIN_DIR first"
+    resolved="$(python3 - "$resolved" <<'PY'
+import os
+import sys
+
+print(os.path.realpath(sys.argv[1]))
+PY
+)"
+    [[ "$resolved" == "$expected" ]] || die "PATH shadows the fleet launcher for $name: $resolved; put $FLEET_BIN_DIR first"
   done
 }
 
@@ -348,14 +544,21 @@ daemon_preflight() {
 atomic_link() {
   local target="$1"
   local link="$2"
-  local temporary="$FLEET_ROOT/.$(basename "$link").new.$$"
+  local temporary
+  temporary="$FLEET_ROOT/.$(basename "$link").new.$$"
   ln -s "$target" "$temporary"
-  mv -Tf "$temporary" "$link"
+  python3 - "$temporary" "$link" <<'PY'
+import os
+import sys
+
+os.replace(sys.argv[1], sys.argv[2])
+PY
 }
 
 switch_to() {
   local generation="$1"
-  local old="$(current_generation)"
+  local old
+  old="$(current_generation)"
   [[ "$old" != "$generation" ]] || return 0
   daemon_preflight
   if [[ -n "$old" ]]; then
@@ -369,11 +572,12 @@ install_generation() {
   require_generation "$generation"
   acquire_install_lock
   mkdir -p "$RELEASES_DIR"
-  local old="$(current_generation)"
+  local old
+  old="$(current_generation)"
   printf 'fleet-install: %s -> %s\n' "${old:-<none>}" "$generation"
   if [[ -d "$RELEASES_DIR/$generation" ]]; then
     make_work_dir
-    local installed_outer="$WORK_DIR/installed-manifest.json"
+    local installed_outer="$WORK_DIR/installed-generation.json"
     fetch_generation_manifest "$generation" "$installed_outer"
     verify_installed_release "$RELEASES_DIR/$generation" "$installed_outer"
     ensure_launchers_and_path
@@ -382,19 +586,23 @@ install_generation() {
     return
   fi
   make_work_dir
-  local outer="$WORK_DIR/manifest.json"
+  local outer="$WORK_DIR/generation.json"
   local archive="$WORK_DIR/artifact.tar.gz"
   local unpack="$WORK_DIR/unpack"
   fetch_generation_manifest "$generation" "$outer"
-  local artifact expected actual
+  local artifact expected expected_size actual actual_size
   artifact="$(platform_value "$outer" artifact)"
   expected="$(platform_value "$outer" sha256)"
+  expected_size="$(platform_value "$outer" size_bytes)"
   download "$FLEET_PACKAGE_URL/$FLEET_OWNER/generic/$FLEET_PACKAGE/$generation/$artifact" "$archive"
   actual="$(sha256_file "$archive")"
+  actual_size="$(file_size "$archive")"
+  [[ "$actual_size" == "$expected_size" ]] \
+    || die "archive size mismatch for $generation: expected $expected_size, got $actual_size"
   [[ "$actual" == "$expected" ]] || die "archive digest mismatch for $generation: expected $expected, got $actual"
   mkdir -p "$unpack"
   extract_and_verify "$archive" "$unpack" "$outer"
-  mv -T "$unpack/release" "$RELEASES_DIR/$generation"
+  mv "$unpack/release" "$RELEASES_DIR/$generation"
   chmod -R a-w "$RELEASES_DIR/$generation"
   ensure_launchers_and_path
   switch_to "$generation"
@@ -423,8 +631,15 @@ rollback() {
   [[ -L "$PREVIOUS_LINK" ]] || die 'no previous generation to roll back to'
   local current previous
   current="$(current_generation)"
-  previous="$(basename "$(readlink -f "$PREVIOUS_LINK")")"
+  local previous_target
+  previous_target="$(readlink "$PREVIOUS_LINK")"
+  [[ "$previous_target" =~ ^releases/[^/]+$ ]] || die "previous has an unsafe target: $previous_target"
+  previous="${previous_target#releases/}"
   [[ -d "$RELEASES_DIR/$previous" ]] || die "previous generation is missing: $previous"
+  [[ -f "$RELEASES_DIR/$previous/.generation.json" ]] \
+    || die "previous generation has no verified generation metadata: $previous"
+  make_work_dir
+  verify_installed_release "$RELEASES_DIR/$previous" "$RELEASES_DIR/$previous/.generation.json"
   printf 'fleet-install: %s -> %s (rollback)\n' "$current" "$previous"
   daemon_preflight
   atomic_link "releases/$previous" "$CURRENT_LINK"
@@ -438,7 +653,7 @@ usage() {
 
 main() {
   [[ $# -eq 1 ]] || usage
-  require_linux
+  PLATFORM="$(host_platform)"
   case "$1" in
     status)
       READ_ONLY=1

--- a/scripts/fleet-install
+++ b/scripts/fleet-install
@@ -16,8 +16,10 @@ PLATFORM=""
 AUTH_HEADER_FILE=""
 WORK_DIR=""
 READ_ONLY=0
-INSTALL_LOCK_DIR=""
+INSTALL_LOCK_PATH=""
+INSTALL_LOCK_OWNER=""
 INSTALL_LOCK_HELD=0
+readonly GENERATION_INCOMPLETE_EXIT=20
 
 die() {
   printf 'fleet-install: %s\n' "$*" >&2
@@ -27,8 +29,17 @@ die() {
 cleanup() {
   [[ -z "$WORK_DIR" ]] || rm -rf -- "$WORK_DIR"
   if ((INSTALL_LOCK_HELD)); then
-    rm -f -- "$INSTALL_LOCK_DIR/pid"
-    rmdir "$INSTALL_LOCK_DIR" 2>/dev/null || true
+    python3 - "$INSTALL_LOCK_PATH" "$INSTALL_LOCK_OWNER" <<'PY'
+import os
+import sys
+
+path, owner = sys.argv[1:]
+try:
+    if os.path.islink(path) and os.readlink(path) == owner:
+        os.unlink(path)
+except FileNotFoundError:
+    pass
+PY
   fi
 }
 trap cleanup EXIT
@@ -60,11 +71,38 @@ make_work_dir() {
 
 acquire_install_lock() {
   mkdir -p "$FLEET_ROOT"
-  INSTALL_LOCK_DIR="$FLEET_ROOT/.install.lock"
-  mkdir "$INSTALL_LOCK_DIR" 2>/dev/null \
-    || die "another fleet-install mutation is already running, or a stale lock remains: $INSTALL_LOCK_DIR"
+  INSTALL_LOCK_PATH="$FLEET_ROOT/.install.lock"
+  INSTALL_LOCK_OWNER="$$-$(python3 - <<'PY'
+import secrets
+
+print(secrets.token_hex(8))
+PY
+)"
+  if ! ln -s "$INSTALL_LOCK_OWNER" "$INSTALL_LOCK_PATH" 2>/dev/null; then
+    local owner pid
+    owner="$(readlink "$INSTALL_LOCK_PATH" 2>/dev/null)" \
+      || die "fleet-install lock is malformed; inspect and remove it if safe: $INSTALL_LOCK_PATH"
+    pid="${owner%%-*}"
+    [[ "$pid" =~ ^[0-9]+$ ]] \
+      || die "fleet-install lock has an invalid owner; inspect and remove it if safe: $INSTALL_LOCK_PATH"
+    if kill -0 "$pid" 2>/dev/null; then
+      die "another fleet-install mutation is already running (pid $pid)"
+    fi
+    python3 - "$INSTALL_LOCK_PATH" "$owner" <<'PY'
+import os
+import sys
+
+path, stale_owner = sys.argv[1:]
+try:
+    if os.path.islink(path) and os.readlink(path) == stale_owner:
+        os.unlink(path)
+except FileNotFoundError:
+    pass
+PY
+    ln -s "$INSTALL_LOCK_OWNER" "$INSTALL_LOCK_PATH" 2>/dev/null \
+      || die "another fleet-install mutation acquired the lock while reclaiming a stale owner"
+  fi
   INSTALL_LOCK_HELD=1
-  printf '%s\n' "$$" >"$INSTALL_LOCK_DIR/pid"
 }
 
 prepare_auth() {
@@ -93,7 +131,28 @@ download() {
   local url="$1"
   local destination="$2"
   prepare_auth
+  # Never forward the package credential through an HTTP redirect.
   curl --fail --silent --show-error --header "@$AUTH_HEADER_FILE" --output "$destination" "$url"
+}
+
+download_generation_manifest() {
+  local url="$1"
+  local destination="$2"
+  prepare_auth
+  local http_status rc
+  if http_status="$(
+    curl --silent --show-error --header "@$AUTH_HEADER_FILE" --output "$destination" \
+      --write-out '%{http_code}' "$url"
+  )"; then
+    case "$http_status" in
+      200) return 0 ;;
+      404) return "$GENERATION_INCOMPLETE_EXIT" ;;
+      *) die "generation manifest request returned HTTP $http_status" ;;
+    esac
+  else
+    rc=$?
+  fi
+  return "$rc"
 }
 
 latest_generation() {
@@ -126,10 +185,18 @@ PY
   local candidate index=0
   while IFS= read -r candidate; do
     index=$((index + 1))
-    if fetch_generation_manifest "$candidate" "$WORK_DIR/latest-$index-generation.json" >/dev/null 2>&1; then
+    local result
+    if fetch_generation_manifest "$candidate" "$WORK_DIR/latest-$index-generation.json"; then
       printf '%s\n' "$candidate"
       return 0
+    else
+      result=$?
     fi
+    if ((result == GENERATION_INCOMPLETE_EXIT)); then
+      printf 'fleet-install: skipping incomplete %s generation %s\n' "$PLATFORM" "$candidate" >&2
+      continue
+    fi
+    die "could not verify advertised generation $candidate"
   done < <(python3 - "$all" <<'PY'
 import json
 import sys
@@ -147,7 +214,13 @@ fetch_generation_manifest() {
   local generation="$1"
   local destination="$2"
   require_generation "$generation"
-  download "$FLEET_PACKAGE_URL/$FLEET_OWNER/generic/$FLEET_PACKAGE/$generation/generation.json" "$destination"
+  local result
+  download_generation_manifest \
+    "$FLEET_PACKAGE_URL/$FLEET_OWNER/generic/$FLEET_PACKAGE/$generation/generation.json" "$destination" \
+    || {
+      result=$?
+      return "$result"
+    }
   python3 - "$destination" "$generation" "$PLATFORM" "$TRUSTED_APPLE_TEAM_ID" <<'PY'
 import json
 import re
@@ -178,9 +251,11 @@ if not isinstance(version, int) or isinstance(version, bool) or version < 1:
     raise SystemExit("generation manifest has invalid peer_protocol_version")
 entry = manifest.get("platforms", {}).get(platform)
 if not isinstance(entry, dict):
-    raise SystemExit(f"generation has no {platform} artifact")
+    print(f"generation has no {platform} artifact", file=sys.stderr)
+    raise SystemExit(20)
 if entry.get("state") != "installable-internal":
-    raise SystemExit(f"generation artifact for {platform} is not installable-internal")
+    print(f"generation artifact for {platform} is not installable-internal", file=sys.stderr)
+    raise SystemExit(20)
 artifact = entry.get("artifact")
 digest = entry.get("sha256")
 size = entry.get("size_bytes")
@@ -241,6 +316,21 @@ else:
     if central["certificate_sha256"] != signing["certificate_sha256"] or entry.get("signing") != signing:
         raise SystemExit("Darwin generation has inconsistent signing metadata")
 PY
+}
+
+require_generation_manifest() {
+  local generation="$1"
+  local destination="$2"
+  local result
+  if fetch_generation_manifest "$generation" "$destination"; then
+    return 0
+  else
+    result=$?
+  fi
+  if ((result == GENERATION_INCOMPLETE_EXIT)); then
+    die "generation $generation is not complete for $PLATFORM"
+  fi
+  die "could not fetch requested generation $generation"
 }
 
 manifest_value() {
@@ -578,7 +668,7 @@ install_generation() {
   if [[ -d "$RELEASES_DIR/$generation" ]]; then
     make_work_dir
     local installed_outer="$WORK_DIR/installed-generation.json"
-    fetch_generation_manifest "$generation" "$installed_outer"
+    require_generation_manifest "$generation" "$installed_outer"
     verify_installed_release "$RELEASES_DIR/$generation" "$installed_outer"
     ensure_launchers_and_path
     switch_to "$generation"
@@ -589,7 +679,7 @@ install_generation() {
   local outer="$WORK_DIR/generation.json"
   local archive="$WORK_DIR/artifact.tar.gz"
   local unpack="$WORK_DIR/unpack"
-  fetch_generation_manifest "$generation" "$outer"
+  require_generation_manifest "$generation" "$outer"
   local artifact expected expected_size actual actual_size
   artifact="$(platform_value "$outer" artifact)"
   expected="$(platform_value "$outer" sha256)"
@@ -615,7 +705,7 @@ show_status() {
   current="$(current_generation)"
   latest="$(latest_generation)"
   target_manifest="$WORK_DIR/latest-manifest.json"
-  fetch_generation_manifest "$latest" "$target_manifest"
+  require_generation_manifest "$latest" "$target_manifest"
   current_version="$(protocol_version "$CURRENT_LINK")"
   target_version="$(manifest_value "$target_manifest" peer_protocol_version)"
   printf 'current: %s (peer protocol %s)\n' "${current:-<none>}" "${current_version:-unknown}"

--- a/scripts/test-fleet-install.sh
+++ b/scripts/test-fleet-install.sh
@@ -15,8 +15,32 @@ fail() {
   exit 1
 }
 
-generation_one="20260815T210000Z-f111111111111-caaaaaaaaaaaa"
-generation_two="20260815T220000Z-f222222222222-cbbbbbbbbbbbb"
+file_sha256() {
+  python3 - "$1" <<'PY'
+import hashlib
+import sys
+
+print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())
+PY
+}
+
+file_mode() {
+  python3 - "$1" <<'PY'
+import os
+import stat
+import sys
+
+print(format(stat.S_IMODE(os.stat(sys.argv[1]).st_mode), "o"))
+PY
+}
+
+link_generation() {
+  basename "$(readlink "$1")"
+}
+
+generation_one="20260815T210000Z-r1-f111111111111-caaaaaaaaaaaa"
+generation_two="20260815T220000Z-r2-f222222222222-cbbbbbbbbbbbb"
+generation_incomplete="20260815T225000Z-r9-f999999999999-cffffffffffff"
 fixture_root="$test_root/packages"
 fake_bin="$test_root/fake-bin"
 mkdir -p "$test_root/home/.config/flotilla" "$fixture_root" "$fake_bin"
@@ -36,13 +60,18 @@ make_generation() {
     chmod 0755 "$bundle/bin/$name"
   done
   printf 'ghostty\n' >"$bundle/lib/libghostty-vt.so.0"
-  TEST_BUNDLE="$bundle" TEST_PLATFORM="$platform" TEST_PROTOCOL="$protocol" TEST_CORRUPT_INNER="$corrupt_inner" python3 - <<'PY'
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$bundle/install.sh"
+  chmod 0755 "$bundle/install.sh"
+TEST_BUNDLE="$bundle" TEST_PLATFORM="$platform" TEST_PROTOCOL="$protocol" TEST_CORRUPT_INNER="$corrupt_inner" python3 - <<'PY'
 import hashlib
 import json
 import os
+import re
 from pathlib import Path
 
 bundle = Path(os.environ["TEST_BUNDLE"])
+identity = re.fullmatch(r".+-f([0-9a-f]{12})-c([0-9a-f]{12})", bundle.parent.name.removeprefix("bundle-"))
+sources = {"flotilla": identity.group(1) + "1" * 28, "cleat": identity.group(2) + "a" * 28}
 files = []
 for path in sorted(bundle.rglob("*")):
     if path.is_file():
@@ -54,43 +83,170 @@ for path in sorted(bundle.rglob("*")):
     "schema_version": 1,
     "kind": "unsigned-fleet-candidate",
     "platform": os.environ["TEST_PLATFORM"],
+    "sources": sources,
     "peer_protocol_version": int(os.environ["TEST_PROTOCOL"]),
+    "signed": False,
     "files": files,
 }, sort_keys=True) + "\n")
 PY
   local artifact="fleet-candidate-linux-x86_64-gnu2.36.tar.gz"
-  tar -C "$(dirname "$bundle")" -czf "$directory/$artifact" "$(basename "$bundle")"
+  COPYFILE_DISABLE=1 tar -C "$(dirname "$bundle")" -czf "$directory/$artifact" "$(basename "$bundle")"
   local digest
-  digest="$(sha256sum "$directory/$artifact" | awk '{print $1}')"
-  TEST_GENERATION="$generation" TEST_PROTOCOL="$protocol" TEST_PLATFORM="$platform" TEST_ARTIFACT="$artifact" TEST_DIGEST="$digest" TEST_DIRECTORY="$directory" python3 - <<'PY'
+  digest="$(file_sha256 "$directory/$artifact")"
+  local size
+  size="$(python3 - "$directory/$artifact" <<'PY'
+import os
+import sys
+
+print(os.path.getsize(sys.argv[1]))
+PY
+)"
+  TEST_GENERATION="$generation" TEST_PROTOCOL="$protocol" TEST_PLATFORM="$platform" TEST_ARTIFACT="$artifact" TEST_DIGEST="$digest" TEST_SIZE="$size" TEST_DIRECTORY="$directory" python3 - <<'PY'
 import json
 import os
+import re
 from pathlib import Path
 
+identity = re.fullmatch(r".+-f([0-9a-f]{12})-c([0-9a-f]{12})", os.environ["TEST_GENERATION"])
+sources = {"flotilla": identity.group(1) + "1" * 28, "cleat": identity.group(2) + "a" * 28}
 manifest = {
     "schema_version": 1,
-    "kind": "flotilla-fleet-generation",
+    "kind": "internal-promoted-fleet-generation",
     "generation": os.environ["TEST_GENERATION"],
+    "sources": sources,
     "peer_protocol_version": int(os.environ["TEST_PROTOCOL"]),
     "platforms": {
         os.environ["TEST_PLATFORM"]: {
             "artifact": os.environ["TEST_ARTIFACT"],
             "sha256": os.environ["TEST_DIGEST"],
+            "size_bytes": int(os.environ["TEST_SIZE"]),
+            "signed": False,
+            "state": "installable-internal",
         }
     },
 }
-(Path(os.environ["TEST_DIRECTORY"]) / "manifest.json").write_text(json.dumps(manifest, sort_keys=True) + "\n")
+(Path(os.environ["TEST_DIRECTORY"]) / "generation.json").write_text(json.dumps(manifest, sort_keys=True) + "\n")
+PY
+}
+
+add_darwin_derivative() {
+  local generation="$1"
+  local source_generation="$2"
+  local directory="$fixture_root/$generation"
+  local bundle="$test_root/darwin-$generation/fleet-signed-darwin-aarch64"
+  mkdir -p "$bundle/bin" "$bundle/lib"
+  for name in flotilla flotillad cleat; do
+    printf '%s signed for %s\n' "$name" "$generation" >"$bundle/bin/$name"
+    chmod 0755 "$bundle/bin/$name"
+  done
+  printf 'ghostty signed\n' >"$bundle/lib/libghostty-vt.dylib"
+  chmod 0755 "$bundle/lib/libghostty-vt.dylib"
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$bundle/install.sh"
+  chmod 0755 "$bundle/install.sh"
+  TEST_BUNDLE="$bundle" TEST_GENERATION="$generation" TEST_SOURCE_GENERATION="$source_generation" python3 - <<'PY'
+import hashlib
+import json
+import os
+from pathlib import Path
+
+bundle = Path(os.environ["TEST_BUNDLE"])
+sources = {
+    "flotilla": os.environ["TEST_GENERATION"].split("-f", 1)[1].split("-c", 1)[0] + "1" * 28,
+    "cleat": os.environ["TEST_GENERATION"].rsplit("-c", 1)[1] + "a" * 28,
+}
+files = [
+    {
+        "path": str(path.relative_to(bundle)),
+        "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        "size_bytes": path.stat().st_size,
+    }
+    for path in sorted(bundle.rglob("*"))
+    if path.is_file()
+]
+signing = {
+    "identity": "Apple Development: Robert Wittams (DYYMCPD885)",
+    "team_id": "973L4GV58R",
+    "certificate_sha256": "d" * 64,
+    "entitlements_sha256": "e" * 64,
+    "options": ["runtime", "timestamp=none"],
+}
+(bundle / "manifest.json").write_text(json.dumps({
+    "schema_version": 1,
+    "kind": "signed-fleet-derivative",
+    "platform": "darwin-aarch64",
+    "sources": sources,
+    "build_profile": "release",
+    "peer_protocol_version": 21,
+    "signed": True,
+    "source_generation": os.environ["TEST_SOURCE_GENERATION"],
+    "source_artifact_sha256": "c" * 64,
+    "signing": signing,
+    "files": files,
+}, sort_keys=True) + "\n")
+PY
+  local artifact="fleet-signed-darwin-aarch64.tar.gz"
+  COPYFILE_DISABLE=1 tar -C "$(dirname "$bundle")" -czf "$directory/$artifact" "$(basename "$bundle")"
+  local digest size
+  digest="$(file_sha256 "$directory/$artifact")"
+  size="$(python3 - "$directory/$artifact" <<'PY'
+import os
+import sys
+
+print(os.path.getsize(sys.argv[1]))
+PY
+)"
+  TEST_GENERATION="$generation" TEST_SOURCE_GENERATION="$source_generation" TEST_ARTIFACT="$artifact" \
+    TEST_DIGEST="$digest" TEST_SIZE="$size" TEST_DIRECTORY="$directory" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+path = Path(os.environ["TEST_DIRECTORY"]) / "generation.json"
+manifest = json.loads(path.read_text())
+signing = {
+    "identity": "Apple Development: Robert Wittams (DYYMCPD885)",
+    "team_id": "973L4GV58R",
+    "certificate_sha256": "d" * 64,
+    "entitlements_sha256": "e" * 64,
+    "options": ["runtime", "timestamp=none"],
+}
+manifest["source_generation"] = os.environ["TEST_SOURCE_GENERATION"]
+manifest["central_signing"] = {
+    "derivative_package": "lab-signing/flotilla-fleet-darwin-signed",
+    "derivative_version": os.environ["TEST_SOURCE_GENERATION"],
+    "attestation": "darwin-signing-attestation.json",
+    "attestation_sha256": "f" * 64,
+    "cms": "darwin-signing-attestation.cms",
+    "cms_sha256": "1" * 64,
+    "certificate": "darwin-signing-certificate.pem",
+    "certificate_sha256": signing["certificate_sha256"],
+    "signing": signing,
+}
+manifest["platforms"]["darwin-aarch64"] = {
+    "artifact": os.environ["TEST_ARTIFACT"],
+    "sha256": os.environ["TEST_DIGEST"],
+    "size_bytes": int(os.environ["TEST_SIZE"]),
+    "signed": True,
+    "state": "installable-internal",
+    "source_artifact": "fleet-candidate-darwin-aarch64.tar.gz",
+    "source_artifact_sha256": "c" * 64,
+    "signing": signing,
+}
+path.write_text(json.dumps(manifest, sort_keys=True) + "\n")
 PY
 }
 
 make_generation "$generation_one" 20
 make_generation "$generation_two" 21
+source_generation_two="20260815T215500Z-r2-f222222222222-cbbbbbbbbbbbb"
+add_darwin_derivative "$generation_two" "$source_generation_two"
 
 cat >"$fixture_root/packages-page-1.json" <<JSON
 [
   {"type":"generic","name":"flotilla-fleet","version":"$generation_one","created_at":"2026-08-15T21:00:00Z"},
   {"type":"generic","name":"another-package","version":"ignored","created_at":"2026-08-15T23:00:00Z"},
-  {"type":"generic","name":"flotilla-fleet","version":"$generation_two","created_at":"2026-08-15T22:00:00Z"}
+  {"type":"generic","name":"flotilla-fleet","version":"$generation_two","created_at":"2026-08-15T22:00:00Z"},
+  {"type":"generic","name":"flotilla-fleet","version":"$generation_incomplete","created_at":"2026-08-15T22:50:00Z"}
 ]
 JSON
 
@@ -131,33 +287,67 @@ cat >"$fake_bin/pgrep" <<'SH'
 SH
 chmod 0755 "$fake_bin/pgrep"
 
+cat >"$fake_bin/codesign" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$CODESIGN_LOG"
+path="${!#}"
+if [[ " $* " == *' --verify '* ]]; then
+  [[ -z "${FAIL_CODESIGN_FOR:-}" || "$path" != *"$FAIL_CODESIGN_FOR"* ]] || exit 1
+elif [[ " $* " == *' -d '* ]]; then
+  printf 'Authority=Apple Development: Robert Wittams (DYYMCPD885)\n' >&2
+  printf 'TeamIdentifier=973L4GV58R\n' >&2
+  printf 'CDHash=0123456789abcdef\n' >&2
+elif [[ " $* " == *' --entitlements '* ]]; then
+  printf '%s\n' '<?xml version="1.0" encoding="UTF-8"?><plist version="1.0"><dict/></plist>'
+else
+  exit 2
+fi
+SH
+chmod 0755 "$fake_bin/codesign"
+
 run_installer() {
   HOME="$test_root/home" \
     PATH="$test_root/home/.local/bin:$fake_bin:$PATH" \
     FIXTURE_ROOT="$fixture_root" \
+    FLEET_INSTALL_UNAME_S=Linux \
+    FLEET_INSTALL_UNAME_M=x86_64 \
     FLEET_INSTALL_API_URL="https://test.invalid/api/v1" \
     FLEET_INSTALL_PACKAGE_URL="https://test.invalid/api/packages" \
     "$installer" "$@"
 }
 
-if HOME="$test_root/home" FLEET_INSTALL_UNAME_S=Darwin FLEET_INSTALL_UNAME_M=arm64 "$installer" status >"$test_root/darwin.out" 2>&1; then
-  fail 'Darwin did not fail closed'
-fi
-grep -Fq '#1553' "$test_root/darwin.out" || fail 'Darwin refusal did not point at #1553'
+run_darwin_installer() {
+  local home="$1"
+  shift
+  HOME="$home" \
+    PATH="$home/.local/bin:$fake_bin:$PATH" \
+    FIXTURE_ROOT="$fixture_root" \
+    CODESIGN_LOG="$test_root/codesign.log" \
+    FAIL_CODESIGN_FOR="${FAIL_CODESIGN_FOR:-}" \
+    FLEET_INSTALL_TESTING=1 \
+    FLEET_INSTALL_TEST_CODESIGN="$fake_bin/codesign" \
+    FLEET_INSTALL_UNAME_S=Darwin \
+    FLEET_INSTALL_UNAME_M=arm64 \
+    FLEET_INSTALL_API_URL="https://test.invalid/api/v1" \
+    FLEET_INSTALL_PACKAGE_URL="https://test.invalid/api/packages" \
+    "$installer" "$@"
+}
 
 status_home="$test_root/status-home"
 mkdir -p "$status_home/.config/flotilla"
 cp "$test_root/home/.config/flotilla/fleet-reader-token" "$status_home/.config/flotilla/fleet-reader-token"
 HOME="$status_home" PATH="$status_home/.local/bin:$fake_bin:$PATH" FIXTURE_ROOT="$fixture_root" \
+  FLEET_INSTALL_UNAME_S=Linux FLEET_INSTALL_UNAME_M=x86_64 \
   FLEET_INSTALL_API_URL=https://test.invalid/api/v1 FLEET_INSTALL_PACKAGE_URL=https://test.invalid/api/packages \
   "$installer" status >"$test_root/fresh-status.out"
 test ! -e "$status_home/.local/opt/flotilla-fleet" || fail 'status mutated the install root'
 
 run_installer "$generation_one" >"$test_root/install-one.out"
-test "$(basename "$(readlink -f "$test_root/home/.local/opt/flotilla-fleet/current")")" = "$generation_one" || fail 'exact generation was not selected'
+test "$(link_generation "$test_root/home/.local/opt/flotilla-fleet/current")" = "$generation_one" || fail 'exact generation was not selected'
 test -x "$test_root/home/.local/opt/flotilla-fleet/releases/$generation_one/bin/flotilla" || fail 'candidate binaries were not staged'
 test ! -w "$test_root/home/.local/opt/flotilla-fleet/releases/$generation_one/manifest.json" || fail 'selected generation is writable'
-test "$(stat -c '%a' "$test_root/home/.local/bin")" = 755 || fail 'credential umask leaked into the launcher directory'
+test "$(file_mode "$test_root/home/.local/bin")" = 755 || fail 'credential umask leaked into the launcher directory'
 for name in flotilla flotillad cleat; do
   grep -Fq '# managed by fleet-install' "$test_root/home/.local/bin/$name" || fail "missing stable $name launcher"
 done
@@ -167,45 +357,91 @@ grep -Fq "current: $generation_one (peer protocol 20)" <<<"$status" || fail 'sta
 grep -Fq "latest:  $generation_two (peer protocol 21)" <<<"$status" || fail 'status selected the wrong promoted generation'
 grep -Fq 'warning: peer protocol changes from 20 to 21' <<<"$status" || fail 'status omitted wire-bump warning'
 
-before_manifest="$(sha256sum "$test_root/home/.local/opt/flotilla-fleet/releases/$generation_one/manifest.json")"
+before_manifest="$(file_sha256 "$test_root/home/.local/opt/flotilla-fleet/releases/$generation_one/manifest.json")"
 run_installer "$generation_one" >/dev/null
-after_manifest="$(sha256sum "$test_root/home/.local/opt/flotilla-fleet/releases/$generation_one/manifest.json")"
+after_manifest="$(file_sha256 "$test_root/home/.local/opt/flotilla-fleet/releases/$generation_one/manifest.json")"
 [[ "$before_manifest" == "$after_manifest" ]] || fail 'exact-generation reinstall mutated the release'
 
-exec 9>"$test_root/home/.local/opt/flotilla-fleet/.install.lock"
-flock -n 9
+mkdir "$test_root/home/.local/opt/flotilla-fleet/.install.lock"
 if run_installer "$generation_one" >"$test_root/locked.out" 2>&1; then
   fail 'concurrent mutation lock was ignored'
 fi
-flock -u 9
-exec 9>&-
+rmdir "$test_root/home/.local/opt/flotilla-fleet/.install.lock"
 grep -Fq 'another fleet-install mutation is already running' "$test_root/locked.out" || fail 'concurrent mutation error was unclear'
 
 if FAIL_ARTIFACT_FOR="$generation_two" run_installer "$generation_two" >"$test_root/interrupted.out" 2>&1; then
   fail 'interrupted download was accepted'
 fi
-test "$(basename "$(readlink -f "$test_root/home/.local/opt/flotilla-fleet/current")")" = "$generation_one" || fail 'interrupted download switched current'
+test "$(link_generation "$test_root/home/.local/opt/flotilla-fleet/current")" = "$generation_one" || fail 'interrupted download switched current'
 test ! -e "$test_root/home/.local/opt/flotilla-fleet/releases/$generation_two" || fail 'interrupted download published a release'
 
 if DAEMON_RUNNING=1 STOP_FAIL=1 run_installer "$generation_two" >"$test_root/daemon.out" 2>&1; then
   fail 'daemon stop refusal was ignored'
 fi
 grep -Fq 'flotilla daemon stop' "$test_root/daemon.out" || fail 'daemon refusal omitted recovery instruction'
-test "$(basename "$(readlink -f "$test_root/home/.local/opt/flotilla-fleet/current")")" = "$generation_one" || fail 'failed daemon preflight switched current'
+test "$(link_generation "$test_root/home/.local/opt/flotilla-fleet/current")" = "$generation_one" || fail 'failed daemon preflight switched current'
 
 DAEMON_RUNNING=1 STOP_FAIL=0 run_installer latest >"$test_root/latest.out"
 grep -Fq "$generation_one -> $generation_two" "$test_root/latest.out" || fail 'latest did not print the exact transition'
 grep -Fq 'daemon stop requested' "$test_root/latest.out" || fail 'running daemon was not stopped before switching'
-test "$(basename "$(readlink -f "$test_root/home/.local/opt/flotilla-fleet/current")")" = "$generation_two" || fail 'latest did not select newest promoted generation'
-test "$(basename "$(readlink -f "$test_root/home/.local/opt/flotilla-fleet/previous")")" = "$generation_one" || fail 'switch did not record previous generation'
+test "$(link_generation "$test_root/home/.local/opt/flotilla-fleet/current")" = "$generation_two" || fail 'latest did not select newest promoted generation'
+test "$(link_generation "$test_root/home/.local/opt/flotilla-fleet/previous")" = "$generation_one" || fail 'switch did not record previous generation'
 
 run_installer rollback >"$test_root/rollback.out"
-test "$(basename "$(readlink -f "$test_root/home/.local/opt/flotilla-fleet/current")")" = "$generation_one" || fail 'rollback did not restore previous generation'
-test "$(basename "$(readlink -f "$test_root/home/.local/opt/flotilla-fleet/previous")")" = "$generation_two" || fail 'rollback did not retain displaced generation'
+test "$(link_generation "$test_root/home/.local/opt/flotilla-fleet/current")" = "$generation_one" || fail 'rollback did not restore previous generation'
+test "$(link_generation "$test_root/home/.local/opt/flotilla-fleet/previous")" = "$generation_two" || fail 'rollback did not retain displaced generation'
 
-bad_digest="20260815T230000Z-f333333333333-ccccccccccccc"
+darwin_home="$test_root/darwin-home"
+mkdir -p "$darwin_home/.config/flotilla"
+cp "$test_root/home/.config/flotilla/fleet-reader-token" "$darwin_home/.config/flotilla/fleet-reader-token"
+: >"$test_root/codesign.log"
+run_darwin_installer "$darwin_home" "$generation_two" >"$test_root/darwin-install.out"
+test "$(link_generation "$darwin_home/.local/opt/flotilla-fleet/current")" = "$generation_two" \
+  || fail 'signed Darwin generation was not selected'
+test -f "$darwin_home/.local/opt/flotilla-fleet/releases/$generation_two/lib/libghostty-vt.dylib" \
+  || fail 'signed Darwin dynamic library was not installed'
+test "$(grep -c -- '--verify' "$test_root/codesign.log")" = 4 \
+  || fail 'Darwin install did not strictly verify every Mach-O payload'
+test "$(grep -c -- '--entitlements' "$test_root/codesign.log")" = 4 \
+  || fail 'Darwin install did not verify every Mach-O entitlement set'
+
+darwin_fail_home="$test_root/darwin-fail-home"
+mkdir -p "$darwin_fail_home/.config/flotilla"
+cp "$test_root/home/.config/flotilla/fleet-reader-token" "$darwin_fail_home/.config/flotilla/fleet-reader-token"
+if FAIL_CODESIGN_FOR=bin/cleat run_darwin_installer "$darwin_fail_home" "$generation_two" \
+  >"$test_root/darwin-signature-failure.out" 2>&1; then
+  fail 'Darwin signature failure was accepted'
+fi
+grep -Fq 'strict signature verification failed: bin/cleat' "$test_root/darwin-signature-failure.out" \
+  || fail 'Darwin signature failure was unclear'
+test ! -L "$darwin_fail_home/.local/opt/flotilla-fleet/current" \
+  || fail 'Darwin signature failure selected a generation'
+test ! -e "$darwin_fail_home/.local/opt/flotilla-fleet/releases/$generation_two" \
+  || fail 'Darwin signature failure published a release'
+
+cp "$fixture_root/$generation_two/generation.json" "$test_root/generation-two-good.json"
+python3 - "$fixture_root/$generation_two/generation.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+manifest = json.load(open(path))
+manifest["central_signing"]["signing"]["team_id"] = "ATTACKERTEAM"
+open(path, "w").write(json.dumps(manifest) + "\n")
+PY
+darwin_team_home="$test_root/darwin-team-home"
+mkdir -p "$darwin_team_home/.config/flotilla"
+cp "$test_root/home/.config/flotilla/fleet-reader-token" "$darwin_team_home/.config/flotilla/fleet-reader-token"
+if run_darwin_installer "$darwin_team_home" "$generation_two" >"$test_root/darwin-team.out" 2>&1; then
+  fail 'Darwin artifact from an untrusted Apple team was accepted'
+fi
+grep -Fq 'trusted Apple team 973L4GV58R' "$test_root/darwin-team.out" \
+  || fail 'Darwin team rejection was unclear'
+mv "$test_root/generation-two-good.json" "$fixture_root/$generation_two/generation.json"
+
+bad_digest="20260815T230000Z-r3-f333333333333-ccccccccccccc"
 make_generation "$bad_digest" 21
-python3 - "$fixture_root/$bad_digest/manifest.json" <<'PY'
+python3 - "$fixture_root/$bad_digest/generation.json" <<'PY'
 import json
 import sys
 path = sys.argv[1]
@@ -218,14 +454,14 @@ if run_installer "$bad_digest" >"$test_root/digest.out" 2>&1; then
 fi
 test ! -e "$test_root/home/.local/opt/flotilla-fleet/releases/$bad_digest" || fail 'digest rejection published a release'
 
-bad_manifest="20260815T231000Z-f444444444444-cdddddddddddd"
+bad_manifest="20260815T231000Z-r4-f444444444444-cdddddddddddd"
 make_generation "$bad_manifest" 21 linux-x86_64-gnu2.36 yes
 if run_installer "$bad_manifest" >"$test_root/manifest.out" 2>&1; then
   fail 'inner manifest mismatch was accepted'
 fi
 test ! -e "$test_root/home/.local/opt/flotilla-fleet/releases/$bad_manifest" || fail 'manifest rejection published a release'
 
-bad_platform="20260815T232000Z-f555555555555-ceeeeeeeeeeee"
+bad_platform="20260815T232000Z-r5-f555555555555-ceeeeeeeeeeee"
 make_generation "$bad_platform" 21 darwin-aarch64
 if run_installer "$bad_platform" >"$test_root/platform.out" 2>&1; then
   fail 'wrong-platform generation was accepted'
@@ -241,6 +477,7 @@ for name in flotilla flotillad cleat; do
   chmod 0755 "$shadow_bin/$name"
 done
 if HOME="$shadow_home" PATH="$shadow_bin:$shadow_home/.local/bin:$fake_bin:$PATH" FIXTURE_ROOT="$fixture_root" \
+  FLEET_INSTALL_UNAME_S=Linux FLEET_INSTALL_UNAME_M=x86_64 \
   FLEET_INSTALL_API_URL=https://test.invalid/api/v1 FLEET_INSTALL_PACKAGE_URL=https://test.invalid/api/packages \
   "$installer" "$generation_one" >"$test_root/shadow.out" 2>&1; then
   fail 'PATH shadow was accepted'

--- a/scripts/test-fleet-install.sh
+++ b/scripts/test-fleet-install.sh
@@ -255,10 +255,12 @@ cat >"$fake_bin/curl" <<'SH'
 set -euo pipefail
 destination=""
 url=""
+write_out=""
 while (($#)); do
   case "$1" in
     --output) destination="$2"; shift 2 ;;
     --header) shift 2 ;;
+    --write-out) write_out="$2"; shift 2 ;;
     --fail|--silent|--show-error|--location) shift ;;
     *) url="$1"; shift ;;
   esac
@@ -273,11 +275,20 @@ fi
 generation="$(basename "$(dirname "$url")")"
 file="$(basename "$url")"
 source="$FIXTURE_ROOT/$generation/$file"
+if [[ "${FAIL_MANIFEST_FOR:-}" == "$generation" && "$file" == generation.json ]]; then
+  [[ -z "$write_out" ]] || printf '503'
+  exit 0
+fi
+if [[ ! -f "$source" ]]; then
+  [[ -z "$write_out" ]] || printf '404'
+  exit 0
+fi
 if [[ "${FAIL_ARTIFACT_FOR:-}" == "$generation" && "$file" == *.tar.gz ]]; then
   printf 'interrupted' >"$destination"
   exit 56
 fi
 cp "$source" "$destination"
+[[ -z "$write_out" ]] || printf '200'
 SH
 chmod 0755 "$fake_bin/curl"
 
@@ -352,22 +363,43 @@ for name in flotilla flotillad cleat; do
   grep -Fq '# managed by fleet-install' "$test_root/home/.local/bin/$name" || fail "missing stable $name launcher"
 done
 
-status="$(run_installer status)"
+status="$(run_installer status 2>"$test_root/status.err")"
 grep -Fq "current: $generation_one (peer protocol 20)" <<<"$status" || fail 'status omitted current manifest protocol'
 grep -Fq "latest:  $generation_two (peer protocol 21)" <<<"$status" || fail 'status selected the wrong promoted generation'
 grep -Fq 'warning: peer protocol changes from 20 to 21' <<<"$status" || fail 'status omitted wire-bump warning'
+grep -Fq "skipping incomplete linux-x86_64-gnu2.36 generation $generation_incomplete" "$test_root/status.err" \
+  || fail 'latest did not explain why it skipped an incomplete generation'
+
+if run_installer "$generation_incomplete" >"$test_root/incomplete-exact.out" 2>&1; then
+  fail 'an explicitly requested incomplete generation was accepted'
+fi
+grep -Fq "generation $generation_incomplete is not complete for linux-x86_64-gnu2.36" \
+  "$test_root/incomplete-exact.out" || fail 'incomplete exact-generation error was unclear'
+
+if FAIL_MANIFEST_FOR="$generation_two" run_installer status >"$test_root/latest-fetch.out" 2>&1; then
+  fail 'latest silently downgraded after a promoted-generation fetch failure'
+fi
+grep -Fq "generation manifest request returned HTTP 503" "$test_root/latest-fetch.out" \
+  || fail 'latest hid the promoted-generation fetch failure'
+if grep -Fq "could not verify advertised generation $generation_two" "$test_root/latest-fetch.out"; then
+  fail 'fatal generation fetch was incorrectly treated as a skippable generation'
+fi
 
 before_manifest="$(file_sha256 "$test_root/home/.local/opt/flotilla-fleet/releases/$generation_one/manifest.json")"
 run_installer "$generation_one" >/dev/null
 after_manifest="$(file_sha256 "$test_root/home/.local/opt/flotilla-fleet/releases/$generation_one/manifest.json")"
 [[ "$before_manifest" == "$after_manifest" ]] || fail 'exact-generation reinstall mutated the release'
 
-mkdir "$test_root/home/.local/opt/flotilla-fleet/.install.lock"
+ln -s "$$-active-test-owner" "$test_root/home/.local/opt/flotilla-fleet/.install.lock"
 if run_installer "$generation_one" >"$test_root/locked.out" 2>&1; then
   fail 'concurrent mutation lock was ignored'
 fi
-rmdir "$test_root/home/.local/opt/flotilla-fleet/.install.lock"
+rm "$test_root/home/.local/opt/flotilla-fleet/.install.lock"
 grep -Fq 'another fleet-install mutation is already running' "$test_root/locked.out" || fail 'concurrent mutation error was unclear'
+
+ln -s '999999999-stale-test-owner' "$test_root/home/.local/opt/flotilla-fleet/.install.lock"
+run_installer "$generation_one" >"$test_root/stale-lock.out"
+test ! -L "$test_root/home/.local/opt/flotilla-fleet/.install.lock" || fail 'stale install lock was not reclaimed'
 
 if FAIL_ARTIFACT_FOR="$generation_two" run_installer "$generation_two" >"$test_root/interrupted.out" 2>&1; then
   fail 'interrupted download was accepted'


### PR DESCRIPTION
## Summary

- consume the promoter's real `generation.json` contract instead of the provisional manifest shape
- install immutable Linux candidates and centrally signed Darwin derivatives
- verify outer and inner manifests, sizes, digests, platform/source linkage, and executable payloads before selection
- require the trusted Apple team, recorded authority, strict designated requirement, and empty entitlements for every Darwin Mach-O payload
- keep installs operator-pulled with status, exact-generation, latest, and verified rollback commands
- document bootstrap and the promoted-generation consumer contract

## Root cause

The installer merged in #1567 expected `manifest.json` with kind `flotilla-fleet-generation`, while the promoter publishes `generation.json` with kind `internal-promoted-fleet-generation`. It also relied on GNU-only utilities, so it could neither consume the live package nor run on macOS.

## Validation

- `scripts/test-fleet-install.sh`
- `ci/fleet-candidates/test-workflow.sh`
- `bash -n scripts/fleet-install scripts/test-fleet-install.sh`
- `shellcheck --severity=warning scripts/fleet-install scripts/test-fleet-install.sh`
- `git diff --check`

The completed generation `20260815T233635Z-r84-f63871b20ec6f-c4e78c7c83873` was also installed into isolated roots on Kiwi and Udder. Flotilla, flotillad, and Cleat ran on both hosts, and Cleat resolved its bundled Ghostty dynamic library. The proof did not replace either host's active binaries or move its live `current` link.

Relates to #1553.
